### PR TITLE
Fix README false zero-deps claim (sp-v1m)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ A lightweight, LLM-agnostic research harness for running synthetic focus groups 
 
 ## Architecture
 
-Pure Python 3.10+, zero external dependencies for core functionality. Optional deps: `mcp` (MCP server), `httpx`/`pyyaml` (if declared in pyproject.toml).
+Pure Python 3.10+ with minimal dependencies (`httpx` for HTTP, `pyyaml` for YAML parsing). Optional deps: `mcp` (MCP server).
 
 ```
 src/synth_panel/

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ instrument.yaml ─┘                 ├──> Panelist 2 ──> LLM ──>
 
 ### Design Principles
 
-- **Zero external dependencies** — pure Python 3.10+, standard library only
+- **Minimal dependencies** — pure Python 3.10+ with only `httpx` and `pyyaml` as required deps
 - **Provider agnostic** — swap LLMs without changing research definitions
 - **Cost transparent** — every API call is tracked and priced
 - **Reproducible** — same personas + same instrument = comparable output


### PR DESCRIPTION
## Summary
- Fixes README falsely claiming zero external dependencies when httpx and pyyaml are hard deps
- Source issue: sp-v1m (P0 bug)
- Polecat: furiosa
- MR bead: sp-wisp-l2er

## Pre-existing test failures (not caused by this branch)
- `test_unreachable_base_url` → sp-5qg
- `test_alias_is_resolved_in_send` ��� sp-s6o