### PR TITLE
Remove login/logout stub commands from CLI (sp-p4z)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -244,15 +244,3 @@ def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return 0
 
 
-def handle_login(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """Start an authentication flow."""
-    # TODO: implement OAuth flow
-    emit(fmt, message="[stub] Login not yet implemented.")
-    return 0
-
-
-def handle_logout(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """Clear saved authentication credentials."""
-    # TODO: implement credential clearing
-    emit(fmt, message="[stub] Logout not yet implemented.")
-    return 0

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -85,16 +85,4 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start the MCP server (stdio transport).",
     )
 
-    # login
-    subparsers.add_parser(
-        "login",
-        help="Start an authentication flow.",
-    )
-
-    # logout
-    subparsers.add_parser(
-        "logout",
-        help="Clear saved authentication credentials.",
-    )
-
     return parser

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -11,8 +11,6 @@ import sys
 from synth_panel.cli.parser import build_parser
 from synth_panel.cli.repl import run_repl
 from synth_panel.cli.commands import (
-    handle_login,
-    handle_logout,
     handle_mcp_serve,
     handle_panel_run,
     handle_prompt,
@@ -37,10 +35,6 @@ def main(argv: list[str] | None = None) -> int:
             return 1
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
-    elif args.command == "login":
-        return handle_login(args, output_format)
-    elif args.command == "logout":
-        return handle_logout(args, output_format)
     else:
         # No subcommand → interactive REPL
         return run_repl(args, output_format)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,16 +78,6 @@ class TestParser:
         assert args.personas == "p.yaml"
         assert args.instrument == "i.yaml"
 
-    def test_login_subcommand(self):
-        parser = build_parser()
-        args = parser.parse_args(["login"])
-        assert args.command == "login"
-
-    def test_logout_subcommand(self):
-        parser = build_parser()
-        args = parser.parse_args(["logout"])
-        assert args.command == "logout"
-
     def test_invalid_permission_mode(self):
         parser = build_parser()
         with pytest.raises(SystemExit):
@@ -266,14 +256,6 @@ class TestMain:
 
         code = main(["prompt", "hello"])
         assert code == 1
-
-    def test_login_command(self, capsys):
-        code = main(["login"])
-        assert code == 0
-
-    def test_logout_command(self, capsys):
-        code = main(["logout"])
-        assert code == 0
 
 
 # --- YAML loading tests ---


### PR DESCRIPTION
## Summary
- Removes stub login/logout commands from CLI
- Source issue: sp-p4z (P1)
- Polecat: nux
- MR bead: sp-wisp-srq5

## Pre-existing test failures (not caused by this branch)
- `test_unreachable_base_url` → sp-5qg
- `test_alias_is_resolved_in_send` → sp-s6o