### PR TITLE
pyproject.toml cleanup — authors, remove pytest-httpx (sp-7b5)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = "MIT"
+authors = [{name = "DataViking", email = "openclaw@dataviking.tech"}]
 readme = "README.md"
 keywords = ["llm", "research", "focus-group", "synthetic", "personas", "user-research", "ai"]
 classifiers = [
@@ -32,7 +33,6 @@ mcp = [
 ]
 dev = [
     "pytest>=8.0",
-    "pytest-httpx>=0.30",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Cleans up pyproject.toml: authors, removes pytest-httpx dependency
- Source issue: sp-7b5 (P2)
- Polecat: capable
- MR bead: sp-wisp-fz07