### PR TITLE
feat: add template engine (templates.py) (sp-tsz)

### DIFF
--- a/src/synth_panel/templates.py
+++ b/src/synth_panel/templates.py
@@ -1,0 +1,123 @@
+"""Template engine for rendering dynamic questions from synthesis context.
+
+Flattens SynthesisResult into a template context dict and renders
+{theme_0}, {agreement_0}, etc. placeholders in question text fields.
+Unresolvable keys render as literal placeholders (safe failure).
+"""
+
+from __future__ import annotations
+
+import copy
+import string
+from typing import Any
+
+from synth_panel.synthesis import SynthesisResult
+
+
+def build_template_context(synthesis: SynthesisResult) -> dict[str, str]:
+    """Flatten a SynthesisResult into a string-keyed template context.
+
+    Returns keys like: summary, recommendation, theme_0, theme_1, ...,
+    agreement_0, ..., disagreement_0, ..., surprise_0, ...
+    """
+    ctx: dict[str, str] = {
+        "summary": synthesis.summary,
+        "recommendation": synthesis.recommendation,
+    }
+    for prefix, items in [
+        ("theme", synthesis.themes),
+        ("agreement", synthesis.agreements),
+        ("disagreement", synthesis.disagreements),
+        ("surprise", synthesis.surprises),
+    ]:
+        for i, item in enumerate(items):
+            ctx[f"{prefix}_{i}"] = item
+    return ctx
+
+
+class _SafeFormatter(string.Formatter):
+    """Formatter that returns literal placeholder on missing keys."""
+
+    def vformat(self, format_string: str, args: tuple, kwargs: dict) -> str:  # type: ignore[override]
+        # Override to increase recursion limit guard
+        return super().vformat(format_string, args, kwargs)
+
+    def get_field(self, field_name: str, args: tuple, kwargs: dict) -> tuple[Any, str]:  # type: ignore[override]
+        # Block dotted/bracket attribute access to prevent injection
+        # Only allow simple key lookups
+        first, rest = field_name, iter([])
+        try:
+            import _string
+            first, rest = _string.formatter_field_name_split(field_name)
+        except (ImportError, ValueError):
+            pass
+
+        # Get the base value
+        obj = self.get_value(first, args, kwargs)
+
+        # If there's attribute/item access and the base was unresolved,
+        # return the whole expression as a literal
+        rest_list = list(rest)
+        if rest_list:
+            # If base key was missing (literal passthrough), return whole field as literal
+            if isinstance(obj, str) and obj.startswith("{") and obj.endswith("}"):
+                return "{" + field_name + "}", field_name
+            # Even for resolved keys, block attribute traversal for safety
+            return "{" + field_name + "}", field_name
+
+        return obj, str(first)
+
+    def get_value(self, key: int | str, args: tuple, kwargs: dict) -> str:  # type: ignore[override]
+        if isinstance(key, str):
+            try:
+                return kwargs[key]
+            except KeyError:
+                return "{" + key + "}"
+        return super().get_value(key, args, kwargs)
+
+    def format_field(self, value: Any, format_spec: str) -> str:
+        # If value is a literal placeholder passthrough, return as-is
+        if isinstance(value, str) and value.startswith("{") and value.endswith("}"):
+            return value  # ignore format spec on unresolved keys
+        return super().format_field(value, format_spec)
+
+
+_formatter = _SafeFormatter()
+
+
+def render_questions(
+    questions: list[dict[str, Any]], context: dict[str, str]
+) -> list[dict[str, Any]]:
+    """Deep-copy questions and render template placeholders in text fields.
+
+    Only string values in 'text' and 'follow_ups' (recursively) are rendered.
+    """
+    rendered = copy.deepcopy(questions)
+    for q in rendered:
+        if "text" in q and isinstance(q["text"], str):
+            q["text"] = _formatter.format(q["text"], **context)
+        if "follow_ups" in q and isinstance(q["follow_ups"], list):
+            for fu in q["follow_ups"]:
+                if isinstance(fu, str):
+                    idx = q["follow_ups"].index(fu)
+                    q["follow_ups"][idx] = _formatter.format(fu, **context)
+                elif isinstance(fu, dict) and "text" in fu and isinstance(fu["text"], str):
+                    fu["text"] = _formatter.format(fu["text"], **context)
+    return rendered
+
+
+def validate_template(text: str, context: dict[str, str]) -> list[str]:
+    """Return list of unresolvable placeholder keys in text.
+
+    Parses the format string and checks each field name against context.
+    Returns empty list if all keys are resolvable.
+    """
+    unresolvable: list[str] = []
+    for _, field_name, _, _ in _formatter.parse(text):
+        if field_name is None:
+            continue
+        # Handle dotted access like {theme_0.upper} — only check base key
+        base_key = field_name.split(".")[0].split("[")[0]
+        if base_key and base_key not in context:
+            unresolvable.append(base_key)
+    return unresolvable

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,175 @@
+"""Tests for synth_panel.templates — template engine for dynamic questions."""
+
+from synth_panel.synthesis import SynthesisResult
+from synth_panel.templates import (
+    build_template_context,
+    render_questions,
+    validate_template,
+)
+
+
+def _make_synthesis(**overrides) -> SynthesisResult:
+    defaults = dict(
+        summary="Overall positive reception",
+        themes=["usability", "pricing", "integration"],
+        agreements=["easy to learn"],
+        disagreements=["pricing model"],
+        surprises=["unexpected mobile usage"],
+        recommendation="Focus on mobile experience",
+    )
+    defaults.update(overrides)
+    return SynthesisResult(**defaults)
+
+
+class TestBuildTemplateContext:
+    def test_basic_flattening(self):
+        synthesis = _make_synthesis()
+        ctx = build_template_context(synthesis)
+
+        assert ctx["summary"] == "Overall positive reception"
+        assert ctx["recommendation"] == "Focus on mobile experience"
+        assert ctx["theme_0"] == "usability"
+        assert ctx["theme_1"] == "pricing"
+        assert ctx["theme_2"] == "integration"
+        assert ctx["agreement_0"] == "easy to learn"
+        assert ctx["disagreement_0"] == "pricing model"
+        assert ctx["surprise_0"] == "unexpected mobile usage"
+
+    def test_empty_synthesis(self):
+        synthesis = _make_synthesis(
+            summary="",
+            themes=[],
+            agreements=[],
+            disagreements=[],
+            surprises=[],
+            recommendation="",
+        )
+        ctx = build_template_context(synthesis)
+
+        assert ctx["summary"] == ""
+        assert ctx["recommendation"] == ""
+        # No indexed keys should exist
+        assert "theme_0" not in ctx
+        assert "agreement_0" not in ctx
+        assert "disagreement_0" not in ctx
+        assert "surprise_0" not in ctx
+
+    def test_many_themes(self):
+        synthesis = _make_synthesis(themes=[f"theme_{i}" for i in range(10)])
+        ctx = build_template_context(synthesis)
+        for i in range(10):
+            assert ctx[f"theme_{i}"] == f"theme_{i}"
+
+
+class TestRenderQuestions:
+    def test_basic_rendering(self):
+        ctx = {"theme_0": "usability", "summary": "Good overall"}
+        questions = [{"text": "Tell me about {theme_0}"}]
+        result = render_questions(questions, ctx)
+
+        assert result[0]["text"] == "Tell me about usability"
+
+    def test_missing_key_renders_literal(self):
+        ctx = {"theme_0": "usability"}
+        questions = [{"text": "Tell me about {nonexistent}"}]
+        result = render_questions(questions, ctx)
+
+        assert result[0]["text"] == "Tell me about {nonexistent}"
+
+    def test_does_not_mutate_original(self):
+        ctx = {"theme_0": "usability"}
+        questions = [{"text": "About {theme_0}"}]
+        result = render_questions(questions, ctx)
+
+        assert questions[0]["text"] == "About {theme_0}"
+        assert result[0]["text"] == "About usability"
+
+    def test_follow_ups_string(self):
+        ctx = {"theme_0": "usability"}
+        questions = [
+            {
+                "text": "Main question",
+                "follow_ups": ["Tell me more about {theme_0}"],
+            }
+        ]
+        result = render_questions(questions, ctx)
+        assert result[0]["follow_ups"][0] == "Tell me more about usability"
+
+    def test_follow_ups_dict(self):
+        ctx = {"agreement_0": "easy to learn"}
+        questions = [
+            {
+                "text": "Main question",
+                "follow_ups": [{"text": "You agreed on {agreement_0}?"}],
+            }
+        ]
+        result = render_questions(questions, ctx)
+        assert result[0]["follow_ups"][0]["text"] == "You agreed on easy to learn?"
+
+    def test_multiple_placeholders(self):
+        ctx = {"theme_0": "usability", "theme_1": "pricing"}
+        questions = [{"text": "Compare {theme_0} and {theme_1}"}]
+        result = render_questions(questions, ctx)
+
+        assert result[0]["text"] == "Compare usability and pricing"
+
+    def test_no_placeholders(self):
+        ctx = {"theme_0": "usability"}
+        questions = [{"text": "A plain question with no placeholders"}]
+        result = render_questions(questions, ctx)
+
+        assert result[0]["text"] == "A plain question with no placeholders"
+
+    def test_empty_questions(self):
+        result = render_questions([], {"theme_0": "usability"})
+        assert result == []
+
+    def test_non_text_fields_untouched(self):
+        ctx = {"theme_0": "usability"}
+        questions = [{"text": "About {theme_0}", "response_schema": {"type": "text"}}]
+        result = render_questions(questions, ctx)
+
+        assert result[0]["response_schema"] == {"type": "text"}
+
+    def test_injection_attempt_curly_braces(self):
+        """Ensure format strings can't trigger code execution."""
+        ctx = {"theme_0": "usability"}
+        questions = [{"text": "{__class__.__mro__}"}]
+        result = render_questions(questions, ctx)
+        # Should render as literal — not expose internals
+        assert result[0]["text"] == "{__class__.__mro__}"
+
+    def test_injection_attempt_format_spec(self):
+        ctx = {"theme_0": "usability"}
+        questions = [{"text": "{theme_0!r}"}]
+        result = render_questions(questions, ctx)
+        assert result[0]["text"] == "'usability'"
+
+
+class TestValidateTemplate:
+    def test_all_keys_valid(self):
+        ctx = {"theme_0": "usability", "summary": "Good"}
+        result = validate_template("About {theme_0}: {summary}", ctx)
+        assert result == []
+
+    def test_missing_keys(self):
+        ctx = {"theme_0": "usability"}
+        result = validate_template("About {theme_0} and {missing_key}", ctx)
+        assert result == ["missing_key"]
+
+    def test_no_placeholders(self):
+        result = validate_template("A plain string", {})
+        assert result == []
+
+    def test_multiple_missing(self):
+        ctx = {}
+        result = validate_template("{a} and {b} and {c}", ctx)
+        assert set(result) == {"a", "b", "c"}
+
+    def test_empty_context(self):
+        result = validate_template("{theme_0}", {})
+        assert result == ["theme_0"]
+
+    def test_empty_text(self):
+        result = validate_template("", {"theme_0": "usability"})
+        assert result == []


### PR DESCRIPTION
## Summary
- Adds `synth_panel/templates.py` with `build_template_context()`, `render_questions()`, and `validate_template()`
- Flattens SynthesisResult into template variables for dynamic question rendering
- Safe string formatting with KeyError fallback (no eval)

## Test plan
- [x] 327 tests pass (20 new template tests)
- [x] Rebase on main: clean

MR bead: sp-wisp-24ip | Worker: nux | Issue: sp-tsz