### PR TITLE
feat: instrument v2 parser with round definitions (sp-65a)

### DIFF
--- a/examples/multi-round-study.yaml
+++ b/examples/multi-round-study.yaml
@@ -1,0 +1,51 @@
+instrument:
+  version: 2
+  rounds:
+    - name: discovery
+      questions:
+        - text: >
+            What is the biggest challenge you face when onboarding
+            new team members to your codebase?
+          response_schema:
+            type: text
+          follow_ups:
+            - "Can you walk me through a recent example?"
+
+        - text: >
+            How do you currently document architectural decisions,
+            and how well does that process work?
+          response_schema:
+            type: text
+
+    - name: deep_dive
+      depends_on: discovery
+      questions:
+        - text: >
+            Earlier the group identified "{theme_0}" as a key theme.
+            What specific tools or processes have you tried to address this?
+          response_schema:
+            type: text
+          follow_ups:
+            - "What worked and what didn't?"
+
+        - text: >
+            If you could change one thing about how your team handles
+            "{theme_1}", what would it be?
+          response_schema:
+            type: text
+
+    - name: validation
+      depends_on: deep_dive
+      questions:
+        - text: >
+            We've heard suggestions around "{recommendation}".
+            On a scale of 1-5, how impactful would this be for your team?
+          response_schema:
+            type: text
+
+        - text: >
+            What would prevent your team from adopting this kind of change?
+          response_schema:
+            type: text
+          follow_ups:
+            - "Is that a technical constraint or an organizational one?"

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -15,6 +15,7 @@ import yaml
 
 from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cost import ZERO_USAGE, TokenUsage, UsageTracker, estimate_cost, format_summary, lookup_pricing
+from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
 from synth_panel.llm.models import TextBlock
 from synth_panel.orchestrator import run_panel_parallel
@@ -108,26 +109,21 @@ def _load_personas(path: str) -> list[dict[str, Any]]:
     raise ValueError(f"Invalid personas file: expected 'personas' key or a list, got {type(data).__name__}")
 
 
-def _load_instrument(path: str) -> dict[str, Any]:
+def _load_instrument(path: str) -> Instrument:
     """Load an instrument/survey from a YAML file.
 
-    Expected format::
-
-        instrument:
-          questions:
-            - text: "What do you think about ...?"
-              response_schema: {type: text}
-              follow_ups: ["Can you elaborate?"]
+    Supports both v1 (flat questions) and v2 (multi-round) formats.
+    Returns a validated :class:`Instrument` with normalized round definitions.
     """
     data = _load_yaml(path)
     if isinstance(data, dict) and "instrument" in data:
-        instrument = data["instrument"]
-    elif isinstance(data, dict) and "questions" in data:
-        instrument = data
+        raw = data["instrument"]
+    elif isinstance(data, dict) and ("questions" in data or "rounds" in data):
+        raw = data
     else:
-        raise ValueError(f"Invalid instrument file: expected 'instrument' or 'questions' key")
-    instrument.setdefault("version", 1)
-    return instrument
+        raise ValueError("Invalid instrument file: expected 'instrument', 'questions', or 'rounds' key")
+    raw.setdefault("version", 1)
+    return parse_instrument(raw)
 
 
 def _load_schema(value: str) -> dict[str, Any]:
@@ -160,11 +156,11 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     try:
         instrument = _load_instrument(args.instrument)
-    except (FileNotFoundError, ValueError) as exc:
+    except (FileNotFoundError, ValueError, InstrumentError) as exc:
         print(f"Error loading instrument: {exc}", file=sys.stderr)
         return 1
 
-    questions = instrument.get("questions", [])
+    questions = instrument.questions
     if not questions:
         print("Error: instrument has no questions", file=sys.stderr)
         return 1

--- a/src/synth_panel/instrument.py
+++ b/src/synth_panel/instrument.py
@@ -1,0 +1,141 @@
+"""Instrument parser — supports v1 (flat questions) and v2 (multi-round) formats.
+
+v1 format (backward compatible):
+    instrument:
+      version: 1
+      questions:
+        - text: "..."
+
+v2 format (multi-round):
+    instrument:
+      version: 2
+      rounds:
+        - name: discovery
+          questions:
+            - text: "..."
+        - name: deep_dive
+          depends_on: discovery
+          questions:
+            - text: "Based on {theme_0}, ..."
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Round:
+    """A single round in a multi-round instrument."""
+
+    name: str
+    questions: list[dict[str, Any]]
+    depends_on: str | None = None
+
+
+@dataclass
+class Instrument:
+    """Parsed instrument with round definitions.
+
+    Both v1 and v2 YAML formats normalize to this structure.
+    v1 instruments become a single round named "default".
+    """
+
+    version: int
+    rounds: list[Round] = field(default_factory=list)
+
+    @property
+    def questions(self) -> list[dict[str, Any]]:
+        """Flat question list — convenience for single-round instruments."""
+        if len(self.rounds) == 1:
+            return self.rounds[0].questions
+        # For multi-round, return all questions across rounds
+        result: list[dict[str, Any]] = []
+        for r in self.rounds:
+            result.extend(r.questions)
+        return result
+
+    @property
+    def is_multi_round(self) -> bool:
+        return len(self.rounds) > 1
+
+
+class InstrumentError(ValueError):
+    """Raised when an instrument definition is invalid."""
+
+
+def parse_instrument(data: dict[str, Any]) -> Instrument:
+    """Parse a raw instrument dict into a validated Instrument.
+
+    Accepts either:
+    - v1: dict with ``questions`` key → single "default" round
+    - v2: dict with ``rounds`` key → multi-round instrument
+
+    Raises :class:`InstrumentError` on validation failure.
+    """
+    version = data.get("version", 1)
+
+    if "rounds" in data:
+        return _parse_v2(data, version)
+
+    if "questions" in data:
+        return _parse_v1(data, version)
+
+    raise InstrumentError(
+        "Instrument must have either 'questions' (v1) or 'rounds' (v2) key"
+    )
+
+
+def _parse_v1(data: dict[str, Any], version: int) -> Instrument:
+    """Parse v1 flat-questions format into a single-round instrument."""
+    questions = data["questions"]
+    if not isinstance(questions, list) or not questions:
+        raise InstrumentError("'questions' must be a non-empty list")
+    return Instrument(
+        version=version,
+        rounds=[Round(name="default", questions=questions)],
+    )
+
+
+def _parse_v2(data: dict[str, Any], version: int) -> Instrument:
+    """Parse v2 multi-round format with dependency validation."""
+    raw_rounds = data["rounds"]
+    if not isinstance(raw_rounds, list) or not raw_rounds:
+        raise InstrumentError("'rounds' must be a non-empty list")
+
+    rounds: list[Round] = []
+    seen_names: set[str] = set()
+
+    for i, raw in enumerate(raw_rounds):
+        if not isinstance(raw, dict):
+            raise InstrumentError(f"Round {i} must be a mapping, got {type(raw).__name__}")
+
+        name = raw.get("name")
+        if not name or not isinstance(name, str):
+            raise InstrumentError(f"Round {i} must have a 'name' string")
+
+        if name in seen_names:
+            raise InstrumentError(f"Duplicate round name: '{name}'")
+
+        questions = raw.get("questions")
+        if not isinstance(questions, list) or not questions:
+            raise InstrumentError(f"Round '{name}' must have a non-empty 'questions' list")
+
+        depends_on = raw.get("depends_on")
+        if depends_on is not None:
+            if not isinstance(depends_on, str):
+                raise InstrumentError(
+                    f"Round '{name}': 'depends_on' must be a string, "
+                    f"got {type(depends_on).__name__}"
+                )
+            if depends_on not in seen_names:
+                raise InstrumentError(
+                    f"Round '{name}': depends_on '{depends_on}' references "
+                    f"an undefined or later round (only earlier rounds allowed)"
+                )
+
+        seen_names.add(name)
+        rounds.append(Round(name=name, questions=questions, depends_on=depends_on))
+
+    return Instrument(version=version, rounds=rounds)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -331,7 +331,8 @@ class TestYAMLLoading:
             "    - text: What?\n"
         )
         instr = _load_instrument(str(p))
-        assert "questions" in instr
+        assert instr.questions == [{"text": "What?"}]
+        assert len(instr.rounds) == 1
 
     def test_load_instrument_questions_key(self, tmp_path):
         p = tmp_path / "survey.yaml"
@@ -340,7 +341,8 @@ class TestYAMLLoading:
             "  - text: What?\n"
         )
         instr = _load_instrument(str(p))
-        assert "questions" in instr
+        assert instr.questions == [{"text": "What?"}]
+        assert len(instr.rounds) == 1
 
     def test_load_instrument_invalid(self, tmp_path):
         p = tmp_path / "bad.yaml"

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,255 @@
+"""Tests for instrument v1/v2 parser and round validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_panel.instrument import Instrument, InstrumentError, Round, parse_instrument
+
+
+# ---------------------------------------------------------------------------
+# v1 (flat questions) → single "default" round
+# ---------------------------------------------------------------------------
+
+class TestV1Parsing:
+    def test_basic_v1(self):
+        data = {"version": 1, "questions": [{"text": "Hello?"}]}
+        inst = parse_instrument(data)
+        assert inst.version == 1
+        assert len(inst.rounds) == 1
+        assert inst.rounds[0].name == "default"
+        assert inst.rounds[0].questions == [{"text": "Hello?"}]
+        assert inst.rounds[0].depends_on is None
+
+    def test_v1_default_version(self):
+        data = {"questions": [{"text": "Q1"}]}
+        inst = parse_instrument(data)
+        assert inst.version == 1
+
+    def test_v1_multiple_questions(self):
+        qs = [{"text": "Q1"}, {"text": "Q2"}, {"text": "Q3"}]
+        inst = parse_instrument({"questions": qs})
+        assert inst.questions == qs
+
+    def test_v1_is_not_multi_round(self):
+        inst = parse_instrument({"questions": [{"text": "Q"}]})
+        assert not inst.is_multi_round
+
+    def test_v1_empty_questions_raises(self):
+        with pytest.raises(InstrumentError, match="non-empty list"):
+            parse_instrument({"questions": []})
+
+    def test_v1_questions_not_list_raises(self):
+        with pytest.raises(InstrumentError, match="non-empty list"):
+            parse_instrument({"questions": "not a list"})
+
+
+# ---------------------------------------------------------------------------
+# v2 (multi-round) parsing
+# ---------------------------------------------------------------------------
+
+class TestV2Parsing:
+    def test_basic_multi_round(self):
+        data = {
+            "version": 2,
+            "rounds": [
+                {"name": "discovery", "questions": [{"text": "Q1"}]},
+                {
+                    "name": "deep_dive",
+                    "depends_on": "discovery",
+                    "questions": [{"text": "Q2"}],
+                },
+            ],
+        }
+        inst = parse_instrument(data)
+        assert inst.version == 2
+        assert len(inst.rounds) == 2
+        assert inst.rounds[0].name == "discovery"
+        assert inst.rounds[0].depends_on is None
+        assert inst.rounds[1].name == "deep_dive"
+        assert inst.rounds[1].depends_on == "discovery"
+
+    def test_three_round_chain(self):
+        data = {
+            "version": 2,
+            "rounds": [
+                {"name": "a", "questions": [{"text": "Q1"}]},
+                {"name": "b", "depends_on": "a", "questions": [{"text": "Q2"}]},
+                {"name": "c", "depends_on": "b", "questions": [{"text": "Q3"}]},
+            ],
+        }
+        inst = parse_instrument(data)
+        assert inst.is_multi_round
+        assert [r.name for r in inst.rounds] == ["a", "b", "c"]
+
+    def test_round_without_depends_on(self):
+        data = {
+            "version": 2,
+            "rounds": [
+                {"name": "intro", "questions": [{"text": "Q1"}]},
+                {"name": "outro", "questions": [{"text": "Q2"}]},
+            ],
+        }
+        inst = parse_instrument(data)
+        assert all(r.depends_on is None for r in inst.rounds)
+
+    def test_questions_property_multi_round(self):
+        data = {
+            "version": 2,
+            "rounds": [
+                {"name": "a", "questions": [{"text": "Q1"}, {"text": "Q2"}]},
+                {"name": "b", "questions": [{"text": "Q3"}]},
+            ],
+        }
+        inst = parse_instrument(data)
+        assert inst.questions == [{"text": "Q1"}, {"text": "Q2"}, {"text": "Q3"}]
+
+    def test_single_round_v2(self):
+        """v2 format with a single round is valid but not multi-round."""
+        data = {
+            "version": 2,
+            "rounds": [{"name": "only", "questions": [{"text": "Q1"}]}],
+        }
+        inst = parse_instrument(data)
+        assert not inst.is_multi_round
+        assert inst.rounds[0].name == "only"
+
+
+# ---------------------------------------------------------------------------
+# Validation errors
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_no_questions_or_rounds_raises(self):
+        with pytest.raises(InstrumentError, match="'questions'.*or.*'rounds'"):
+            parse_instrument({"version": 1})
+
+    def test_empty_rounds_raises(self):
+        with pytest.raises(InstrumentError, match="non-empty list"):
+            parse_instrument({"rounds": []})
+
+    def test_rounds_not_list_raises(self):
+        with pytest.raises(InstrumentError, match="non-empty list"):
+            parse_instrument({"rounds": "not a list"})
+
+    def test_round_missing_name_raises(self):
+        with pytest.raises(InstrumentError, match="'name' string"):
+            parse_instrument({"rounds": [{"questions": [{"text": "Q"}]}]})
+
+    def test_round_empty_name_raises(self):
+        with pytest.raises(InstrumentError, match="'name' string"):
+            parse_instrument({"rounds": [{"name": "", "questions": [{"text": "Q"}]}]})
+
+    def test_round_missing_questions_raises(self):
+        with pytest.raises(InstrumentError, match="non-empty 'questions'"):
+            parse_instrument({"rounds": [{"name": "a"}]})
+
+    def test_round_empty_questions_raises(self):
+        with pytest.raises(InstrumentError, match="non-empty 'questions'"):
+            parse_instrument({"rounds": [{"name": "a", "questions": []}]})
+
+    def test_round_not_mapping_raises(self):
+        with pytest.raises(InstrumentError, match="must be a mapping"):
+            parse_instrument({"rounds": ["not a dict"]})
+
+    def test_duplicate_round_name_raises(self):
+        with pytest.raises(InstrumentError, match="Duplicate round name"):
+            parse_instrument({
+                "rounds": [
+                    {"name": "a", "questions": [{"text": "Q1"}]},
+                    {"name": "a", "questions": [{"text": "Q2"}]},
+                ],
+            })
+
+    def test_forward_ref_depends_on_raises(self):
+        with pytest.raises(InstrumentError, match="undefined or later round"):
+            parse_instrument({
+                "rounds": [
+                    {
+                        "name": "first",
+                        "depends_on": "second",
+                        "questions": [{"text": "Q1"}],
+                    },
+                    {"name": "second", "questions": [{"text": "Q2"}]},
+                ],
+            })
+
+    def test_self_ref_depends_on_raises(self):
+        with pytest.raises(InstrumentError, match="undefined or later round"):
+            parse_instrument({
+                "rounds": [
+                    {
+                        "name": "self_ref",
+                        "depends_on": "self_ref",
+                        "questions": [{"text": "Q1"}],
+                    },
+                ],
+            })
+
+    def test_nonexistent_depends_on_raises(self):
+        with pytest.raises(InstrumentError, match="undefined or later round"):
+            parse_instrument({
+                "rounds": [
+                    {
+                        "name": "a",
+                        "depends_on": "nonexistent",
+                        "questions": [{"text": "Q1"}],
+                    },
+                ],
+            })
+
+    def test_depends_on_not_string_raises(self):
+        with pytest.raises(InstrumentError, match="must be a string"):
+            parse_instrument({
+                "rounds": [
+                    {"name": "a", "questions": [{"text": "Q1"}]},
+                    {
+                        "name": "b",
+                        "depends_on": ["a"],
+                        "questions": [{"text": "Q2"}],
+                    },
+                ],
+            })
+
+
+# ---------------------------------------------------------------------------
+# Dataclass behavior
+# ---------------------------------------------------------------------------
+
+class TestDataclasses:
+    def test_round_defaults(self):
+        r = Round(name="test", questions=[{"text": "Q"}])
+        assert r.depends_on is None
+
+    def test_instrument_defaults(self):
+        inst = Instrument(version=1)
+        assert inst.rounds == []
+        assert inst.questions == []
+        assert not inst.is_multi_round
+
+
+# ---------------------------------------------------------------------------
+# Integration: example YAML file
+# ---------------------------------------------------------------------------
+
+class TestExampleYAML:
+    def test_multi_round_study_parses(self):
+        """Verify the shipped example file parses without errors."""
+        import yaml
+        from pathlib import Path
+
+        example = Path(__file__).parent.parent / "examples" / "multi-round-study.yaml"
+        if not example.exists():
+            pytest.skip("Example file not found")
+
+        with open(example) as f:
+            data = yaml.safe_load(f)
+
+        raw = data["instrument"]
+        inst = parse_instrument(raw)
+        assert inst.version == 2
+        assert len(inst.rounds) == 3
+        assert inst.rounds[0].name == "discovery"
+        assert inst.rounds[1].depends_on == "discovery"
+        assert inst.rounds[2].depends_on == "deep_dive"
+        assert inst.is_multi_round


### PR DESCRIPTION
## Summary
- Adds v2 instrument YAML parser with `rounds` key support
- Multi-round instruments with `depends_on` validation (no cycles, no forward refs)
- Single `questions` key auto-wraps as single default round
- Includes `examples/multi-round-study.yaml` demonstrating 3-round instrument

## Test plan
- [x] 334 tests pass (27 new instrument tests)
- [x] Rebase on main: clean

MR bead: sp-wisp-r8ag | Worker: furiosa | Issue: sp-65a