### PR TITLE
feat: session reuse in orchestrator for multi-round support (sp-yln)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -181,7 +181,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     client = LLMClient()
 
     # Run all panelists in parallel via the orchestrator
-    panelist_results, _registry = run_panel_parallel(
+    panelist_results, _registry, _sessions = run_panel_parallel(
         client=client,
         personas=personas,
         questions=questions,

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -79,7 +79,7 @@ def _run_panel_sync(
 ) -> tuple[list[PanelistResult], list[dict[str, Any]], CostTokenUsage, Any, dict[str, Any] | None]:
     """Run panel synchronously. Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict)."""
     client = LLMClient()
-    panelist_results, _registry = run_panel_parallel(
+    panelist_results, _registry, _sessions = run_panel_parallel(
         client=client,
         personas=personas,
         questions=questions,

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -262,7 +262,8 @@ def _run_panelist(
     system_prompt_fn: Callable[[dict[str, Any]], str],
     question_prompt_fn: Callable[[dict[str, Any]], str],
     response_schema: dict[str, Any] | None = None,
-) -> PanelistResult:
+    session: Session | None = None,
+) -> tuple[PanelistResult, Session]:
     """Execute a single panelist's full interview. Runs in a worker thread.
 
     Manages the worker lifecycle: spawning → ready → running → finished/failed.
@@ -280,7 +281,8 @@ def _run_panelist(
         registry.transition(worker_id, WorkerStatus.PROMPT_ACCEPTED, "prompt received")
         registry.transition(worker_id, WorkerStatus.RUNNING, "executing questions")
 
-        session = Session()
+        if session is None:
+            session = Session()
         runtime = AgentRuntime(
             client=client,
             session=session,
@@ -357,11 +359,12 @@ def _run_panelist(
         registry.set_result(worker_id, {"responses": responses}, tracker.cumulative_usage)
         registry.transition(worker_id, WorkerStatus.FINISHED, "all questions complete")
 
-        return PanelistResult(
+        result = PanelistResult(
             persona_name=name,
             responses=responses,
             usage=tracker.cumulative_usage,
         )
+        return result, session
 
     except Exception as exc:
         # Transition to failed
@@ -376,7 +379,7 @@ def _run_panelist(
             responses=responses,
             usage=tracker.cumulative_usage,
             error=str(exc),
-        )
+        ), session
 
 
 def run_panel_parallel(
@@ -388,7 +391,8 @@ def run_panel_parallel(
     question_prompt_fn: Callable[[dict[str, Any]], str],
     max_workers: int | None = None,
     response_schema: dict[str, Any] | None = None,
-) -> tuple[list[PanelistResult], WorkerRegistry]:
+    sessions: dict[str, Session] | None = None,
+) -> tuple[list[PanelistResult], WorkerRegistry, dict[str, Session]]:
     """Run all panelists in parallel and return ordered results.
 
     Args:
@@ -402,9 +406,13 @@ def run_panel_parallel(
         response_schema: Optional JSON Schema for structured output. When
             provided, responses are extracted as structured data via tool-use
             forcing instead of free text.
+        sessions: Optional mapping of persona names to existing sessions.
+            When provided, panelists reuse their session (conversation history
+            preserved). When None, each panelist gets a fresh session.
 
     Returns:
-        Tuple of (ordered results matching persona order, registry).
+        Tuple of (ordered results matching persona order, registry,
+        sessions dict mapping persona names to their sessions).
     """
     registry = WorkerRegistry()
     effective_workers = max_workers or len(personas)
@@ -417,10 +425,14 @@ def run_panel_parallel(
         worker_ids.append(wid)
 
     results: list[PanelistResult | None] = [None] * len(personas)
+    out_sessions: dict[str, Session] = {}
+    session_lock = threading.Lock()
 
     with ThreadPoolExecutor(max_workers=effective_workers) as executor:
         future_to_index = {}
         for idx, (persona, worker_id) in enumerate(zip(personas, worker_ids)):
+            name = persona.get("name", "Anonymous")
+            existing_session = (sessions or {}).get(name)
             future = executor.submit(
                 _run_panelist,
                 registry,
@@ -432,13 +444,17 @@ def run_panel_parallel(
                 system_prompt_fn,
                 question_prompt_fn,
                 response_schema,
+                existing_session,
             )
             future_to_index[future] = idx
 
         for future in as_completed(future_to_index):
             idx = future_to_index[future]
             try:
-                results[idx] = future.result()
+                result, sess = future.result()
+                results[idx] = result
+                with session_lock:
+                    out_sessions[result.persona_name] = sess
             except Exception as exc:
                 name = personas[idx].get("name", "Anonymous")
                 results[idx] = PanelistResult(
@@ -449,4 +465,4 @@ def run_panel_parallel(
                 )
 
     # All slots should be filled; cast away None
-    return [r for r in results if r is not None], registry
+    return [r for r in results if r is not None], registry, out_sessions

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -709,6 +709,7 @@ class TestPanelRunWithSchema:
         mock_run.return_value = (
             [PanelistResult(persona_name="X", responses=[{"question": "Q", "response": {"a": 1}, "structured": True}], usage=ZERO_USAGE)],
             MagicMock(),
+            {},
         )
         mock_synth.return_value = _mock_synthesis_result()
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -335,7 +335,7 @@ class TestRunPanelParallel:
         personas = [{"name": "Alice", "age": 30}]
         questions = [{"text": "What do you think?"}]
 
-        results, registry = run_panel_parallel(
+        results, registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -362,7 +362,7 @@ class TestRunPanelParallel:
         ]
         questions = [{"text": "Q1"}, {"text": "Q2"}]
 
-        results, registry = run_panel_parallel(
+        results, registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -393,7 +393,7 @@ class TestRunPanelParallel:
         personas = [{"name": "Alice"}]
         questions = [{"text": "Main Q", "follow_ups": ["Tell me more"]}]
 
-        results, registry = run_panel_parallel(
+        results, registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -413,7 +413,7 @@ class TestRunPanelParallel:
         personas = [{"name": "Alice"}]
         questions = [{"text": "Q1"}, {"text": "Q2"}]
 
-        results, _ = run_panel_parallel(
+        results, _, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -446,7 +446,7 @@ class TestRunPanelParallel:
         personas = [{"name": "Alice"}, {"name": "Bob"}]
         questions = [{"text": "Q1"}]
 
-        results, registry = run_panel_parallel(
+        results, registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -482,7 +482,7 @@ class TestRunPanelParallel:
         personas = [{"name": f"P{i}"} for i in range(6)]
         questions = [{"text": "Q"}]
 
-        results, _ = run_panel_parallel(
+        results, _, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -516,7 +516,7 @@ class TestRunPanelParallel:
         ]
         questions = [{"text": "Q"}]
 
-        results, _ = run_panel_parallel(
+        results, _, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -571,7 +571,7 @@ class TestStructuredOutputIntegration:
         personas = [{"name": "Alice"}]
         questions = [{"text": "What do you think?"}]
 
-        results, registry = run_panel_parallel(
+        results, registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -595,7 +595,7 @@ class TestStructuredOutputIntegration:
         personas = [{"name": "Bob"}]
         questions = [{"text": "Tell me something"}]
 
-        results, _ = run_panel_parallel(
+        results, _, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -625,7 +625,7 @@ class TestStructuredOutputIntegration:
         personas = [{"name": "Carol"}]
         questions = [{"text": "Main Q", "follow_ups": ["Tell me more"]}]
 
-        results, _ = run_panel_parallel(
+        results, _, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
             questions=questions,
@@ -641,3 +641,114 @@ class TestStructuredOutputIntegration:
         # Follow-up is text
         assert responses[1].get("follow_up") is True
         assert "structured" not in responses[1]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Session reuse
+# ---------------------------------------------------------------------------
+
+class TestSessionReuse:
+    def test_sessions_returned_without_input(self):
+        """When no sessions param, fresh sessions are created and returned."""
+        client = _make_mock_client([_make_text_response("Hi")])
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Hello?"}]
+
+        results, _, sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+        )
+
+        assert "Alice" in sessions
+        assert len(sessions["Alice"].messages) > 0
+
+    def test_session_reuse_preserves_history(self):
+        """When a session is passed in, conversation history is preserved."""
+        from synth_panel.persistence import Session
+
+        # Round 1: fresh session
+        responses_r1 = [_make_text_response("Round 1 answer")]
+        client_r1 = _make_mock_client(responses_r1)
+        personas = [{"name": "Alice"}]
+        questions_r1 = [{"text": "First question"}]
+
+        _, _, sessions = run_panel_parallel(
+            client=client_r1,
+            personas=personas,
+            questions=questions_r1,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+        )
+
+        session_after_r1 = sessions["Alice"]
+        msg_count_r1 = len(session_after_r1.messages)
+        assert msg_count_r1 > 0
+
+        # Round 2: reuse sessions
+        responses_r2 = [_make_text_response("Round 2 answer")]
+        client_r2 = _make_mock_client(responses_r2)
+        questions_r2 = [{"text": "Follow-up question"}]
+
+        _, _, sessions_r2 = run_panel_parallel(
+            client=client_r2,
+            personas=personas,
+            questions=questions_r2,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            sessions=sessions,
+        )
+
+        # Same session object, more messages accumulated
+        session_after_r2 = sessions_r2["Alice"]
+        assert session_after_r2 is session_after_r1
+        assert len(session_after_r2.messages) > msg_count_r1
+
+    def test_sessions_dict_maps_all_personas(self):
+        """Returned sessions dict has an entry for every persona."""
+        responses = [_make_text_response(f"R{i}") for i in range(4)]
+        client = _make_mock_client(responses)
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Q1"}, {"text": "Q2"}]
+
+        _, _, sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+        )
+
+        assert set(sessions.keys()) == {"Alice", "Bob"}
+
+    def test_partial_sessions_creates_missing(self):
+        """If sessions dict only has some personas, missing ones get fresh sessions."""
+        from synth_panel.persistence import Session
+
+        existing_session = Session()
+        responses = [_make_text_response("A"), _make_text_response("B")]
+        client = _make_mock_client(responses)
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Q"}]
+
+        _, _, sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            sessions={"Alice": existing_session},
+        )
+
+        # Alice reused the existing session
+        assert sessions["Alice"] is existing_session
+        # Bob got a fresh session
+        assert "Bob" in sessions
+        assert sessions["Bob"] is not existing_session


### PR DESCRIPTION
## Summary
- Adds `session` param to `_run_panelist()` for session reuse across rounds
- Adds `sessions` dict to `run_panel_parallel()`, returns sessions in result tuple
- Foundation for multi-round panels and panel extend functionality

## Test plan
- [x] 311 tests pass (4 new orchestrator session-reuse tests)
- [x] Rebase on main: clean

MR bead: sp-wisp-71ou | Worker: slit | Issue: sp-yln