### PR TITLE
fix: CI failure — add importorskip guard for mcp tests (sp-1wq)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
 
       - name: Run tests
         run: pytest tests/ -x --ignore=tests/test_acceptance.py

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -9,6 +9,8 @@ from unittest.mock import AsyncMock, MagicMock, patch, ANY
 
 import pytest
 
+pytest.importorskip("mcp", reason="mcp package not installed (pip install .[mcp])")
+
 
 @pytest.fixture(autouse=True)
 def _data_dir(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Adds `pytest.importorskip('mcp')` guard to `test_mcp_server.py`
- Prevents `ModuleNotFoundError` when `mcp` optional dependency is not installed
- Unblocks PRs #22-#27 which are all blocked by CI branch protection

## Test plan
- [x] 307 passed, 1 skipped (mcp test properly skips), 0 failures
- [x] Rebase on main: clean

MR bead: sp-wisp-qa91 | Worker: dementus | Issue: sp-1wq