### PR TITLE
feat: add response_sentiment condition evaluator (sp-uqu, conflict resolved)

### DIFF
--- a/src/synth_panel/conditions.py
+++ b/src/synth_panel/conditions.py
@@ -1,4 +1,4 @@
-"""Condition evaluation for conditional follow-ups (EXECUTION-PLAN-030.md F2-A).
+"""Condition evaluation for conditional follow-ups.
 
 Evaluates whether a follow-up question should be asked based on a condition
 string and the response text from the main question.
@@ -10,8 +10,13 @@ via json.dumps before condition evaluation.
 from __future__ import annotations
 
 import json
-from typing import Any, Callable
+import logging
+from typing import TYPE_CHECKING, Any, Callable
 
+if TYPE_CHECKING:
+    from synth_panel.llm.client import LLMClient
+
+log = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Evaluator registry
@@ -28,12 +33,83 @@ EVALUATORS: dict[str, Callable[[str, str], bool]] = {
     "response_contains": _eval_contains,
 }
 
+_SENTIMENT_PROMPT = (
+    "Classify the sentiment of the following text as exactly one of: "
+    "positive, negative, neutral.\n\n"
+    "Text: {text}\n\n"
+    "Respond with a single word: positive, negative, or neutral."
+)
+
+_VALID_SENTIMENTS = {"positive", "negative", "neutral"}
+
+
+# ---------------------------------------------------------------------------
+# Sentiment evaluator (LLM-based)
+# ---------------------------------------------------------------------------
+
+def _eval_sentiment(
+    target: str,
+    response_text: str,
+    client: LLMClient,
+    sentiment_cache: dict[str, str] | None = None,
+) -> bool:
+    """Classify response sentiment via a haiku LLM call.
+
+    Args:
+        target: Expected sentiment (positive, negative, neutral).
+        response_text: Text to classify.
+        client: LLM client for making the classification call.
+        sentiment_cache: Optional cache mapping response_text -> sentiment.
+            Avoids duplicate LLM calls for the same response.
+
+    Returns:
+        True if the classified sentiment matches *target*.
+    """
+    from synth_panel.llm.models import CompletionRequest, InputMessage, TextBlock
+
+    target = target.lower().strip()
+
+    # Check cache first
+    if sentiment_cache is not None and response_text in sentiment_cache:
+        cached = sentiment_cache[response_text]
+        log.debug("sentiment cache hit: %r -> %s", response_text[:40], cached)
+        return cached == target
+
+    prompt = _SENTIMENT_PROMPT.format(text=response_text)
+    request = CompletionRequest(
+        model="haiku",
+        max_tokens=16,
+        messages=[InputMessage(role="user", content=[TextBlock(text=prompt)])],
+    )
+    response = client.send(request)
+    classification = response.text.strip().lower()
+
+    # Validate — fall back to neutral on unexpected output
+    if classification not in _VALID_SENTIMENTS:
+        log.warning(
+            "Unexpected sentiment classification %r for text %r, defaulting to neutral",
+            classification, response_text[:60],
+        )
+        classification = "neutral"
+
+    # Populate cache
+    if sentiment_cache is not None:
+        sentiment_cache[response_text] = classification
+
+    return classification == target
+
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-def evaluate_condition(condition: str, response_text: Any) -> bool:
+def evaluate_condition(
+    condition: str,
+    response_text: Any,
+    *,
+    client: LLMClient | None = None,
+    sentiment_cache: dict[str, str] | None = None,
+) -> bool:
     """Evaluate whether a follow-up should fire.
 
     Args:
@@ -41,9 +117,13 @@ def evaluate_condition(condition: str, response_text: Any) -> bool:
             - ``"always"`` -- always fire (default)
             - ``"never"`` -- never fire
             - ``"response_contains: <keyword>"`` -- case-insensitive substring
+            - ``"response_sentiment: <positive|negative|neutral>"`` -- LLM-based
             - Unknown types default to True (forward-compatible)
         response_text: The response from the main question. If a dict or other
             non-string type, it is serialized to JSON before evaluation.
+        client: Optional LLM client, required for ``response_sentiment``.
+        sentiment_cache: Optional cache to avoid duplicate LLM calls for
+            the same response text.
 
     Returns:
         True if the follow-up should be asked.
@@ -61,6 +141,14 @@ def evaluate_condition(condition: str, response_text: Any) -> bool:
     else:
         ctype = condition.lower()
         arg = ""
+
+    # Handle response_sentiment separately (needs LLM client)
+    if ctype == "response_sentiment":
+        if client is None:
+            # Graceful degradation: no client → default to True
+            log.debug("response_sentiment: no client, defaulting to True")
+            return True
+        return _eval_sentiment(arg, response_text, client, sentiment_cache)
 
     evaluator = EVALUATORS.get(ctype)
     if evaluator is None:

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -264,6 +264,7 @@ def _run_panelist(
     question_prompt_fn: Callable[[dict[str, Any]], str],
     response_schema: dict[str, Any] | None = None,
     session: Session | None = None,
+    sentiment_cache: dict[str, str] | None = None,
 ) -> tuple[PanelistResult, Session]:
     """Execute a single panelist's full interview. Runs in a worker thread.
 
@@ -341,19 +342,23 @@ def _run_panelist(
                     "error": True,
                 })
 
-            # Handle follow-ups (always text mode — structured output applies to main questions)
-            follow_ups = question.get("follow_ups", []) if isinstance(question, dict) else []
-            # Get the main question's response for condition evaluation
-            main_response = responses[-1]["response"] if responses else ""
-            for follow_up in follow_ups:
-                fu_norm = normalize_follow_up(follow_up)
-                if not evaluate_condition(fu_norm["condition"], main_response):
+            # Handle conditional follow-ups (text mode only)
+            raw_follow_ups = question.get("follow_ups", []) if isinstance(question, dict) else []
+            # Get the last main-question response text for condition eval
+            last_response = responses[-1].get("response", "") if responses else ""
+            for raw_fu in raw_follow_ups:
+                fu = normalize_follow_up(raw_fu)
+                condition = fu.get("condition", "always")
+                if not evaluate_condition(
+                    condition, last_response,
+                    client=client, sentiment_cache=sentiment_cache,
+                ):
                     continue
                 try:
-                    fu_summary = runtime.run_turn(fu_norm["text"])
+                    fu_summary = runtime.run_turn(fu["text"])
                     fu_text = _extract_text(fu_summary)
                     responses.append({
-                        "question": fu_norm["text"],
+                        "question": fu["text"],
                         "response": fu_text,
                         "follow_up": True,
                     })
@@ -422,6 +427,7 @@ def run_panel_parallel(
     """
     registry = WorkerRegistry()
     effective_workers = max_workers or len(personas)
+    sentiment_cache: dict[str, str] = {}
 
     # Create workers and map to personas (preserves order)
     worker_ids: list[str] = []
@@ -451,6 +457,7 @@ def run_panel_parallel(
                 question_prompt_fn,
                 response_schema,
                 existing_session,
+                sentiment_cache,
             )
             future_to_index[future] = idx
 

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,8 +1,10 @@
 """Tests for condition evaluation module."""
 
 import json
+from unittest.mock import MagicMock
 
 from synth_panel.conditions import evaluate_condition, normalize_follow_up
+from synth_panel.llm.models import CompletionResponse, TextBlock, TokenUsage
 
 
 # ---------------------------------------------------------------------------
@@ -65,14 +67,117 @@ class TestResponseContains:
 # ---------------------------------------------------------------------------
 
 class TestUnknownCondition:
-    def test_unknown_defaults_to_true(self):
-        assert evaluate_condition("response_sentiment: positive", "great!") is True
-
     def test_completely_unknown_type(self):
         assert evaluate_condition("some_future_condition: arg", "text") is True
 
     def test_unknown_without_arg(self):
         assert evaluate_condition("future_check", "text") is True
+
+
+# ---------------------------------------------------------------------------
+# evaluate_condition — "response_sentiment" (LLM-based)
+# ---------------------------------------------------------------------------
+
+def _mock_client(classification: str) -> MagicMock:
+    """Create a mock LLMClient that returns *classification* as text."""
+    client = MagicMock()
+    client.send.return_value = CompletionResponse(
+        id="test",
+        model="claude-haiku-4-5-20251001",
+        content=[TextBlock(text=classification)],
+        usage=TokenUsage(),
+    )
+    return client
+
+
+class TestResponseSentiment:
+    def test_positive_match(self):
+        client = _mock_client("positive")
+        assert evaluate_condition(
+            "response_sentiment: positive", "I love this product!", client=client,
+        ) is True
+        client.send.assert_called_once()
+
+    def test_negative_match(self):
+        client = _mock_client("negative")
+        assert evaluate_condition(
+            "response_sentiment: negative", "This is terrible", client=client,
+        ) is True
+
+    def test_neutral_match(self):
+        client = _mock_client("neutral")
+        assert evaluate_condition(
+            "response_sentiment: neutral", "It's okay I guess", client=client,
+        ) is True
+
+    def test_mismatch(self):
+        client = _mock_client("negative")
+        assert evaluate_condition(
+            "response_sentiment: positive", "This is terrible", client=client,
+        ) is False
+
+    def test_case_insensitive_target(self):
+        client = _mock_client("positive")
+        assert evaluate_condition(
+            "response_sentiment: POSITIVE", "great!", client=client,
+        ) is True
+
+    def test_case_insensitive_classification(self):
+        client = _mock_client("  Positive  ")
+        assert evaluate_condition(
+            "response_sentiment: positive", "great!", client=client,
+        ) is True
+
+    def test_no_client_defaults_to_true(self):
+        """Graceful degradation: no client means condition passes."""
+        assert evaluate_condition("response_sentiment: negative", "text") is True
+
+    def test_cache_hit_avoids_llm_call(self):
+        client = _mock_client("positive")
+        cache: dict[str, str] = {"I love it": "positive"}
+        result = evaluate_condition(
+            "response_sentiment: positive", "I love it",
+            client=client, sentiment_cache=cache,
+        )
+        assert result is True
+        client.send.assert_not_called()
+
+    def test_cache_populated_after_call(self):
+        client = _mock_client("negative")
+        cache: dict[str, str] = {}
+        evaluate_condition(
+            "response_sentiment: negative", "awful experience",
+            client=client, sentiment_cache=cache,
+        )
+        assert cache["awful experience"] == "negative"
+
+    def test_cache_shared_across_calls(self):
+        client = _mock_client("positive")
+        cache: dict[str, str] = {}
+        # First call populates cache
+        evaluate_condition(
+            "response_sentiment: positive", "great product",
+            client=client, sentiment_cache=cache,
+        )
+        assert client.send.call_count == 1
+        # Second call uses cache
+        evaluate_condition(
+            "response_sentiment: positive", "great product",
+            client=client, sentiment_cache=cache,
+        )
+        assert client.send.call_count == 1  # No additional call
+
+    def test_unexpected_classification_defaults_neutral(self):
+        client = _mock_client("ambivalent")  # not a valid sentiment
+        assert evaluate_condition(
+            "response_sentiment: neutral", "mixed feelings",
+            client=client,
+        ) is True
+        # "ambivalent" → "neutral" (default), matches "neutral" target
+        assert evaluate_condition(
+            "response_sentiment: positive", "mixed feelings",
+            client=client,
+        ) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds LLM-based sentiment classification to `conditions.py` (originally PR #26)
- Conflict resolved: combined session-reuse params (from #25) with sentiment_cache params
- `evaluate_condition()` gains optional `client` param for sentiment evaluation
- Sentiment cache avoids duplicate LLM calls (~$0.003/panel)

## Test plan
- [x] 378 passed, 1 skipped
- [x] Rebase on main: clean (conflicts resolved)

MR bead: sp-wisp-zbqf | Issue: sp-uqu (conflict resolution of sp-3uw)