### PR TITLE
ci: add semver auto-tag + PyPI publish workflow (sp-aet)

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,15 @@
+- name: "semver:major"
+  color: "d93f0b"
+  description: "Bump major version on merge"
+
+- name: "semver:minor"
+  color: "0e8a16"
+  description: "Bump minor version on merge"
+
+- name: "semver:patch"
+  color: "1d76db"
+  description: "Bump patch version on merge"
+
+- name: "semver:skip"
+  color: "e4e669"
+  description: "Skip version bump on merge"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,122 @@
+name: Auto Semver Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
+jobs:
+  auto-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
+      skipped: ${{ steps.check.outputs.skipped }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse semver labels
+        id: check
+        env:
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          SEMVER_LABELS=$(echo "$LABELS" | jq -r '.[] | select(startswith("semver:"))' | grep -v '^semver:skip$' || true)
+          SKIP=$(echo "$LABELS" | jq -r '.[] | select(. == "semver:skip")' || true)
+
+          if [ -n "$SKIP" ]; then
+            echo "semver:skip label found — skipping release"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          COUNT=$(echo "$SEMVER_LABELS" | grep -c . || true)
+
+          if [ "$COUNT" -eq 0 ]; then
+            echo "No semver label found — skipping release"
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$COUNT" -gt 1 ]; then
+            echo "::error::Multiple semver labels found: $(echo $SEMVER_LABELS | tr '\n' ', '). Use exactly one."
+            exit 1
+          fi
+
+          BUMP="${SEMVER_LABELS#semver:}"
+          echo "bump=$BUMP" >> "$GITHUB_OUTPUT"
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+          echo "Bump type: $BUMP"
+
+      - name: Compute next version
+        if: steps.check.outputs.skipped != 'true'
+        id: bump
+        env:
+          BUMP: ${{ steps.check.outputs.bump }}
+        run: |
+          LATEST=$(git tag --list 'v*.*.*' --sort=-v:refname | head -n 1)
+
+          if [ -z "$LATEST" ]; then
+            LATEST="v0.0.0"
+            echo "No existing tags found — starting from v0.0.0"
+          fi
+          echo "Latest tag: $LATEST"
+
+          VERSION="${LATEST#v}"
+          MAJOR="${VERSION%%.*}"
+          REST="${VERSION#*.}"
+          MINOR="${REST%%.*}"
+          PATCH="${REST#*.}"
+
+          case "$BUMP" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "::error::Unknown bump type: $BUMP"
+              exit 1
+              ;;
+          esac
+
+          NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "New tag: $NEW_TAG"
+
+      - name: Create and push tag
+        if: steps.check.outputs.skipped != 'true'
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG (PR #${PR_NUMBER}: ${PR_TITLE})"
+          git push origin "$NEW_TAG"
+
+  publish:
+    needs: auto-tag
+    if: needs.auto-tag.outputs.skipped != 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.auto-tag.outputs.tag }}
+    permissions:
+      id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,51 +1,57 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
   push:
-    branches: [main]
-    paths:
-      - 'synth_panel/**'
-      - 'pyproject.toml'
+    tags:
+      - "v*"
 
 permissions:
   id-token: write
 
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Determine tag ref
+        id: ref
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout at tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
 
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Update pyproject.toml version to match tag
+        env:
+          TAG: ${{ steps.ref.outputs.tag }}
+        run: |
+          VERSION="${TAG#v}"
+          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" pyproject.toml
+          echo "Set version to ${VERSION}"
+          grep '^version' pyproject.toml
 
       - name: Install build tools
         run: pip install build
 
       - name: Build package
         run: python -m build
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-  publish:
-    needs: build
-    runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synth-panel"
-version = "0.1.0"
+version = "0.4.0"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Adds `.github/labels.yml` with semver labels (major/minor/patch/skip)
- Creates `.github/workflows/auto-tag.yml` — parses semver label from merged PRs, computes next version, creates annotated tag
- Creates `.github/workflows/publish.yml` — triggered by auto-tag or tag push, builds and publishes to PyPI
- Bumps `pyproject.toml` to 0.4.0
- Replaces old publish workflow that triggered on every push to main

## Test plan
- [x] 378 passed, 1 skipped
- [x] Rebase on main: clean

MR bead: sp-wisp-5wxe | Worker: furiosa | Issue: sp-aet