### PR TITLE
fix(sp-2hg): fail loud when all provider requests error

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -225,8 +225,27 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         })
         panelist_usage = panelist_usage + pr.usage
 
+    # ── Failure analysis (sp-2hg) ──────────────────────────────────────
+    # Count panelist-question pairs and determine how many errored. A pair
+    # is considered errored if its response dict is flagged ``error: True``
+    # OR if the panelist wrapper itself failed (no responses recorded).
+    failure_stats = _analyze_failures(panelist_results, questions)
+    strict = getattr(args, "strict", False)
+    threshold = getattr(args, "failure_threshold", 0.5)
+    try:
+        threshold = float(threshold)
+    except (TypeError, ValueError):
+        threshold = 0.5
+    run_invalid = (
+        failure_stats["total_pairs"] > 0
+        and failure_stats["failure_rate"] > threshold
+    )
+    strict_violation = strict and failure_stats["errored_pairs"] > 0
+
     # Synthesis step (unless --no-synthesis)
     skip_synthesis = getattr(args, "no_synthesis", False)
+    if run_invalid or strict_violation:
+        skip_synthesis = True  # don't synthesize garbage
     synthesis_result = None
 
     if not skip_synthesis:
@@ -257,7 +276,13 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     synthesis_dict = synthesis_result.to_dict() if synthesis_result else None
 
     # Output results
+    banner = _build_invalid_banner(
+        failure_stats, threshold, strict=strict, strict_violation=strict_violation
+    )
+
     if fmt is OutputFormat.TEXT:
+        if banner:
+            print(banner, file=sys.stderr)
         path_line = _format_path(_degenerate_path(instrument))
         if path_line:
             print(f"path: {path_line}")
@@ -309,6 +334,16 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                                  model=synthesis_result.model, is_estimated=synth_est))
         print(format_summary("Total", total_usage, total_cost_est,
                              model=model, is_estimated=is_estimated))
+        if total_cost_est.total_cost == 0 and failure_stats["errored_pairs"] > 0:
+            print(
+                "  \u26a0\ufe0f  no-cost = no-data (every request errored; "
+                "cost line reflects that no tokens were billed)",
+                file=sys.stderr,
+            )
+        if banner:
+            # Repeat the banner at the bottom so a scrolled terminal still
+            # surfaces it — this is the critical fix for sp-2hg.
+            print(banner, file=sys.stderr)
     else:
         legacy = getattr(args, "legacy_output", False)
         if legacy:
@@ -339,9 +374,145 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 persona_count=len(personas),
                 question_count=len(questions),
             )
-        emit(fmt, message="Panel complete", extra=extra)
+        # Surface failure stats + run validity in structured output so
+        # downstream consumers (MCP, CI) can gate on it without parsing text.
+        extra["failure_stats"] = failure_stats
+        extra["run_invalid"] = bool(run_invalid or strict_violation)
+        if run_invalid or strict_violation:
+            extra["message"] = (
+                banner.replace("\n", " ").strip() if banner else "PANEL RUN INVALID"
+            )
+        emit(fmt, message=extra.get("message", "Panel complete"), extra=extra)
 
+    # sp-2hg: exit non-zero when the run is invalid so automation (CI,
+    # refinery, wrapper scripts) can detect silent-failure scenarios.
+    if strict_violation:
+        return 3
+    if run_invalid:
+        return 2
     return 0
+
+
+def _analyze_failures(
+    panelist_results: list[Any],
+    questions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Count errored panelist-question pairs across a run.
+
+    A pair errors if:
+      - the panelist-level wrapper threw (``pr.error`` set), in which
+        case *every* authored question is counted as an error, even
+        those the panelist never reached, OR
+      - an individual response dict was flagged ``error: True`` (the
+        orchestrator sets this when a per-question call raises).
+
+    Returns a dict with ``total_pairs``, ``errored_pairs``,
+    ``failure_rate`` (0-1), ``failed_panelists`` (panelist-level
+    failures) and ``errored_personas`` (names of affected personas).
+    """
+    total_questions = len(questions) if questions else 0
+    total_pairs = 0
+    errored_pairs = 0
+    failed_panelists = 0
+    errored_personas: set[str] = set()
+
+    for pr in panelist_results:
+        if getattr(pr, "error", None):
+            # Whole panelist exploded — every authored question counts as
+            # an error for the purposes of the failure-rate calculation.
+            failed_panelists += 1
+            errored_pairs += total_questions
+            total_pairs += total_questions
+            errored_personas.add(getattr(pr, "persona_name", "unknown"))
+            continue
+
+        pair_count = 0
+        err_count = 0
+        for resp in getattr(pr, "responses", []) or []:
+            if isinstance(resp, dict) and resp.get("follow_up"):
+                # Follow-ups are not counted as primary QA pairs — they
+                # are second-order and would double-count toward the rate.
+                continue
+            pair_count += 1
+            if isinstance(resp, dict) and resp.get("error"):
+                err_count += 1
+        # If the panelist never produced any primary responses (e.g. a
+        # structured-output path that bailed before recording), treat the
+        # shortfall as errored against the authored question count.
+        if total_questions and pair_count < total_questions:
+            shortfall = total_questions - pair_count
+            err_count += shortfall
+            pair_count += shortfall
+        total_pairs += pair_count
+        errored_pairs += err_count
+        if err_count > 0:
+            errored_personas.add(getattr(pr, "persona_name", "unknown"))
+
+    failure_rate = (errored_pairs / total_pairs) if total_pairs > 0 else 0.0
+    return {
+        "total_pairs": total_pairs,
+        "errored_pairs": errored_pairs,
+        "failure_rate": failure_rate,
+        "failed_panelists": failed_panelists,
+        "errored_personas": sorted(errored_personas),
+    }
+
+
+def _build_invalid_banner(
+    stats: dict[str, Any],
+    threshold: float,
+    *,
+    strict: bool,
+    strict_violation: bool,
+) -> str:
+    """Render the fatal banner printed to stderr on an invalid run.
+
+    Returns an empty string when the run is valid. The banner is
+    intentionally loud — the entire point of sp-2hg is that a user
+    skimming output cannot miss that the panel was not executed
+    successfully.
+    """
+    total = stats["total_pairs"]
+    errored = stats["errored_pairs"]
+    if total == 0:
+        return ""
+    rate = stats["failure_rate"]
+    over_threshold = rate > threshold
+    if not (over_threshold or strict_violation):
+        return ""
+
+    bar = "!" * 70
+    lines = [bar]
+    if strict_violation and not over_threshold:
+        lines.append(
+            f"PANEL RUN INVALID (--strict): {errored}/{total} panelist-question"
+            f" pairs errored."
+        )
+    else:
+        lines.append(
+            f"PANEL RUN INVALID: {errored}/{total} panelist-question pairs"
+            f" errored ({rate:.0%} > threshold {threshold:.0%})."
+        )
+    lines.append("No synthesis was performed — the run produced no usable data.")
+    if stats.get("failed_panelists"):
+        lines.append(
+            f"  {stats['failed_panelists']} panelist(s) failed wholesale"
+            f" (no responses recorded)."
+        )
+    if stats.get("errored_personas"):
+        shown = ", ".join(stats["errored_personas"][:4])
+        extra = len(stats["errored_personas"]) - 4
+        if extra > 0:
+            shown += f", +{extra} more"
+        lines.append(f"  Affected personas: {shown}")
+    lines.append(
+        "Check provider status (e.g. rate-limit / 503), run with a different"
+    )
+    lines.append(
+        "--model, or re-run once the upstream provider is healthy."
+    )
+    lines.append(bar)
+    return "\n".join(lines)
 
 
 def _build_rounds_shape(

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -117,6 +117,27 @@ def build_parser() -> argparse.ArgumentParser:
             "stderr; will be removed in 0.6.0."
         ),
     )
+    panel_run_parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help=(
+            "Treat any panelist-question error as fatal. When any error "
+            "occurs, synthesis is skipped and the run exits non-zero. "
+            "Use this to avoid spending retry budget on a broken run."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--failure-threshold",
+        type=float,
+        default=0.5,
+        metavar="RATIO",
+        help=(
+            "Fraction of panelist-question pairs that may error before the "
+            "run is declared invalid (default: 0.5). When exceeded, "
+            "synthesis is auto-disabled and the run exits non-zero."
+        ),
+    )
 
     # pack
     pack_parser = subparsers.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -535,6 +535,216 @@ class TestPanelRun:
         ])
         assert code == 1
 
+    # --- sp-2hg: silent-failure-on-universal-provider-errors ------------
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_all_errored_returns_nonzero_and_skips_synthesis(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """sp-2hg: when every question errors the run must exit non-zero,
+        surface a fatal banner, and NOT call synthesize_panel."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[
+                        {"question": "Q1", "response": "[error: boom]", "error": True},
+                        {"question": "Q2", "response": "[error: boom]", "error": True},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Bob",
+                    responses=[
+                        {"question": "Q1", "response": "[error: boom]", "error": True},
+                        {"question": "Q2", "response": "[error: boom]", "error": True},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+            ],
+            registry,
+            {},
+        )
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: Q1\n"
+            "    - text: Q2\n"
+        )
+
+        code = main([
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+        ])
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "PANEL RUN INVALID" in err
+        assert "4/4" in err
+        # Synthesis MUST not run on a fully-errored panel
+        mock_synth.assert_not_called()
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_strict_flag_bails_on_any_error(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """sp-2hg: --strict turns any error into a fatal run (exit 3)."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[
+                        {"question": "Q1", "response": "good answer"},
+                        {"question": "Q2", "response": "good answer"},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Bob",
+                    responses=[
+                        {"question": "Q1", "response": "[error: boom]", "error": True},
+                        {"question": "Q2", "response": "good answer"},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+            ],
+            registry,
+            {},
+        )
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: Q1\n"
+            "    - text: Q2\n"
+        )
+
+        code = main([
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+            "--strict",
+        ])
+        assert code == 3
+        err = capsys.readouterr().err
+        assert "--strict" in err
+        mock_synth.assert_not_called()
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_partial_errors_below_threshold_still_synthesizes(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """sp-2hg: a single-error panel (25% failure) should still synthesize
+        when --strict is NOT set and the failure rate is below the default
+        threshold (0.5). Exit code is 0."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[
+                        {"question": "Q1", "response": "good"},
+                        {"question": "Q2", "response": "good"},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Bob",
+                    responses=[
+                        {"question": "Q1", "response": "[error: x]", "error": True},
+                        {"question": "Q2", "response": "good"},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+            ],
+            registry,
+            {},
+        )
+        mock_synth.return_value = _mock_synthesis_result()
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: Q1\n"
+            "    - text: Q2\n"
+        )
+
+        code = main([
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+        ])
+        assert code == 0
+        mock_synth.assert_called_once()
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_json_output_includes_failure_stats(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """sp-2hg: structured output must carry failure_stats + run_invalid
+        so MCP/CI consumers can gate without parsing banners."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[
+                        {"question": "Q1", "response": "[error: x]", "error": True},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+            ],
+            registry,
+            {},
+        )
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q1\n")
+
+        code = main([
+            "--output-format", "json",
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+        ])
+        assert code == 2
+        data = json.loads(capsys.readouterr().out)
+        assert data["run_invalid"] is True
+        assert data["failure_stats"]["errored_pairs"] == 1
+        assert data["failure_stats"]["total_pairs"] == 1
+        assert data["failure_stats"]["failure_rate"] == 1.0
+        mock_synth.assert_not_called()
+
 
 # --- Pack CLI tests ---
 


### PR DESCRIPTION
## Summary

Panel runs were silently "succeeding" with `$0.0000` cost when every provider request errored (e.g. gemini-2.5-flash 503s). Operators could act on non-data.

This MR adds loud failure signaling and strict-mode gating so a dead run is impossible to miss.

## Changes

- `cli/commands.py`: failure analysis over panelist_results — counts errored panelist-question pairs (individual error responses + wholesale panelist-level exceptions).
- Loud `PANEL RUN INVALID` banner (stderr, top + bottom) when failure_rate exceeds `--failure-threshold` (default 0.5).
- Auto-disables synthesis when the run is invalid.
- New `--strict` flag: any single errored pair is fatal.
- Exit codes: `2` on threshold-exceeded, `3` on strict violation, `0` otherwise.
- `failure_stats` + `run_invalid` surfaced in `--output-format json` so MCP/CI consumers can gate without parsing text.
- `no-cost = no-data` annotation when every request errored.
- 210 lines of new tests in `tests/test_cli.py`.

Closes sp-2hg (P1, filed by mayor on 2026-04-09 during Traitprint research prep).

## Test plan

- [x] Full test suite passes on rebase onto main (443 passed, 7 pre-existing failures on main deselected)
- [x] Clean fast-forward against main (no conflicts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)