### PR TITLE
fix(sp-f4t): default --model respects available credentials + announces pick

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -25,14 +25,81 @@ from synth_panel.runtime import AgentRuntime
 from synth_panel.synthesis import synthesize_panel
 
 
+# Preference chain for --model default (sp-f4t). Each entry is
+# (env var that signals provider availability, model alias or name).
+# Walked in order: the first provider with credentials wins. The alias
+# side prefers the provider's workhorse model so the user gets a
+# sensible default without guessing which canonical ID to type.
+_DEFAULT_MODEL_PREFERENCE: list[tuple[str, str]] = [
+    ("ANTHROPIC_API_KEY", "sonnet"),
+    ("OPENAI_API_KEY", "gpt-4o-mini"),
+    ("GEMINI_API_KEY", "gemini-2.5-flash"),
+    ("GOOGLE_API_KEY", "gemini-2.5-flash"),
+    ("XAI_API_KEY", "grok-3"),
+]
+
+
+def _resolve_default_model() -> tuple[str, str | None]:
+    """Pick a default model alias based on which API keys are present.
+
+    Returns ``(model_alias, source_env_var)``. If no provider credentials
+    are available the fallback is still ``"sonnet"`` (the previous
+    hard-coded default) so the LLM client's own credential check can
+    emit its canonical error message.
+    """
+    import os
+    for env_var, alias in _DEFAULT_MODEL_PREFERENCE:
+        if os.environ.get(env_var, "").strip():
+            return alias, env_var
+    return "sonnet", None
+
+
 def _resolve_model(args: argparse.Namespace) -> str:
-    """Return the model alias from CLI args, defaulting to 'sonnet'."""
-    return args.model or "sonnet"
+    """Return the model alias from CLI args.
+
+    When ``--model`` is not supplied, walk the preference chain in
+    :data:`_DEFAULT_MODEL_PREFERENCE` and pick the first provider with
+    credentials present in the environment. Falls back to ``"sonnet"``
+    if nothing is set so the LLM client's missing-credentials error is
+    still the one the user sees.
+    """
+    if args.model:
+        return args.model
+    alias, _source = _resolve_default_model()
+    return alias
+
+
+def _announce_default_model(args: argparse.Namespace) -> None:
+    """Print the auto-selected default model to stderr.
+
+    sp-f4t: the CLI help claims "Default: best available" but the
+    selection was previously silent — an operator running a panel
+    against the auto-picked model could not tell *which* provider was
+    being used. Surface the selection loudly so the user can ^C and
+    re-run with ``--model`` if the pick is wrong.
+    """
+    if getattr(args, "model", None):
+        return
+    alias, source = _resolve_default_model()
+    if source:
+        print(
+            f"[synth-panel] --model not specified; using '{alias}' "
+            f"(detected {source}). Override with --model <name>.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"[synth-panel] --model not specified and no provider API "
+            f"keys detected; falling back to '{alias}'. Set one of: "
+            f"{', '.join(env for env, _ in _DEFAULT_MODEL_PREFERENCE)}.",
+            file=sys.stderr,
+        )
 
 
 def handle_prompt(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run a single non-interactive prompt and exit."""
     prompt_text = " ".join(args.text)
+    _announce_default_model(args)
     model = _resolve_model(args)
 
     client = LLMClient()
@@ -163,6 +230,7 @@ def _load_schema(value: str) -> dict[str, Any]:
 
 def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run a panel: load personas + instrument, run panelists in parallel."""
+    _announce_default_model(args)
     model = _resolve_model(args)
 
     try:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -19,7 +19,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model",
         default=None,
-        help="LLM model to use (e.g. sonnet, opus, grok). Default: best available.",
+        help=(
+            "LLM model to use (e.g. sonnet, opus, grok, gemini-2.5-flash). "
+            "Default: first provider with credentials in the environment "
+            "(ANTHROPIC_API_KEY > OPENAI_API_KEY > GEMINI_API_KEY > "
+            "XAI_API_KEY). The chosen model is printed to stderr before "
+            "each run so you can cancel and override."
+        ),
     )
     parser.add_argument(
         "--permission-mode",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -746,6 +746,127 @@ class TestPanelRun:
         mock_synth.assert_not_called()
 
 
+# --- sp-f4t: default model resolution -----------------------------------
+
+
+class TestDefaultModelResolution:
+    """sp-f4t: ``--model`` default must respect available credentials and
+    surface the chosen model so the user can cancel/override."""
+
+    def test_resolve_default_model_prefers_anthropic(self, monkeypatch):
+        from synth_panel.cli.commands import _resolve_default_model
+        for env in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "XAI_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        alias, source = _resolve_default_model()
+        assert alias == "sonnet"
+        assert source == "ANTHROPIC_API_KEY"
+
+    def test_resolve_default_model_falls_through_to_gemini(self, monkeypatch):
+        from synth_panel.cli.commands import _resolve_default_model
+        for env in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "XAI_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "gemkey")
+        alias, source = _resolve_default_model()
+        assert alias == "gemini-2.5-flash"
+        assert source == "GEMINI_API_KEY"
+
+    def test_resolve_default_model_falls_back_to_sonnet_when_no_creds(self, monkeypatch):
+        from synth_panel.cli.commands import _resolve_default_model
+        for env in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "XAI_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+        alias, source = _resolve_default_model()
+        assert alias == "sonnet"
+        assert source is None
+
+    def test_resolve_default_model_respects_preference_order(self, monkeypatch):
+        """Anthropic beats Gemini even if both keys are set."""
+        from synth_panel.cli.commands import _resolve_default_model
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("GEMINI_API_KEY", "gemkey")
+        alias, source = _resolve_default_model()
+        assert alias == "sonnet"
+        assert source == "ANTHROPIC_API_KEY"
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_announces_default_model_on_stderr(
+        self, mock_client_cls, mock_run, mock_synth, monkeypatch, capsys, tmp_path
+    ):
+        """When --model is omitted, the chosen default is printed to stderr
+        so an operator can cancel and re-run with an explicit override."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        for env in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "XAI_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setenv("GEMINI_API_KEY", "gemkey")
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [PanelistResult(persona_name="A", responses=[
+                {"question": "Q", "response": "ok"}], usage=ZERO_USAGE)],
+            registry,
+            {},
+        )
+        mock_synth.return_value = _mock_synthesis_result()
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: A\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q\n")
+
+        code = main([
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+        ])
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "gemini-2.5-flash" in err
+        assert "GEMINI_API_KEY" in err
+        assert "Override with --model" in err
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_explicit_model_suppresses_announcement(
+        self, mock_client_cls, mock_run, mock_synth, monkeypatch, capsys, tmp_path
+    ):
+        """When --model is explicit, no auto-select message is printed."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        monkeypatch.setenv("GEMINI_API_KEY", "gemkey")
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [PanelistResult(persona_name="A", responses=[
+                {"question": "Q", "response": "ok"}], usage=ZERO_USAGE)],
+            registry,
+            {},
+        )
+        mock_synth.return_value = _mock_synthesis_result()
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: A\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q\n")
+
+        code = main([
+            "--model", "gemini-2.5-flash-lite",
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+        ])
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "--model not specified" not in err
+
+
 # --- Pack CLI tests ---
 
 


### PR DESCRIPTION
## Summary

`--model` default was static, picking `gemini-2.5-flash` via alias resolution regardless of whether that key was present or the model was reachable. On 2026-04-09 (Traitprint prep) the default blew up silently on a 503'd Gemini.

This MR makes "best available" actually inspect env credentials, pick a provider in a stable preference order, and announce the chosen model before the run starts so operators can cancel/override.

## Changes

- `cli/commands.py`: credential-aware default model resolution (checks `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` / `GOOGLE_API_KEY`, `XAI_API_KEY` in preference order).
- `cli/parser.py`: updated help text so the CLI no longer lies about "best available".
- 121 lines of new tests in `tests/test_cli.py` covering the selection matrix and no-credential failure mode.

Companion to sp-2hg (PR #37, just merged). Closes sp-f4t.

## Test plan

- [x] Full suite passes on rebase onto main (449 passed, 7 pre-existing failures deselected)
- [x] Clean rebase (force-pushed after rebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)