### PR TITLE
feat(sp-1hb): --var KEY=VALUE and --vars-file for instrument templates

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -210,6 +210,75 @@ def _load_instrument(path_or_name: str) -> Instrument:
     return parse_instrument(raw)
 
 
+def _collect_template_vars(args: argparse.Namespace) -> dict[str, str]:
+    """Merge ``--vars-file`` and repeated ``--var KEY=VALUE`` flags into a
+    single substitution context.
+
+    CLI ``--var`` entries override matching keys from ``--vars-file``
+    so ad-hoc overrides win on conflict. Both sources stringify their
+    values because the underlying template engine operates on strings.
+    Raises :class:`ValueError` on malformed input so the caller can
+    surface a friendly message.
+    """
+    merged: dict[str, str] = {}
+
+    vars_file = getattr(args, "vars_file", None)
+    if vars_file:
+        try:
+            data = _load_yaml(vars_file)
+        except FileNotFoundError as exc:
+            raise ValueError(str(exc)) from exc
+        if data is None:
+            data = {}
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"--vars-file must be a YAML mapping, got {type(data).__name__}"
+            )
+        for k, v in data.items():
+            merged[str(k)] = _stringify_var(v)
+
+    for entry in getattr(args, "vars", None) or []:
+        if "=" not in entry:
+            raise ValueError(
+                f"--var expects KEY=VALUE, got: {entry!r}"
+            )
+        key, value = entry.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"--var has empty key: {entry!r}")
+        merged[key] = value
+    return merged
+
+
+def _stringify_var(value: Any) -> str:
+    """Convert a YAML-loaded var value to a string suitable for substitution.
+
+    Lists and tuples are joined with ``", "`` so ``candidates: [A, B, C]``
+    in a vars file renders the way a human would write it inline. Other
+    scalars go through ``str()``.
+    """
+    if isinstance(value, (list, tuple)):
+        return ", ".join(str(item) for item in value)
+    return str(value)
+
+
+def _apply_vars_to_instrument(
+    instrument: Instrument, template_vars: dict[str, str]
+) -> None:
+    """Substitute ``template_vars`` into every round's question text.
+
+    Mutates the instrument in place: each ``Round.questions`` list is
+    replaced with its rendered form. The rendering is routed through
+    :func:`synth_panel.templates.render_questions` so we inherit safe-
+    failure behavior (unknown keys render as literal ``{placeholder}``
+    rather than raising).
+    """
+    from synth_panel.templates import render_questions
+
+    for rnd in instrument.rounds:
+        rnd.questions = render_questions(rnd.questions, template_vars)
+
+
 def _load_schema(value: str) -> dict[str, Any]:
     """Load a JSON Schema from a file path or inline JSON string."""
     p = Path(value)
@@ -249,6 +318,19 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     # are non-fatal but the user should see them before any LLM call fires.
     for w in instrument.warnings:
         print(f"warning: {w}", file=sys.stderr)
+
+    # ── sp-1hb: variable substitution ──────────────────────────────────
+    # Bundled instrument packs ship with {candidates}, {theme_0}, and
+    # similar placeholders so they can be reused as research templates.
+    # Without --var the user had to hand-edit YAML; this resolves the
+    # variables at load time so the panelists see substituted text.
+    try:
+        template_vars = _collect_template_vars(args)
+    except ValueError as exc:
+        print(f"Error parsing --var / --vars-file: {exc}", file=sys.stderr)
+        return 1
+    if template_vars:
+        _apply_vars_to_instrument(instrument, template_vars)
 
     questions = instrument.questions
     if not questions:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -144,6 +144,29 @@ def build_parser() -> argparse.ArgumentParser:
             "synthesis is auto-disabled and the run exits non-zero."
         ),
     )
+    panel_run_parser.add_argument(
+        "--var",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        dest="vars",
+        help=(
+            "Substitute template placeholders in the instrument's "
+            "question text. Repeatable. Example: "
+            "--var 'candidates=Name A, Name B' --var theme=pricing. "
+            "The value replaces any literal {KEY} token in a question."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--vars-file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "YAML file of key: value pairs to substitute into instrument "
+            "templates. Values merge with --var (CLI flag wins on "
+            "conflicts)."
+        ),
+    )
 
     # pack
     pack_parser = subparsers.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -867,6 +867,163 @@ class TestDefaultModelResolution:
         assert "--model not specified" not in err
 
 
+# --- sp-1hb: CLI variable passing ---------------------------------------
+
+
+class TestVarSubstitution:
+    """sp-1hb: ``--var KEY=VALUE`` and ``--vars-file`` substitute template
+    placeholders in instrument question text."""
+
+    def test_collect_template_vars_parses_cli_flags(self):
+        from synth_panel.cli.commands import _collect_template_vars
+        import argparse as _ap
+        ns = _ap.Namespace(
+            vars=["candidates=Alpha, Beta", "theme=pricing"], vars_file=None
+        )
+        result = _collect_template_vars(ns)
+        assert result == {"candidates": "Alpha, Beta", "theme": "pricing"}
+
+    def test_collect_template_vars_allows_equals_in_value(self):
+        from synth_panel.cli.commands import _collect_template_vars
+        import argparse as _ap
+        ns = _ap.Namespace(vars=["equation=a=b+c"], vars_file=None)
+        assert _collect_template_vars(ns) == {"equation": "a=b+c"}
+
+    def test_collect_template_vars_rejects_malformed_flag(self):
+        from synth_panel.cli.commands import _collect_template_vars
+        import argparse as _ap
+        ns = _ap.Namespace(vars=["novalue"], vars_file=None)
+        with pytest.raises(ValueError, match="KEY=VALUE"):
+            _collect_template_vars(ns)
+
+    def test_collect_template_vars_rejects_empty_key(self):
+        from synth_panel.cli.commands import _collect_template_vars
+        import argparse as _ap
+        ns = _ap.Namespace(vars=["=hello"], vars_file=None)
+        with pytest.raises(ValueError, match="empty key"):
+            _collect_template_vars(ns)
+
+    def test_collect_template_vars_merges_file_and_cli_flags(self, tmp_path):
+        from synth_panel.cli.commands import _collect_template_vars
+        import argparse as _ap
+        f = tmp_path / "vars.yaml"
+        f.write_text(
+            "candidates:\n"
+            "  - Alpha\n"
+            "  - Beta\n"
+            "theme: memorability\n"
+        )
+        ns = _ap.Namespace(vars=["theme=pricing"], vars_file=str(f))
+        result = _collect_template_vars(ns)
+        # List flattened to comma-joined string
+        assert result["candidates"] == "Alpha, Beta"
+        # CLI overrides file
+        assert result["theme"] == "pricing"
+
+    def test_collect_template_vars_rejects_non_mapping_file(self, tmp_path):
+        from synth_panel.cli.commands import _collect_template_vars
+        import argparse as _ap
+        f = tmp_path / "bad.yaml"
+        f.write_text("- just\n- a\n- list\n")
+        ns = _ap.Namespace(vars=None, vars_file=str(f))
+        with pytest.raises(ValueError, match="YAML mapping"):
+            _collect_template_vars(ns)
+
+    def test_apply_vars_to_instrument_mutates_round_questions(self):
+        from synth_panel.cli.commands import _apply_vars_to_instrument
+        from synth_panel.instrument import parse_instrument
+        inst = parse_instrument({
+            "version": 3,
+            "rounds": [
+                {
+                    "name": "intro",
+                    "questions": [
+                        {"text": "Evaluate: {candidates}. Reaction?"},
+                    ],
+                },
+                {
+                    "name": "followup",
+                    "depends_on": "intro",
+                    "questions": [
+                        {"text": "Which of {candidates} do you remember?"},
+                    ],
+                },
+            ],
+        })
+        _apply_vars_to_instrument(inst, {"candidates": "Alpha, Beta, Gamma"})
+        assert inst.rounds[0].questions[0]["text"] == (
+            "Evaluate: Alpha, Beta, Gamma. Reaction?"
+        )
+        assert inst.rounds[1].questions[0]["text"] == (
+            "Which of Alpha, Beta, Gamma do you remember?"
+        )
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_cli_var_substitutes_bundled_placeholder(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """End-to-end: a question containing ``{candidates}`` is passed to
+        ``run_panel_parallel`` already rendered when ``--var candidates=...``
+        is supplied."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [PanelistResult(persona_name="A", responses=[
+                {"question": "rendered", "response": "ok"}],
+                usage=ZERO_USAGE)],
+            registry,
+            {},
+        )
+        mock_synth.return_value = _mock_synthesis_result()
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: A\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: 'Evaluate: {candidates}'\n"
+        )
+
+        code = main([
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+            "--var", "candidates=Alpha, Beta, Gamma",
+        ])
+        assert code == 0
+        # Verify the orchestrator saw the rendered question text
+        _, kwargs = mock_run.call_args
+        questions_passed = kwargs["questions"]
+        assert len(questions_passed) == 1
+        assert questions_passed[0]["text"] == "Evaluate: Alpha, Beta, Gamma"
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_malformed_var_returns_error(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: A\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q\n")
+
+        code = main([
+            "panel", "run",
+            "--personas", str(personas_file),
+            "--instrument", str(survey_file),
+            "--var", "badentry",
+        ])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "KEY=VALUE" in err
+        mock_run.assert_not_called()
+
+
 # --- Pack CLI tests ---
 
 


### PR DESCRIPTION
## Summary

Bundled instrument templates (`name-test`, `feature-prioritization`, `pricing-discovery`, `landing-page-comprehension`, `churn-diagnosis`) ship with `{placeholder}` tokens, but there was no CLI way to bind them. Users had to hand-edit bundled YAML or copy-modify-run. This MR makes the bundled packs actually parameterizable.

## Changes

- `cli/parser.py`: new `--var KEY=VALUE` (repeatable) and `--vars-file PATH` flags on `panel run`.
- `cli/commands.py`: merge `--vars-file` YAML with `--var` flags (CLI wins on conflict), substitute into instrument question text before execution.
- 157 lines of new tests in `tests/test_cli.py`.

Closes sp-1hb. Third in mayor's sequenced 2026-04-09 chain after sp-2hg (#37) and sp-f4t (#38).

## Conflict resolution

Branch added `--var` / `--vars-file` to the same `panel_run_parser` block as sp-2hg's `--strict` / `--failure-threshold`. Rebase conflict was a clean additive collision — both sets of arguments kept, ordered: strict → failure-threshold → var → vars-file.

## Test plan

- [x] Rebased onto post-sp-f4t main, conflict resolved additively
- [x] Parser builds clean (`python -c "from synth_panel.cli.parser import build_parser; build_parser()"`)
- [x] Full suite: 458 passed, 7 pre-existing failures deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)