### PR TITLE
fix(sp-oem): add 'pack show <id>' as an API-parity alias

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -466,6 +466,17 @@ def handle_pack_export(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return 0
 
 
+def handle_pack_show(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Print a saved persona pack's YAML to stdout.
+
+    sp-oem: API parity alias for ``instruments show``. Internally
+    delegates to :func:`handle_pack_export` with ``output=None`` so
+    behaviour stays identical to ``pack export <id>`` (no file arg).
+    """
+    args.output = None
+    return handle_pack_export(args, fmt)
+
+
 def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Start the MCP server on stdio transport."""
     from synth_panel.mcp.server import serve

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -121,7 +121,7 @@ def build_parser() -> argparse.ArgumentParser:
     # pack
     pack_parser = subparsers.add_parser(
         "pack",
-        help="Persona pack management: list, import, export.",
+        help="Persona pack management: list, import, export, show.",
     )
     pack_subparsers = pack_parser.add_subparsers(dest="pack_command")
 
@@ -169,6 +169,17 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="FILE",
         help="Write to file instead of stdout.",
+    )
+
+    # pack show (sp-oem: API parity with `instruments show`)
+    pack_show_parser = pack_subparsers.add_parser(
+        "show",
+        help="Print a saved persona pack's YAML to stdout.",
+    )
+    pack_show_parser.add_argument(
+        "pack_id",
+        metavar="PACK_ID",
+        help="ID of the persona pack to show.",
     )
 
     # instruments

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -19,6 +19,7 @@ from synth_panel.cli.commands import (
     handle_pack_export,
     handle_pack_import,
     handle_pack_list,
+    handle_pack_show,
     handle_panel_run,
     handle_prompt,
 )
@@ -48,6 +49,8 @@ def main(argv: list[str] | None = None) -> int:
             return handle_pack_import(args, output_format)
         elif sub == "export":
             return handle_pack_export(args, output_format)
+        elif sub == "show":
+            return handle_pack_show(args, output_format)
         else:
             parser.parse_args(["pack", "--help"])
             return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -608,6 +608,34 @@ class TestPackCommands:
         code = main(["pack", "export", "nope"])
         assert code == 1
 
+    def test_pack_show_prints_yaml_to_stdout(self, capsys):
+        """sp-oem: `pack show <id>` is an alias for stdout export."""
+        from synth_panel.mcp.data import save_persona_pack
+        save_persona_pack("Show Test", [{"name": "Zoe"}], pack_id="shtest")
+        code = main(["pack", "show", "shtest"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Zoe" in out
+        assert "Show Test" in out
+
+    def test_pack_show_matches_pack_export_stdout(self, capsys):
+        """sp-oem: `pack show <id>` must produce the same output as
+        `pack export <id>` with no output file - the whole point of the
+        alias is that they are interchangeable for inspection use."""
+        from synth_panel.mcp.data import save_persona_pack
+        save_persona_pack(
+            "Parity Test", [{"name": "Iris", "age": 40}], pack_id="parity"
+        )
+        main(["pack", "export", "parity"])
+        export_out = capsys.readouterr().out
+        main(["pack", "show", "parity"])
+        show_out = capsys.readouterr().out
+        assert export_out == show_out
+
+    def test_pack_show_nonexistent(self, capsys):
+        code = main(["pack", "show", "nope"])
+        assert code == 1
+
     def test_pack_list_json(self, capsys):
         from synth_panel.mcp.data import save_persona_pack
         save_persona_pack("JSON Pack", [{"name": "X"}], pack_id="jp")


### PR DESCRIPTION
## Summary

`synth-panel instruments show <name>` worked but `synth-panel pack show <name>` errored. Fixes the CLI asymmetry by adding `pack show` as an alias for `pack export` to stdout.

## Changes

- `cli/parser.py`: register `pack show <id>` subcommand
- `cli/commands.py`: handler that prints the pack YAML to stdout
- `main.py`: wire it in
- 28 lines of new tests in `tests/test_cli.py`

Closes sp-oem (P3). **Fifth and final** in mayor's 2026-04-09 chain: sp-2hg ✓, sp-f4t ✓, sp-1hb ✓, sp-56u ✓, sp-oem ✓.

## Test plan

- [x] Clean rebase onto post-sp-56u main
- [x] Full suite: 461 passed, 7 pre-existing failures deselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)