### PR TITLE
fix(ci): remove invalid permissions from auto-tag publish job

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -127,5 +127,3 @@ jobs:
     uses: ./.github/workflows/publish.yml
     with:
       tag: ${{ needs.auto-tag.outputs.tag }}
-    permissions:
-      id-token: write


### PR DESCRIPTION
startup_failure on every PR merge. GitHub disallows permissions on reusable workflow call jobs. publish.yml already has the correct permissions internally.