### PR TITLE
feat(ci): add TestPyPI dev publish + RELEASING docs (sp-d7i.4)

### DIFF
--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -1,0 +1,72 @@
+name: Publish Dev to TestPyPI
+
+# Every merge to main publishes a dev build to test.pypi.org.
+# Version is auto-generated: {pyproject.toml version}.dev{run_number}
+#
+# ONE-TIME MANUAL SETUP (required before the first successful publish):
+#
+#   1. On https://test.pypi.org/manage/account/publishing/ add a trusted
+#      publisher with:
+#        project name = synth-panel
+#        owner        = DataViking-Tech
+#        repo         = synth-panel
+#        workflow     = publish-test.yml
+#        environment  = pypi-test   (must match the `environment:` key below)
+#   2. In GitHub repo Settings -> Environments, create an environment
+#      named `pypi-test`.
+#
+# The trusted publisher + environment are already configured by the founder.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish-dev:
+    runs-on: ubuntu-latest
+    environment: pypi-test
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate dev version
+        id: version
+        run: |
+          set -euo pipefail
+          BASE=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+          DEV_VERSION="${BASE}.dev${GITHUB_RUN_NUMBER}"
+          sed -i "s/^version = \".*\"/version = \"${DEV_VERSION}\"/" pyproject.toml
+          echo "version=$DEV_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Dev version: $DEV_VERSION"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Show built artifacts
+        run: ls -lh dist/
+
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Summarize
+        env:
+          DEV_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## Published synth-panel ${DEV_VERSION} (dev)"
+            echo ""
+            echo "- TestPyPI: https://test.pypi.org/project/synth-panel/${DEV_VERSION}/"
+            echo "- Install: \`pip install -i https://test.pypi.org/simple/ synth-panel==${DEV_VERSION}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,68 @@
+# Releasing synth-panel
+
+## Release flow (production PyPI)
+
+Releases follow semver and are fully automated via GitHub Actions:
+
+1. **Open a PR** against `main` with your changes.
+2. **Add a semver label** to the PR: `semver:patch`, `semver:minor`, or `semver:major`.
+   - Use `semver:skip` to merge without creating a release.
+3. **Merge the PR.** On merge, `auto-tag.yml` runs:
+   - Reads the semver label to determine the bump type.
+   - Computes the next version from the latest `v*.*.*` tag.
+   - Creates and pushes a new git tag (e.g. `v0.5.0`).
+   - Creates a GitHub Release with auto-generated notes.
+   - Triggers `publish.yml` which builds and publishes to [PyPI](https://pypi.org/project/synth-panel/).
+
+### Manual publish
+
+You can re-publish an existing tag via workflow dispatch:
+
+1. Go to **Actions → Publish to PyPI → Run workflow**.
+2. Enter the tag (e.g. `v0.4.0`). The tag must already exist in the repo.
+
+## Dev builds (TestPyPI)
+
+Every merge to `main` automatically publishes a dev build to [TestPyPI](https://test.pypi.org/project/synth-panel/):
+
+- Version format: `{base_version}.dev{run_number}` (e.g. `0.4.0.dev42`).
+- Workflow: `publish-test.yml`.
+- No labels or manual steps required — it runs on every push to `main`.
+
+### Install a dev build
+
+```bash
+# Latest dev build from TestPyPI
+pip install -i https://test.pypi.org/simple/ synth-panel
+
+# Specific dev version
+pip install -i https://test.pypi.org/simple/ synth-panel==0.4.0.dev42
+```
+
+> **Note:** TestPyPI may not have all dependencies. If installation fails due to
+> missing deps, install them from real PyPI first, then install synth-panel from
+> TestPyPI:
+>
+> ```bash
+> pip install httpx pyyaml
+> pip install -i https://test.pypi.org/simple/ --no-deps synth-panel==0.4.0.dev42
+> ```
+
+## Install a release
+
+```bash
+# Latest stable release from PyPI
+pip install synth-panel
+
+# Specific version
+pip install synth-panel==0.4.0
+```
+
+## GitHub environments
+
+| Environment | Purpose | Trusted publisher workflow |
+|-------------|---------|---------------------------|
+| `pypi` | Production PyPI releases | `publish.yml` |
+| `pypi-test` | Dev builds on TestPyPI | `publish-test.yml` |
+
+Both environments and their trusted publishers are configured in the GitHub repo settings.


### PR DESCRIPTION
## Summary

- Add `.github/workflows/publish-test.yml` for automatic dev version publishing to TestPyPI on merge to main
- Create `docs/RELEASING.md` documenting release and beta version workflows
- Minor fix to `.github/workflows/auto-tag.yml`

- **Issue**: sp-d7i.4
- **Polecat**: rictus
- **Tests**: 250 passed, 1 pre-existing failure (sp-4c6)

---
*Created by Gas Town Refinery*