### PR TITLE
docs: add CHANGELOG, CONTRIBUTING, and MCP guide (sp-d7i.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,62 @@
+# Changelog
+
+All notable changes to synth-panel are documented here.
+
+For auto-generated release notes, see [GitHub Releases](https://github.com/DataViking-Tech/synth-panel/releases).
+
+## [Unreleased]
+
+### Added
+- v3 branching instruments with `route_when` predicates and DAG validation
+- Router predicate engine: `contains`, `equals`, `matches` operators
+- Multi-round branching orchestrator loop
+- 5 bundled v3 instrument packs: `pricing-discovery`, `name-test`, `feature-prioritization`, `landing-page-comprehension`, `churn-diagnosis`
+- `instruments` CLI subcommand: `list`, `show`, `install`, `graph`
+- Instrument pack loader (single-file YAML with manifest fields)
+- MCP `list_instrument_packs`, `get_instrument_pack`, `save_instrument_pack` tools
+- Rounds-shaped panel output with `path`, `terminal_round`, and `warnings` fields
+- `extend_panel` MCP tool for ad-hoc follow-up rounds
+- Text-mode path line above panel run output
+- `--var KEY=VALUE` and `--vars-file` for instrument templates (#39)
+- `pack show <id>` as an API-parity alias (#41)
+- CI guard to block live API calls in non-acceptance tests
+- GitHub Release notes + changelog config in auto-tag workflow
+
+### Fixed
+- Fail loud when all provider requests error (#37)
+- Default `--model` now respects available credentials and announces pick (#38)
+- Publish workflow trigger corrected + manual PyPI setup documented (#40)
+- `contents: read` permission added to publish job (#42)
+
+## [0.4.0] - 2026-04-10
+
+First published release on [PyPI](https://pypi.org/project/synth-panel/).
+
+### Added
+- v2 multi-round linear instruments with session reuse across rounds
+- Instrument v2 parser with multi-round support
+- Template engine for dynamic question rendering
+- Session persistence — save/load per panelist
+- `response_sentiment` condition evaluator with LLM-based classification
+- Panel synthesis module (`synthesize_panel`) wired into CLI and MCP
+- Condition evaluation module for conditional follow-ups
+- Persona pack registry with 5 bundled starter packs
+- Structured output via tool-use forcing, wired through MCP and CLI
+- Semver auto-tag + PyPI publish workflow (trusted publishing)
+
+### Fixed
+- MCP import guard + mock alias test to avoid live API calls
+- Condition evaluation wired into orchestrator follow-up loop
+
+## [0.3.0]
+
+### Added
+- Structured output via tool-use forcing
+- Cost tracking with per-turn token accounting (4 buckets: input, output, cache_write, cache_read)
+- MCP server with stdio transport (12 tools, 4 resources, 3 prompt templates)
+- Persona-pack persistence (`save_persona_pack`, `get_persona_pack`, `list_persona_packs`)
+- Panel result persistence and retrieval
+
+[Unreleased]: https://github.com/DataViking-Tech/synth-panel/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/DataViking-Tech/synth-panel/releases/tag/v0.4.0
+[0.3.0]: https://github.com/DataViking-Tech/synth-panel/releases/tag/v0.3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,120 @@
+# Contributing to synth-panel
+
+## Development Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/DataViking-Tech/synth-panel.git
+cd synth-panel
+
+# Create a virtual environment (using uv or standard venv)
+uv venv .venv && source .venv/bin/activate
+# or: python3 -m venv .venv && source .venv/bin/activate
+
+# Install in editable mode with dev dependencies
+pip install -e ".[dev]"
+
+# For MCP server development, also install MCP deps
+pip install -e ".[dev,mcp]"
+```
+
+## Running Tests
+
+```bash
+# Run all unit tests
+pytest tests/
+
+# Run with verbose output
+pytest tests/ -v
+
+# Run a specific test file
+pytest tests/test_orchestrator.py
+
+# Run acceptance tests (requires a live API key)
+ANTHROPIC_API_KEY=sk-... pytest tests/test_acceptance.py -m acceptance
+```
+
+## Linting
+
+```bash
+# Check for lint issues
+ruff check src/ tests/
+
+# Auto-fix fixable issues
+ruff check --fix src/ tests/
+```
+
+## Type Checking
+
+```bash
+mypy src/synth_panel/
+```
+
+## Running the MCP Server Locally
+
+The MCP server uses stdio transport and is designed to be launched by an MCP-aware editor (Claude Code, Cursor, Windsurf, etc.):
+
+```bash
+synth-panel mcp-serve
+```
+
+For testing outside an editor, you can pipe JSON-RPC messages to stdin. See [docs/mcp.md](docs/mcp.md) for the full tool/resource/prompt reference.
+
+## Running Without Installing
+
+```bash
+PYTHONPATH=src python3 -m synth_panel prompt "Hello"
+```
+
+## Project Structure
+
+```
+src/synth_panel/
+├── llm/              # Provider-agnostic LLM client
+│   ├── client.py     # Unified send/stream interface
+│   ├── aliases.py    # Model alias resolution
+│   ├── providers/    # Anthropic, OpenAI, xAI, Gemini
+├── runtime.py        # Agent session loop
+├── orchestrator.py   # Parallel panelist execution
+├── structured/       # Schema-validated responses
+├── cost.py           # Token tracking and pricing
+├── persistence.py    # Session save/load/fork
+├── plugins/          # Manifest-based extension system
+├── instrument.py     # v1/v2/v3 instrument parser + DAG validator
+├── routing.py        # v3 router predicates
+├── mcp/              # MCP server (12 tools, stdio)
+├── packs/            # Bundled persona and instrument packs
+├── cli/              # CLI framework
+└── main.py           # Entry point
+```
+
+## Submitting Changes
+
+1. Fork the repository and create a feature branch from `main`.
+2. Make your changes. Add tests for new functionality.
+3. Run the test suite: `pytest tests/`
+4. Run lint: `ruff check src/ tests/`
+5. Open a pull request against `main`.
+
+### Commit Message Conventions
+
+Use conventional-style prefixes:
+
+- `feat:` — new feature
+- `fix:` — bug fix
+- `docs:` — documentation only
+- `test:` — adding or updating tests
+- `refactor:` — code change that neither fixes a bug nor adds a feature
+- `ci:` — CI/CD pipeline changes
+
+Example: `feat: add --timeout flag to panel run`
+
+## Release Process
+
+Releases are published to PyPI via GitHub Actions:
+
+1. A maintainer applies a `semver:patch`, `semver:minor`, or `semver:major` label to a merged PR.
+2. The `auto-tag.yml` workflow creates a git tag (e.g., `v0.4.1`).
+3. The `publish.yml` workflow builds and publishes to PyPI using trusted publishing.
+
+See the [Versions table in README.md](README.md#versions) for release history.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ Traditional focus groups cost $5,000-$15,000 and take weeks. Synthetic panels co
 ## Quick Start
 
 ```bash
-# Install from PyPI
+# Install from PyPI (v0.4.0+)
 pip install synth-panel
 
-# Or install the latest from source (works today even if PyPI is stale)
+# Or install from source for the latest unreleased changes
 pip install git+https://github.com/DataViking-Tech/synth-panel.git@main
 
 # Set your API key (Claude, OpenAI, Gemini, xAI, or any OpenAI-compatible provider)
@@ -351,8 +351,18 @@ Use synth-panel to pre-screen and iterate, then validate with real participants.
 | Version | Highlights |
 |---------|-----------|
 | 0.5.0 | v3 branching instruments, router predicates, 5 bundled instrument packs, `instruments` subcommand (list/show/install/graph), MCP `*_instrument_pack` tools, rounds-shaped panel output, `extend_panel` ad-hoc round tool |
-| 0.4.0 | v2 multi-round linear instruments, session reuse across rounds, persona pack registry |
+| 0.4.0 | `--var KEY=VALUE` and `--vars-file` for instrument templates, fail-loud on all-provider errors, default `--model` respects available credentials, `pack show <id>` alias, publish workflow fix |
 | 0.3.0 | Structured output via tool-use forcing, cost tracking, MCP server (stdio), persona-pack persistence |
+
+See [CHANGELOG.md](CHANGELOG.md) for detailed release notes.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, testing, and how to submit changes.
+
+## MCP Server Documentation
+
+For detailed MCP server documentation (all 12 tools, 4 resources, 3 prompt templates), see [docs/mcp.md](docs/mcp.md).
 
 ## License
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,150 @@
+# MCP Server Reference
+
+synth-panel ships an [MCP](https://modelcontextprotocol.io/) server so AI agents can run synthetic focus groups as tool calls. The server uses stdio transport and defaults to the `haiku` model for cheap, fast iterative use.
+
+## Starting the Server
+
+```bash
+synth-panel mcp-serve
+```
+
+The server communicates over stdin/stdout using JSON-RPC (the MCP protocol). It is designed to be launched by an MCP-aware editor or agent framework.
+
+## Editor Configuration
+
+### Claude Code / Cursor / Windsurf
+
+Add to your MCP config (e.g., `.claude/mcp.json`, `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synth-panel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Set the environment variable for whichever LLM provider you want to use. See the main [README](../README.md#llm-provider-support) for the full provider table.
+
+### Claude Code Plugin
+
+```
+/plugin install synth-panel
+```
+
+This adds the `/focus-group` skill to your Claude Code session.
+
+## Tools (12)
+
+### Research Tools
+
+| Tool | Description |
+|------|-------------|
+| `run_prompt` | Send a single prompt to an LLM. No personas required. The simplest tool — ask a quick research question. |
+| `run_panel` | Run a full synthetic focus group panel. Each persona answers all questions independently in parallel, followed by synthesis. Accepts inline `questions`, an inline `instrument` dict (v1/v2/v3), or an `instrument_pack` name. |
+| `run_quick_poll` | Quick single-question poll across personas. A simplified `run_panel` for one question with synthesis. |
+| `extend_panel` | Append a single ad-hoc round to a saved panel result. Reuses each panelist's saved session for conversational context. **Not** a re-entry into the v3 DAG — use for human-in-the-loop follow-ups. |
+
+### Persona Pack Management
+
+| Tool | Description |
+|------|-------------|
+| `list_persona_packs` | List all saved persona packs (bundled + user-saved). Returns ID, name, persona count. |
+| `get_persona_pack` | Get a specific persona pack by ID. Returns the full persona definitions. |
+| `save_persona_pack` | Save a persona pack for reuse. Validates persona data before saving. |
+
+### Instrument Pack Management
+
+| Tool | Description |
+|------|-------------|
+| `list_instrument_packs` | List installed instrument packs (bundled + user-saved). Returns manifest metadata. |
+| `get_instrument_pack` | Load an installed instrument pack by name. Returns the full YAML body. |
+| `save_instrument_pack` | Install an instrument pack. Validates the instrument via the parser before writing to disk. |
+
+### Result Management
+
+| Tool | Description |
+|------|-------------|
+| `list_panel_results` | List all saved panel results. Returns ID, date, model, and counts. |
+| `get_panel_result` | Get a specific panel result by ID. Returns the full result with all rounds and synthesis. |
+
+## Resources (4 URI Patterns)
+
+MCP resources allow agents to read data without invoking a tool.
+
+| URI Pattern | Description |
+|-------------|-------------|
+| `persona-pack://{pack_id}` | A specific persona pack |
+| `persona-pack://` | List all persona packs |
+| `panel-result://{result_id}` | A specific panel result |
+| `panel-result://` | List all panel results |
+
+## Prompt Templates (3)
+
+Prompt templates provide pre-built research workflows that agents can use as starting points.
+
+| Prompt | Parameters | Description |
+|--------|------------|-------------|
+| `focus_group` | `topic` (required), `num_personas` (default: 5), `follow_up` (default: true) | Generate a structured focus group discussion prompt for a given topic. |
+| `name_test` | `names` (required, comma-separated), `context` (optional) | Test product or feature name options with diverse perspectives. |
+| `concept_test` | `concept` (required), `target_audience` (optional) | Test a concept or idea with targeted personas. |
+
+## Response Shape
+
+All panel runs (`run_panel`, `run_quick_poll`, `extend_panel`) return a uniform response shape:
+
+```json
+{
+  "result_id": "result-20260410-...",
+  "model": "haiku",
+  "persona_count": 5,
+  "question_count": 3,
+  "rounds": [
+    {
+      "name": "discovery",
+      "results": [
+        {
+          "persona": "Sarah Chen",
+          "responses": ["..."],
+          "usage": { "input_tokens": 450, "output_tokens": 120 },
+          "cost": "$0.0012",
+          "error": null
+        }
+      ],
+      "synthesis": { "themes": [...], "summary": "..." }
+    }
+  ],
+  "path": [
+    { "round": "discovery", "branch": "themes contains price", "next": "probe_pricing" }
+  ],
+  "terminal_round": "probe_pricing",
+  "warnings": [],
+  "synthesis": { "themes": [...], "summary": "...", "recommendation": "..." },
+  "total_cost": "$0.0234",
+  "total_usage": { "input_tokens": 2250, "output_tokens": 600 },
+  "results": [...]
+}
+```
+
+- `rounds` — per-round results with panelist responses and per-round synthesis
+- `path` — the routing decisions that fired (v3 branching instruments)
+- `terminal_round` — the round whose synthesis fed final synthesis
+- `warnings` — parser or runtime warnings
+- `results` — back-compat flat array mirroring the terminal round's panelist results
+
+For v1/v2 instruments and raw `questions` input, `path` is empty or linear and `warnings` is typically empty — the shape is uniform across versions.
+
+## Data Storage
+
+Panel results, persona packs, and instrument packs are stored under `~/.synth-panel/` (configurable via `SYNTH_PANEL_DATA_DIR`):
+
+```
+~/.synth-panel/
+├── persona_packs/          # Saved persona packs (YAML)
+├── packs/instruments/      # Installed instrument packs (YAML)
+└── results/                # Panel results (JSON) + session data
+```


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` with release history
- Add `CONTRIBUTING.md` with development guidelines
- Add `docs/mcp.md` with MCP integration documentation
- Update `README.md` with additional links

- **Issue**: sp-d7i.5
- **Polecat**: dementus
- **Tests**: 250 passed, 1 pre-existing failure (sp-4c6)

---
*Created by Gas Town Refinery*