### PR TITLE
fix: install [mcp] extra in CI so MCP tests run (sp-k8k)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
 
       - name: Ruff check
         run: ruff check src/ tests/
@@ -38,7 +38,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
 
       - name: Mypy
         run: mypy src/synth_panel/
@@ -53,7 +53,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
 
       - name: pip-audit
         run: pip-audit
@@ -77,7 +77,7 @@ jobs:
           allow-prereleases: true
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
 
       - name: Run tests with coverage
         run: pytest tests/ -x --ignore=tests/test_acceptance.py
@@ -92,7 +92,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: pip install -e ".[dev]"
+        run: pip install -e ".[dev,mcp]"
 
       - name: Run tests with coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Define personas in YAML. Define your research instrument in YAML. Run against an
 ```bash
 pip install synth-panel
 synth-panel panel run --personas personas.yaml --instrument survey.yaml
+
+# For MCP server support (Claude Code, Cursor, Windsurf, etc.)
+pip install synth-panel[mcp]
 ```
 
 ## Why
@@ -23,6 +26,9 @@ Traditional focus groups cost $5,000-$15,000 and take weeks. Synthetic panels co
 ```bash
 # Install from PyPI (v0.4.0+)
 pip install synth-panel
+
+# For MCP server support (agent integration)
+pip install synth-panel[mcp]
 
 # Or install from source for the latest unreleased changes
 pip install git+https://github.com/DataViking-Tech/synth-panel.git@main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ mcp = [
 ]
 dev = [
     "pytest>=8.0",
+    "pytest-asyncio>=0.23",
     "pytest-cov>=6.0",
     "ruff>=0.4",
     "mypy>=1.10",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -137,12 +137,13 @@ class TestDataTools:
     """Test tools that don't require LLM calls."""
 
     @pytest.mark.asyncio
-    async def test_list_persona_packs_empty(self):
+    async def test_list_persona_packs_builtins_only(self):
         result = await mcp.call_tool("list_persona_packs", {})
         # call_tool returns a list of content blocks
         text = result[0][0].text
         data = json.loads(text)
-        assert data == []
+        assert all(p["builtin"] for p in data)
+        assert len(data) >= 1  # at least one bundled pack
 
     @pytest.mark.asyncio
     async def test_save_and_get_persona_pack(self):
@@ -165,10 +166,11 @@ class TestDataTools:
         assert pack["name"] == "Test Pack"
         assert len(pack["personas"]) == 2
 
-        # List
+        # List — saved pack should appear alongside builtins
         list_result = await mcp.call_tool("list_persona_packs", {})
         packs = json.loads(list_result[0][0].text)
-        assert len(packs) == 1
+        saved_ids = [p["id"] for p in packs if not p.get("builtin")]
+        assert "test-1" in saved_ids
 
     @pytest.mark.asyncio
     async def test_list_panel_results_empty(self):
@@ -320,10 +322,11 @@ class TestInstrumentPackTools:
     """The 3 new instrument-pack tools mirror the persona-pack equivalents."""
 
     @pytest.mark.asyncio
-    async def test_list_empty(self):
+    async def test_list_builtins_only(self):
         result = await mcp.call_tool("list_instrument_packs", {})
         data = json.loads(result[0][0].text)
-        assert data == []
+        assert all(p.get("source") == "bundled" for p in data)
+        assert len(data) >= 1  # at least one bundled pack
 
     @pytest.mark.asyncio
     async def test_save_then_list_then_get(self):
@@ -350,7 +353,8 @@ class TestInstrumentPackTools:
 
         list_res = await mcp.call_tool("list_instrument_packs", {})
         listed = json.loads(list_res[0][0].text)
-        assert len(listed) == 1 and listed[0]["id"] == "demo"
+        saved_ids = [p["id"] for p in listed if p.get("source") != "bundled"]
+        assert "demo" in saved_ids
 
         get_res = await mcp.call_tool("get_instrument_pack", {"name": "demo"})
         loaded = json.loads(get_res[0][0].text)


### PR DESCRIPTION
## Summary
- Change all 5 CI job install steps from `.[dev]` to `.[dev,mcp]` so `test_mcp_server.py` actually runs instead of silently skipping via `pytest.importorskip("mcp")`
- Add `pytest-asyncio` to dev dependencies (required by async MCP tests that were previously skipped)
- Fix 4 MCP test assertions that incorrectly assumed no builtin packs exist (pre-existing bugs exposed by tests now running)
- Add `pip install synth-panel[mcp]` install note to README Quick Start sections

## Test plan
- [x] All 528 tests pass locally (`pytest tests/ --ignore=tests/test_acceptance.py`)
- [x] Coverage at 88.82% (above 80% gate)
- [x] Ruff lint + format clean
- [ ] CI should now run MCP tests that were previously silently skipped

Closes sp-k8k

🤖 Generated with [Claude Code](https://claude.com/claude-code)