### PR TITLE
feat: --extract-schema for dual-path text+structured extraction (sp-5on.1)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -332,6 +332,15 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             print(f"Error loading schema: {exc}", file=sys.stderr)
             return 1
 
+    # Load optional extraction schema (--extract-schema)
+    extract_schema: dict[str, Any] | None = None
+    if getattr(args, "extract_schema", None):
+        try:
+            extract_schema = _load_schema(args.extract_schema)
+        except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+            print(f"Error loading extract-schema: {exc}", file=sys.stderr)
+            return 1
+
     client = LLMClient()
 
     # Run all panelists in parallel via the orchestrator
@@ -343,6 +352,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         system_prompt_fn=persona_system_prompt,
         question_prompt_fn=build_question_prompt,
         response_schema=response_schema,
+        extract_schema=extract_schema,
     )
 
     # Build output results and aggregate panelist usage

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -96,6 +96,20 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     panel_run_parser.add_argument(
+        "--extract-schema",
+        default=None,
+        metavar="SCHEMA",
+        help=(
+            "JSON Schema for post-hoc extraction from free-text responses. "
+            "Can be a file path (e.g. extract.json) or inline JSON string. "
+            "Each panelist responds in free text, then a second LLM call "
+            "extracts structured data matching this schema. The result is "
+            "stored under an 'extraction' key alongside the raw 'response'. "
+            "Unlike --schema (which forces structured-only output), this "
+            "flag preserves the full text response."
+        ),
+    )
+    panel_run_parser.add_argument(
         "--no-synthesis",
         action="store_true",
         default=False,

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -301,6 +301,7 @@ def _run_panelist(
     response_schema: dict[str, Any] | None = None,
     session: Session | None = None,
     sentiment_cache: dict[str, str] | None = None,
+    extract_schema: dict[str, Any] | None = None,
 ) -> tuple[PanelistResult, Session]:
     """Execute a single panelist's full interview. Runs in a worker thread.
 
@@ -335,6 +336,13 @@ def _run_panelist(
             structured_engine = StructuredOutputEngine(client)
             structured_config = StructuredOutputConfig(schema=response_schema)
 
+        # Set up extraction engine for post-hoc structured extraction
+        extract_engine: StructuredOutputEngine | None = None
+        extract_config: StructuredOutputConfig | None = None
+        if extract_schema:
+            extract_engine = StructuredOutputEngine(client)
+            extract_config = StructuredOutputConfig(schema=extract_schema)
+
         for question in questions:
             question_text = question_prompt_fn(question)
 
@@ -366,13 +374,41 @@ def _run_panelist(
                 else:
                     summary = runtime.run_turn(question_text)
                     response_text = _extract_text(summary)
-                    responses.append(
-                        {
-                            "question": question_text,
-                            "response": response_text,
-                        }
-                    )
+                    resp_dict: dict[str, Any] = {
+                        "question": question_text,
+                        "response": response_text,
+                    }
                     tracker.record_turn(summary.usage)
+
+                    # Extraction pass: extract structured data from the
+                    # free-text response (--extract-schema).
+                    if extract_engine and extract_config:
+                        try:
+                            extract_messages = [
+                                InputMessage(
+                                    role="user",
+                                    content=[TextBlock(text=question_text)],
+                                ),
+                                InputMessage(
+                                    role="assistant",
+                                    content=[TextBlock(text=response_text)],
+                                ),
+                            ]
+                            extract_result = extract_engine.extract(
+                                model=model,
+                                max_tokens=4096,
+                                messages=extract_messages,
+                                config=extract_config,
+                                system=system_prompt,
+                            )
+                            tracker.record_turn(_convert_llm_usage(extract_result.response.usage))
+                            resp_dict["extraction"] = extract_result.data
+                            resp_dict["extraction_is_fallback"] = extract_result.is_fallback
+                        except Exception as extract_exc:
+                            resp_dict["extraction"] = None
+                            resp_dict["extraction_error"] = str(extract_exc)
+
+                    responses.append(resp_dict)
             except Exception as exc:
                 responses.append(
                     {
@@ -447,6 +483,7 @@ def run_panel_parallel(
     max_workers: int | None = None,
     response_schema: dict[str, Any] | None = None,
     sessions: dict[str, Session] | None = None,
+    extract_schema: dict[str, Any] | None = None,
 ) -> tuple[list[PanelistResult], WorkerRegistry, dict[str, Session]]:
     """Run all panelists in parallel and return ordered results.
 
@@ -464,6 +501,11 @@ def run_panel_parallel(
         sessions: Optional mapping of persona names to existing sessions.
             When provided, panelists reuse their session (conversation history
             preserved). When None, each panelist gets a fresh session.
+        extract_schema: Optional JSON Schema for post-hoc extraction from
+            free-text responses. When provided (and response_schema is not),
+            each text response is followed by a second LLM call that extracts
+            structured data matching this schema. The result is stored under
+            an ``extraction`` key alongside the raw ``response``.
 
     Returns:
         Tuple of (ordered results matching persona order, registry,
@@ -502,6 +544,7 @@ def run_panel_parallel(
                 response_schema,
                 existing_session,
                 sentiment_cache,
+                extract_schema,
             )
             future_to_index[future] = idx
 
@@ -558,6 +601,7 @@ def run_multi_round_panel(
     synthesize_final_fn: Callable[..., Any] | None = None,
     response_schema: dict[str, Any] | None = None,
     max_workers: int | None = None,
+    extract_schema: dict[str, Any] | None = None,
 ) -> MultiRoundResult:
     """Execute a (possibly branching) multi-round panel run.
 
@@ -613,6 +657,7 @@ def run_multi_round_panel(
             max_workers=max_workers,
             response_schema=response_schema,
             sessions=sessions,
+            extract_schema=extract_schema,
         )
 
         synthesis = synthesize_round_fn(client, panelist_results, current.questions, model=model)

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -75,6 +75,7 @@ def patched_panel(monkeypatch):
         max_workers=None,
         response_schema=None,
         sessions=None,
+        extract_schema=None,
     ):
         results = [
             PanelistResult(

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -773,3 +773,180 @@ class TestSessionReuse:
         # Bob got a fresh session
         assert "Bob" in sessions
         assert sessions["Bob"] is not existing_session
+
+
+# ---------------------------------------------------------------------------
+# Tests: Extraction pass (--extract-schema)
+# ---------------------------------------------------------------------------
+
+_EXTRACT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "themes": {"type": "array", "items": {"type": "string"}},
+        "sentiment": {"type": "string", "enum": ["positive", "negative", "neutral"]},
+    },
+    "required": ["themes", "sentiment"],
+}
+
+
+class TestExtractionPass:
+    def test_extract_schema_adds_extraction_key(self):
+        """When extract_schema is provided, responses include 'extraction' alongside 'response'."""
+        from synth_panel.llm.models import CompletionRequest
+
+        extracted_data = {"themes": ["usability", "pricing"], "sentiment": "negative"}
+
+        def send_side_effect(request):
+            if isinstance(request, CompletionRequest) and request.tool_choice is not None:
+                return _make_tool_response(extracted_data)
+            return _make_text_response("The product is hard to use and too expensive.")
+
+        client = MagicMock()
+        client.send = MagicMock(side_effect=send_side_effect)
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "What frustrates you?"}]
+
+        results, _registry, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            extract_schema=_EXTRACT_SCHEMA,
+        )
+
+        assert len(results) == 1
+        resp = results[0].responses[0]
+        # Free-text response preserved
+        assert isinstance(resp["response"], str)
+        assert "hard to use" in resp["response"]
+        # Extraction present
+        assert resp["extraction"] == extracted_data
+        assert resp["extraction_is_fallback"] is False
+        # Not structured mode
+        assert "structured" not in resp
+
+    def test_extract_schema_ignored_when_response_schema_set(self):
+        """When both --schema and --extract-schema are set, structured mode wins (no extraction)."""
+        from synth_panel.llm.models import CompletionRequest
+
+        structured_data = {"sentiment": "positive", "summary": "Great!"}
+
+        def send_side_effect(request):
+            if isinstance(request, CompletionRequest) and request.tool_choice is not None:
+                return _make_tool_response(structured_data)
+            return _make_text_response("I like it")
+
+        client = MagicMock()
+        client.send = MagicMock(side_effect=send_side_effect)
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "What do you think?"}]
+
+        results, _, _ = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            response_schema=_SENTIMENT_SCHEMA,
+            extract_schema=_EXTRACT_SCHEMA,
+        )
+
+        resp = results[0].responses[0]
+        # Structured mode took over — no extraction key
+        assert resp["structured"] is True
+        assert "extraction" not in resp
+
+    def test_extract_schema_with_multiple_questions(self):
+        """Each question in text mode gets its own extraction call."""
+        from synth_panel.llm.models import CompletionRequest
+
+        call_count = {"text": 0, "extract": 0}
+        lock = threading.Lock()
+
+        def send_side_effect(request):
+            with lock:
+                if isinstance(request, CompletionRequest) and request.tool_choice is not None:
+                    call_count["extract"] += 1
+                    return _make_tool_response({"themes": [f"theme-{call_count['extract']}"], "sentiment": "neutral"})
+                call_count["text"] += 1
+                return _make_text_response(f"Answer {call_count['text']}")
+
+        client = MagicMock()
+        client.send = MagicMock(side_effect=send_side_effect)
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Q1"}, {"text": "Q2"}]
+
+        results, _, _ = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            extract_schema=_EXTRACT_SCHEMA,
+        )
+
+        responses = results[0].responses
+        assert len(responses) == 2
+        for resp in responses:
+            assert "extraction" in resp
+            assert isinstance(resp["extraction"], dict)
+            assert "themes" in resp["extraction"]
+
+    def test_extract_schema_error_captured_gracefully(self):
+        """If the extraction call fails, the response still has text and an error marker."""
+        from synth_panel.llm.models import CompletionRequest
+
+        def send_side_effect(request):
+            if isinstance(request, CompletionRequest) and request.tool_choice is not None:
+                raise ConnectionError("extraction API down")
+            return _make_text_response("Normal text response")
+
+        client = MagicMock()
+        client.send = MagicMock(side_effect=send_side_effect)
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "What do you think?"}]
+
+        results, _, _ = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            extract_schema=_EXTRACT_SCHEMA,
+        )
+
+        resp = results[0].responses[0]
+        # Text response preserved despite extraction failure
+        assert isinstance(resp["response"], str)
+        assert resp["response"] == "Normal text response"
+        # Extraction error captured
+        assert resp["extraction"] is None
+        assert "extraction_error" in resp
+
+    def test_no_extract_schema_no_extraction_key(self):
+        """Without extract_schema, responses have no extraction key."""
+        client = _make_mock_client([_make_text_response("Plain answer")])
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Tell me something"}]
+
+        results, _, _ = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+        )
+
+        resp = results[0].responses[0]
+        assert "extraction" not in resp
+        assert "extraction_is_fallback" not in resp


### PR DESCRIPTION
## Summary
- Adds `--extract-schema` CLI flag to `panel run` for post-hoc structured extraction from free-text responses
- Each panelist responds in free text, then a second `StructuredOutputEngine.extract()` call extracts structured data matching the given schema
- Extraction result stored as `extraction` key alongside raw `response` text in each response dict
- Existing `--schema` flag behavior unchanged (structured-only mode takes precedence when both set)
- Threaded through `_run_panelist` → `run_panel_parallel` → `run_multi_round_panel`

## Test plan
- [x] Unit test: extraction pass adds `extraction` key with structured data
- [x] Unit test: `--schema` takes precedence over `--extract-schema` (no extraction in structured mode)
- [x] Unit test: multiple questions each get individual extraction calls
- [x] Unit test: extraction errors captured gracefully (text response preserved)
- [x] Unit test: no `extraction` key when `--extract-schema` not set
- [x] All 533 existing tests pass (no regressions)
- [x] ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)