### PR TITLE
feat: default synthesis model to panelist model + pre-synthesis cost estimate (sp-5on.4)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -387,6 +387,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     run_invalid = failure_stats["total_pairs"] > 0 and failure_stats["failure_rate"] > threshold
     strict_violation = strict and failure_stats["errored_pairs"] > 0
 
+    # Compute panelist costs (needed before synthesis for cost estimate)
+    pricing, is_estimated = lookup_pricing(model)
+    panelist_cost_est = estimate_cost(panelist_usage, pricing)
+
     # Synthesis step (unless --no-synthesis)
     skip_synthesis = getattr(args, "no_synthesis", False)
     if run_invalid or strict_violation:
@@ -402,14 +406,12 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 panelist_results,
                 questions,
                 model=synthesis_model,
+                panelist_model=model,
                 custom_prompt=custom_prompt,
+                panelist_cost=panelist_cost_est,
             )
         except Exception as exc:
             print(f"Warning: synthesis failed: {exc}", file=sys.stderr)
-
-    # Compute costs
-    pricing, is_estimated = lookup_pricing(model)
-    panelist_cost_est = estimate_cost(panelist_usage, pricing)
 
     if synthesis_result:
         total_usage = panelist_usage + synthesis_result.usage

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -150,7 +150,9 @@ def _run_panel_sync(
                 panelist_results,
                 questions,
                 model=synthesis_model,
+                panelist_model=model,
                 custom_prompt=synthesis_prompt,
+                panelist_cost=panelist_cost,
             )
             synthesis_dict = synthesis_result.to_dict()
         except Exception:
@@ -184,6 +186,7 @@ def _run_multi_round_sync(
             panelist_results,
             questions,
             model=synthesis_model,
+            panelist_model=model,
             custom_prompt=synthesis_prompt,
         )
 
@@ -478,7 +481,7 @@ async def run_panel(
             JSON matching this schema instead of free text.
         synthesis: Whether to run synthesis after collecting responses.
             Defaults to true.
-        synthesis_model: Model to use for synthesis. Defaults to sonnet.
+        synthesis_model: Model to use for synthesis. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt. Replaces the default.
     """
     model = model or MCP_DEFAULT_MODEL
@@ -553,7 +556,7 @@ async def run_quick_poll(
             this schema instead of free text.
         synthesis: Whether to run synthesis after collecting responses.
             Defaults to true.
-        synthesis_model: Model to use for synthesis. Defaults to sonnet.
+        synthesis_model: Model to use for synthesis. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt. Replaces the default.
     """
     model = model or MCP_DEFAULT_MODEL
@@ -685,7 +688,7 @@ async def extend_panel(
             personas as the original run.
         model: LLM model to use for the new round. Defaults to haiku.
         synthesis: Whether to synthesize the new round.
-        synthesis_model: Synthesis model. Defaults to sonnet.
+        synthesis_model: Synthesis model. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt for the new round.
     """
     model = model or MCP_DEFAULT_MODEL
@@ -719,6 +722,7 @@ async def extend_panel(
                     results,
                     questions,
                     model=synthesis_model,
+                    panelist_model=model,
                     custom_prompt=synthesis_prompt,
                 )
             except Exception:

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -8,6 +8,7 @@ into a structured SynthesisResult via an LLM call using tool-use forcing
 from __future__ import annotations
 
 import json
+import sys
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -140,13 +141,33 @@ def _format_panelist_data(
     return "\n".join(parts)
 
 
+def _print_cost_estimate(
+    model: str,
+    user_content: str,
+    panelist_cost: CostEstimate | None,
+) -> None:
+    """Print a pre-synthesis cost estimate to stderr."""
+    pricing, _ = lookup_pricing(model)
+    # Rough token estimate: ~4 chars per token for English text
+    est_input_tokens = len(user_content) // 4
+    est_output_tokens = 1000  # typical synthesis output
+    est_usage = TokenUsage(input_tokens=est_input_tokens, output_tokens=est_output_tokens)
+    est = estimate_cost(est_usage, pricing)
+    parts = [f"Synthesis will cost ~{est.format_usd()}"]
+    if panelist_cost is not None:
+        parts.append(f"(panelist cost was {panelist_cost.format_usd()})")
+    print(" ".join(parts), file=sys.stderr)
+
+
 def synthesize_panel(
     client: LLMClient,
     panelist_results: list[Any],
     questions: list[dict[str, Any]],
     *,
     model: str | None = None,
+    panelist_model: str | None = None,
     custom_prompt: str | None = None,
+    panelist_cost: CostEstimate | None = None,
 ) -> SynthesisResult:
     """Synthesize panelist responses into a structured research finding.
 
@@ -154,13 +175,17 @@ def synthesize_panel(
         client: LLM client for the synthesis call.
         panelist_results: List of PanelistResult from run_panel_parallel.
         questions: The questions that were asked.
-        model: Model to use for synthesis (default: sonnet).
+        model: Explicit model for synthesis (e.g. --synthesis-model).
+        panelist_model: Model used for panelists; used as fallback when
+            *model* is not set so synthesis matches panelist cost tier.
         custom_prompt: Override the default synthesis prompt.
+        panelist_cost: Panelist cost estimate, shown in the pre-synthesis
+            cost estimate printed to stderr.
 
     Returns:
         SynthesisResult with structured findings and cost tracking.
     """
-    resolved_model = model or _DEFAULT_MODEL
+    resolved_model = model or panelist_model or _DEFAULT_MODEL
     prompt_text = custom_prompt or SYNTHESIS_PROMPT
 
     # Format the panelist data into a user message
@@ -176,6 +201,9 @@ def synthesize_panel(
         tool_name="synthesize",
         tool_description="Provide structured synthesis of the panel responses.",
     )
+
+    # Pre-synthesis cost estimate (printed to stderr)
+    _print_cost_estimate(resolved_model, user_content, panelist_cost)
 
     engine = StructuredOutputEngine(client)
     result = engine.extract(

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -124,9 +124,7 @@ class TestSynthesizePanel:
         mock_client = MagicMock()
         mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
 
-        result = synthesize_panel(
-            mock_client, _PANELIST_RESULTS, _QUESTIONS, panelist_model="haiku"
-        )
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS, panelist_model="haiku")
 
         assert result.model == "haiku"
         call_args = mock_client.send.call_args[0][0]
@@ -244,9 +242,7 @@ class TestCostEstimate:
         mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
 
         pc = CostEstimate(input_cost=0.001, output_cost=0.002)
-        synthesize_panel(
-            mock_client, _PANELIST_RESULTS, _QUESTIONS, panelist_cost=pc
-        )
+        synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS, panelist_cost=pc)
 
         captured = capsys.readouterr()
         assert "panelist cost was $" in captured.err

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -109,16 +109,45 @@ class TestSynthesizePanel:
         assert result.cost.total_cost > 0
 
     def test_default_model_is_sonnet(self):
-        """Default model should be sonnet."""
+        """When neither model nor panelist_model is set, defaults to sonnet."""
         mock_client = MagicMock()
         mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
 
         result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
 
         assert result.model == "sonnet"
-        # Verify the model sent to the LLM
         call_args = mock_client.send.call_args[0][0]
         assert call_args.model == "sonnet"
+
+    def test_panelist_model_used_as_default(self):
+        """When no explicit model, synthesis defaults to panelist model."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
+
+        result = synthesize_panel(
+            mock_client, _PANELIST_RESULTS, _QUESTIONS, panelist_model="haiku"
+        )
+
+        assert result.model == "haiku"
+        call_args = mock_client.send.call_args[0][0]
+        assert call_args.model == "haiku"
+
+    def test_explicit_model_overrides_panelist_model(self):
+        """Explicit --synthesis-model overrides panelist model."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
+
+        result = synthesize_panel(
+            mock_client,
+            _PANELIST_RESULTS,
+            _QUESTIONS,
+            model="opus",
+            panelist_model="haiku",
+        )
+
+        assert result.model == "opus"
+        call_args = mock_client.send.call_args[0][0]
+        assert call_args.model == "opus"
 
     def test_custom_model(self):
         """Can override the synthesis model."""
@@ -194,6 +223,44 @@ class TestSynthesizePanel:
         assert call_args.tools[0].name == "synthesize"
         assert call_args.tool_choice is not None
         assert call_args.tool_choice.name == "synthesize"
+
+
+class TestCostEstimate:
+    def test_cost_estimate_printed_to_stderr(self, capsys):
+        """Pre-synthesis cost estimate is printed to stderr."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
+
+        synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        captured = capsys.readouterr()
+        assert "Synthesis will cost ~$" in captured.err
+
+    def test_cost_estimate_includes_panelist_cost(self, capsys):
+        """When panelist_cost is provided, it appears in the estimate."""
+        from synth_panel.cost import CostEstimate
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
+
+        pc = CostEstimate(input_cost=0.001, output_cost=0.002)
+        synthesize_panel(
+            mock_client, _PANELIST_RESULTS, _QUESTIONS, panelist_cost=pc
+        )
+
+        captured = capsys.readouterr()
+        assert "panelist cost was $" in captured.err
+
+    def test_cost_estimate_without_panelist_cost(self, capsys):
+        """Without panelist_cost, the estimate omits the comparison."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
+
+        synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        captured = capsys.readouterr()
+        assert "Synthesis will cost ~$" in captured.err
+        assert "panelist cost" not in captured.err
 
 
 class TestFormatPanelistData:


### PR DESCRIPTION
## Summary
- Defaults synthesis model to match panelist model instead of always using Sonnet, reducing synthesis cost (~80% of total run cost)
- Adds pre-synthesis cost estimate printed to stderr before synthesis runs
- `--synthesis-model` flag still overrides the default

## Test plan
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues (43 source files)
- [x] `pytest` — 538 passed, 88.82% coverage (>80% gate)
- [ ] CI checks pass after merge

Closes sp-5on.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)