### PR TITLE
fix: mock _resolve_provider instead of _provider_cache in alias test (sp-s6o)

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -97,11 +97,14 @@ class TestAliasResolution:
 
             mock_provider = MagicMock()
             mock_provider.send.return_value = _simple_response()
-            client._provider_cache[canonical] = mock_provider
 
-            client.send(_simple_request(model="sonnet"))
-            call_args = mock_provider.send.call_args[0][0]
-            assert call_args.model == canonical
+            with patch.object(client, "_resolve_provider", return_value=mock_provider) as mock_resolve:
+                client.send(_simple_request(model="sonnet"))
+                # _resolve_provider must receive the canonical name, not the alias
+                mock_resolve.assert_called_once_with(canonical)
+                # Provider receives request with the resolved model name
+                call_args = mock_provider.send.call_args[0][0]
+                assert call_args.model == canonical
 
 
 class TestRetry:


### PR DESCRIPTION
## Summary

- Replace fragile `_provider_cache` injection with `patch.object` on `_resolve_provider` in `test_alias_is_resolved_in_send`
- The old approach silently fell through to a real `AnthropicProvider` when the cache key didn't match the resolved alias (e.g., when alias mappings changed)
- New approach makes the test structurally offline — no real provider is ever instantiated

## Test plan

- [x] `test_alias_is_resolved_in_send` passes
- [x] All 514 tests pass (21 skipped)
- [x] Ruff lint clean

Closes sp-s6o