### PR TITLE
docs: rename package synth-panel → synthpanel across repo (sp-4ut)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
-  "name": "synth-panel",
+  "name": "synthpanel",
   "version": "0.1.0",
   "description": "Run synthetic focus groups and user research panels using AI personas. Define personas in YAML, design survey instruments, and collect structured qualitative feedback — all from Claude Code.",
   "mcp_servers": {
     "synth_panel": {
-      "command": "synth-panel",
+      "command": "synthpanel",
       "args": ["mcp-serve"],
       "env": {}
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,10 @@
 {
-	"name": "synth-panel Dev",
+	"name": "synthpanel Dev",
 	"image": "ghcr.io/dataviking-tech/ai-dev-base:edge",
 	"updateRemoteUserUID": false,
 	"containerEnv": {
-		"PYTHONPATH": "/workspaces/synth-panel/src",
-		"VIRTUAL_ENV": "/workspaces/synth-panel/.venv"
+		"PYTHONPATH": "/workspaces/synthpanel/src",
+		"VIRTUAL_ENV": "/workspaces/synthpanel/.venv"
 	},
 	"initializeCommand": "docker pull ghcr.io/dataviking-tech/ai-dev-base:edge || podman pull ghcr.io/dataviking-tech/ai-dev-base:edge || echo No container runtime found, skipping pre-pull",
 	"postCreateCommand": "bash .devcontainer/postCreateCommand.sh",

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,45 +1,45 @@
 #!/usr/bin/env bash
 # postCreateCommand: runs ONCE on container creation.
-# Sets up synth-panel for development and testing.
+# Sets up synthpanel for development and testing.
 set -euo pipefail
 
-echo "Setting up synth-panel development environment..."
+echo "Setting up synthpanel development environment..."
 
-cd /workspaces/synth-panel
+cd /workspaces/synthpanel
 
 # Initialize uv project (creates .venv if needed, generates uv.lock)
 echo "Initializing uv project..."
 uv lock 2>&1 || echo "uv lock failed, continuing..."
 
 # Install the package in editable mode with all extras
-echo "Installing synth-panel (editable)..."
+echo "Installing synthpanel (editable)..."
 uv pip install -e ".[dev,mcp]" 2>&1 || uv pip install -e . 2>&1 || {
   echo "uv pip install failed, falling back to PYTHONPATH mode"
 }
 
-# Verify the synth-panel entry point is available
-if command -v synth-panel >/dev/null 2>&1; then
-  echo "synth-panel CLI installed and on PATH"
-elif [ -x ".venv/bin/synth-panel" ]; then
-  echo "synth-panel installed in .venv (activate with: source .venv/bin/activate)"
+# Verify the synthpanel entry point is available
+if command -v synthpanel >/dev/null 2>&1; then
+  echo "synthpanel CLI installed and on PATH"
+elif [ -x ".venv/bin/synthpanel" ]; then
+  echo "synthpanel installed in .venv (activate with: source .venv/bin/activate)"
 else
-  echo "Warning: synth-panel entry point not found"
+  echo "Warning: synthpanel entry point not found"
   echo "  Use: PYTHONPATH=src python3 -m synth_panel"
 fi
 
 # Verify CLI works
-if synth-panel --help >/dev/null 2>&1 || .venv/bin/synth-panel --help >/dev/null 2>&1; then
-  echo "synth-panel CLI is working"
+if synthpanel --help >/dev/null 2>&1 || .venv/bin/synthpanel --help >/dev/null 2>&1; then
+  echo "synthpanel CLI is working"
 else
-  echo "Warning: synth-panel CLI failed to load"
+  echo "Warning: synthpanel CLI failed to load"
 fi
 
-echo "synth-panel dev environment ready"
+echo "synthpanel dev environment ready"
 echo ""
 echo "Quick start:"
 echo "  export ANTHROPIC_API_KEY='sk-...'"
-echo "  synth-panel prompt 'Say hello'"
-echo "  synth-panel panel run --personas examples/personas.yaml --instrument examples/survey.yaml"
+echo "  synthpanel prompt 'Say hello'"
+echo "  synthpanel panel run --personas examples/personas.yaml --instrument examples/survey.yaml"
 echo ""
 echo "MCP server:"
-echo "  synth-panel mcp-serve"
+echo "  synthpanel mcp-serve"

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,33 +1,33 @@
 #!/usr/bin/env bash
 # postStartCommand: runs on EVERY container start.
-# Ensures synth-panel is ready and prints status.
+# Ensures synthpanel is ready and prints status.
 set -euo pipefail
 
 # Ensure every new terminal activates the venv
-BASHRC_SNIPPET='# synth-panel venv activation
-if [ -d "/workspaces/synth-panel/.venv" ]; then
-  export VIRTUAL_ENV="/workspaces/synth-panel/.venv"
+BASHRC_SNIPPET='# synthpanel venv activation
+if [ -d "/workspaces/synthpanel/.venv" ]; then
+  export VIRTUAL_ENV="/workspaces/synthpanel/.venv"
   export PATH="$VIRTUAL_ENV/bin:$PATH"
 fi
-export PYTHONPATH="${PYTHONPATH:-/workspaces/synth-panel/src}"'
+export PYTHONPATH="${PYTHONPATH:-/workspaces/synthpanel/src}"'
 
-if ! grep -q "synth-panel venv activation" ~/.bashrc 2>/dev/null; then
+if ! grep -q "synthpanel venv activation" ~/.bashrc 2>/dev/null; then
   echo "$BASHRC_SNIPPET" >> ~/.bashrc
 fi
 
 # Activate for this script too
-if [ -d "/workspaces/synth-panel/.venv" ]; then
-  export VIRTUAL_ENV="/workspaces/synth-panel/.venv"
+if [ -d "/workspaces/synthpanel/.venv" ]; then
+  export VIRTUAL_ENV="/workspaces/synthpanel/.venv"
   export PATH="$VIRTUAL_ENV/bin:$PATH"
 fi
 
-export PYTHONPATH="${PYTHONPATH:-/workspaces/synth-panel/src}"
+export PYTHONPATH="${PYTHONPATH:-/workspaces/synthpanel/src}"
 
 # Quick health check
 if python3 -m synth_panel --help >/dev/null 2>&1; then
-  echo "synth-panel is ready"
+  echo "synthpanel is ready"
 else
-  echo "Warning: synth-panel not working, try: uv sync"
+  echo "Warning: synthpanel not working, try: uv sync"
 fi
 
 # Check for API keys

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -7,9 +7,9 @@ name: Publish Dev to TestPyPI
 #
 #   1. On https://test.pypi.org/manage/account/publishing/ add a trusted
 #      publisher with:
-#        project name = synth-panel
+#        project name = synthpanel
 #        owner        = DataViking-Tech
-#        repo         = synth-panel
+#        repo         = synthpanel
 #        workflow     = publish-test.yml
 #        environment  = pypi-test   (must match the `environment:` key below)
 #   2. In GitHub repo Settings -> Environments, create an environment
@@ -65,8 +65,8 @@ jobs:
           DEV_VERSION: ${{ steps.version.outputs.version }}
         run: |
           {
-            echo "## Published synth-panel ${DEV_VERSION} (dev)"
+            echo "## Published synthpanel ${DEV_VERSION} (dev)"
             echo ""
-            echo "- TestPyPI: https://test.pypi.org/project/synth-panel/${DEV_VERSION}/"
-            echo "- Install: \`pip install -i https://test.pypi.org/simple/ synth-panel==${DEV_VERSION}\`"
+            echo "- TestPyPI: https://test.pypi.org/project/synthpanel/${DEV_VERSION}/"
+            echo "- Install: \`pip install -i https://test.pypi.org/simple/ synthpanel==${DEV_VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,9 @@ name: Publish to PyPI
 #
 #   1. On https://pypi.org/manage/account/publishing/ add a trusted
 #      publisher with:
-#        project name = synth-panel
+#        project name = synthpanel
 #        owner        = DataViking-Tech
-#        repo         = synth-panel
+#        repo         = synthpanel
 #        workflow     = publish.yml
 #        environment  = pypi   (must match the `environment:` key below)
 #   2. In GitHub repo Settings → Environments, create an environment
@@ -110,8 +110,8 @@ jobs:
         run: |
           VERSION="${TAG#v}"
           {
-            echo "## Published synth-panel ${VERSION}"
+            echo "## Published synthpanel ${VERSION}"
             echo ""
-            echo "- PyPI: https://pypi.org/project/synth-panel/${VERSION}/"
-            echo "- Install: \`pip install synth-panel==${VERSION}\`"
+            echo "- PyPI: https://pypi.org/project/synthpanel/${VERSION}/"
+            echo "- Install: \`pip install synthpanel==${VERSION}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,8 @@ state.json
 .devcontainer/.env
 .devcontainer/tmp/
 
-# synth-panel data
-.synth-panel/
+# synthpanel data
+.synthpanel/
 sessions/
 
 # Testing

--- a/0.5.0-ARCHITECTURE-REVIEW.md
+++ b/0.5.0-ARCHITECTURE-REVIEW.md
@@ -1,6 +1,6 @@
 # 0.5.0 Architecture Review — Feasibility Pass
 
-**Author:** synth-panel/architect
+**Author:** synthpanel/architect
 **Date:** 2026-04-06
 **Reviewing:** `0.5.0-VISION.md` (CPO, 2026-04-06)
 **Continuity:** `SPEC.md`, `ARCHITECTURE-REVIEW-040.md`
@@ -95,7 +95,7 @@ Persona packs are directories because a pack can have multiple personas + a mani
 name: pricing-discovery
 version: 1
 description: Two-round pricing objection probe with branching on objection type
-author: synth-panel/community
+author: synthpanel/community
 instrument:
   version: 3
   rounds:
@@ -203,7 +203,7 @@ A DAG with no cycles is bounded above by the total round count, which is bounded
 
 Three small additions, none of which need a doc revision — flagging here for when the PM writes the execution plan:
 
-1. **`synth-panel instruments graph <file>` is mentioned in passing.** It should be a hard scope item, not a "if anything." A branching instrument is unreadable without it. ~30 LOC using a Mermaid string template, no graphviz dependency. Ship at 0.5.0.
+1. **`synthpanel instruments graph <file>` is mentioned in passing.** It should be a hard scope item, not a "if anything." A branching instrument is unreadable without it. ~30 LOC using a Mermaid string template, no graphviz dependency. Ship at 0.5.0.
 
 2. **The v3→v2→v1 backward-compat ladder needs a test matrix.** v1 instruments are still in `examples/`, v2 instruments are still in `tests/`, v3 is new. The acceptance tests need to cover all three formats running through the same orchestrator path. The existing `instrument.py` test file is the right place.
 

--- a/0.5.0-VISION.md
+++ b/0.5.0-VISION.md
@@ -1,6 +1,6 @@
-# synth-panel 0.5.0 — CPO Vision
+# synthpanel 0.5.0 — CPO Vision
 
-**Author:** synth-panel/cpo | **Date:** 2026-04-06
+**Author:** synthpanel/cpo | **Date:** 2026-04-06
 
 ---
 
@@ -15,7 +15,7 @@
 | Panel resume / extend | Agents can iterate on a panel through repeated tool calls without losing persona context |
 | Backward-compatible output | Single-round instruments still emit the flat `results`/`synthesis` shape; multi-round emits `rounds` |
 
-Multi-round was the inflection. Before it, synth-panel was a parallel-prompt-runner with a synthesis on top. After it, synth-panel is a research orchestrator: it sequences questions, carries persona memory, and shapes later questions from earlier findings. The agent surface inherited this directly — `extend_panel` made the MCP tool genuinely conversational, not just call-and-response.
+Multi-round was the inflection. Before it, synthpanel was a parallel-prompt-runner with a synthesis on top. After it, synthpanel is a research orchestrator: it sequences questions, carries persona memory, and shapes later questions from earlier findings. The agent surface inherited this directly — `extend_panel` made the MCP tool genuinely conversational, not just call-and-response.
 
 But 0.4.0 also exposed the next ceiling: **every multi-round instrument is linear.** Round 1 → Round 2 → Round 3, regardless of what Round 1 found. If exploration surfaces a pricing objection, the instrument can template the *wording* of the probe round around it — but it can't choose a *different probe round* based on what was surfaced. The research arc is fixed at authoring time.
 
@@ -77,7 +77,7 @@ instrument:
         - text: "If a tool addressed {synthesis.recommendation}, would you switch?"
 ```
 
-**Why this matters:** Linear multi-round is impressive but it's still a script. Branching turns the instrument into a decision tree where the *path* is data-driven. That makes synth-panel genuinely closer to how a researcher actually works — and meaningfully harder for "I could just prompt ChatGPT with personas" to replicate. ChatGPT can simulate one path. Synth-panel chooses the path based on what the panel actually said.
+**Why this matters:** Linear multi-round is impressive but it's still a script. Branching turns the instrument into a decision tree where the *path* is data-driven. That makes synthpanel genuinely closer to how a researcher actually works — and meaningfully harder for "I could just prompt ChatGPT with personas" to replicate. ChatGPT can simulate one path. Synth-panel chooses the path based on what the panel actually said.
 
 **Why this matters for agents:** An agent calling `run_panel` with a branching instrument gets even more leverage per tool call. Instead of "run this 3-round study," the call becomes "run this study, follow the right branch automatically, give me the synthesis at the end of whichever path the panel surfaced." The agent is offloading not just orchestration but **research-design judgment** to the harness. That is the agent-native value proposition deepening, not broadening — more decisions made inside one tool call.
 
@@ -115,20 +115,20 @@ We already have persona packs (0.2.0). Add **instrument packs** as the second co
 
 ```bash
 # Browse community instrument packs
-synth-panel instruments list
+synthpanel instruments list
 
 # Install
-synth-panel instruments install pricing-discovery
+synthpanel instruments install pricing-discovery
 
 # Use directly
-synth-panel panel run --pack startup-founder --instrument pricing-discovery
+synthpanel panel run --pack startup-founder --instrument pricing-discovery
 ```
 
 **MCP equivalents:** `list_instrument_packs`, `save_instrument_pack`, `load_instrument_pack`. Mirrors the persona pack tools. The MCP server already has the infrastructure pattern — this is following an established convention, not inventing one.
 
 **Why this matters:** Authoring a *good* multi-round (and now branching) instrument is the hard part. A novice user with `pricing-discovery`, `name-test`, `landing-page-comprehension`, `feature-prioritization-tradeoff` packs ready to install can do useful research on day one without designing an instrument from scratch. Persona packs answer "who am I asking?" — instrument packs answer "what should I ask them?" Both are needed for the flywheel to spin.
 
-**Curation policy (CPO call):** A small `synth-panel/instruments` repo with hand-vetted packs ships at 0.5.0 launch — five instruments minimum, covering the highest-frequency indie-hacker use cases (name testing, pricing discovery, feature prioritization, landing page comprehension, churn diagnosis). Community contributions accepted via PR. We do not run a registry/marketplace — packs are git-installable, period. (See anti-scope.)
+**Curation policy (CPO call):** A small `synthpanel/instruments` repo with hand-vetted packs ships at 0.5.0 launch — five instruments minimum, covering the highest-frequency indie-hacker use cases (name testing, pricing discovery, feature prioritization, landing page comprehension, churn diagnosis). Community contributions accepted via PR. We do not run a registry/marketplace — packs are git-installable, period. (See anti-scope.)
 
 #### 3. Remove the Flat Output Format
 
@@ -146,7 +146,7 @@ synth-panel panel run --pack startup-founder --instrument pricing-discovery
 - **Not loops or back-edges.** Each round runs at most once. If a user wants to "go back to exploration with new framing," that's a new run.
 - **Not persona-to-persona interaction.** Still independent panelists. Still settled.
 - **Not a hosted instrument registry.** Packs are git-installable. We are not building a marketplace, ratings, comments, payments, or any of the SaaS-shaped surface that comes with one. (Anti-scope.)
-- **Not a web UI for designing branching instruments.** Visualizing a DAG in YAML is not a problem we solve with a GUI. If anything, ship a `synth-panel instruments graph <file>` that emits a DOT/Mermaid diagram on stdout.
+- **Not a web UI for designing branching instruments.** Visualizing a DAG in YAML is not a problem we solve with a GUI. If anything, ship a `synthpanel instruments graph <file>` that emits a DOT/Mermaid diagram on stdout.
 - **Not 1.0.0.** See below.
 
 ---
@@ -170,7 +170,7 @@ That's the demo where someone says "wait, you mean the *instrument itself* branc
 The roadmap rule is "1.0.0 when someone has built something real on top and the API has been stable for 3+ minor releases." After 0.5.0 we will be **at** the threshold but **not past** it.
 
 - API stability: 0.4.0 changed the output shape (added `rounds`). 0.5.0 removes the flat shape. So 0.5.0 → 0.6.0 → 0.7.0 are the three minor releases that need to ship without breaking changes before 1.0.0 is on the table.
-- Real adoption: we need at least one external user shipping something that depends on synth-panel. Could be a research consultancy using it as an internal pre-screen. Could be an open-source product team with synth-panel in their CI as a "run the panel against this PR's copy changes" check. Could be an indie hacker referencing it in a launch post. We don't have this yet — Show HN is the most likely catalyst.
+- Real adoption: we need at least one external user shipping something that depends on synthpanel. Could be a research consultancy using it as an internal pre-screen. Could be an open-source product team with synthpanel in their CI as a "run the panel against this PR's copy changes" check. Could be an indie hacker referencing it in a launch post. We don't have this yet — Show HN is the most likely catalyst.
 
 **0.6.0 will be a stabilization release.** No new features. Bug fixes, doc improvements, performance, expanded instrument library. The discipline of shipping a stabilization release is itself a signal that we respect the 1.0.0 contract.
 
@@ -187,7 +187,7 @@ The roadmap rule is "1.0.0 when someone has built something real on top and the 
 - **0.5.0** — Branching instruments, instrument library, flat output removal. **(this release)**
 - **0.6.0** — Stabilization. No new features. Bug fixes, docs, expanded instrument library, performance.
 - **0.7.0** — TBD; driven by community feedback after 0.5.0/0.6.0 land.
-- **1.0.0** — When someone has built something real on top of synth-panel and the API has been stable for 3+ minor releases.
+- **1.0.0** — When someone has built something real on top of synthpanel and the API has been stable for 3+ minor releases.
 
 ---
 
@@ -221,9 +221,9 @@ I expect two pieces of pushback on this plan. Calling them out so we can have th
 
 ## Summary
 
-0.5.0 is **the adaptive release**. Branching instruments make synth-panel choose its own research path based on what the panel says — the step beyond "linear rounds with templated questions." Instrument packs ship the second ecosystem flywheel, parallel to persona packs from 0.2.0. The flat output shape gets retired, paying down the deprecation debt before 1.0.0.
+0.5.0 is **the adaptive release**. Branching instruments make synthpanel choose its own research path based on what the panel says — the step beyond "linear rounds with templated questions." Instrument packs ship the second ecosystem flywheel, parallel to persona packs from 0.2.0. The flat output shape gets retired, paying down the deprecation debt before 1.0.0.
 
-Branching is still the right bet. What's changed since the original roadmap is the framing: it's not "more sophistication on top of linear multi-round," it's "adaptive research in one tool call" — the deepening of agent-native value, not broadening. A single MCP call now offloads orchestration, persona memory, *and* research-design judgment to the harness. That is what makes synth-panel structurally different from manual prompting in a way that compounds with every release.
+Branching is still the right bet. What's changed since the original roadmap is the framing: it's not "more sophistication on top of linear multi-round," it's "adaptive research in one tool call" — the deepening of agent-native value, not broadening. A single MCP call now offloads orchestration, persona memory, *and* research-design judgment to the harness. That is what makes synthpanel structurally different from manual prompting in a way that compounds with every release.
 
 0.6.0 is a stabilization release. 0.7.0 is community-driven. 1.0.0 stays gated on real external adoption — Show HN (preferably on 0.5.0) is the most credible catalyst.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
-All notable changes to synth-panel are documented here.
+All notable changes to synthpanel are documented here.
 
-For auto-generated release notes, see [GitHub Releases](https://github.com/DataViking-Tech/synth-panel/releases).
+For auto-generated release notes, see [GitHub Releases](https://github.com/DataViking-Tech/synthpanel/releases).
 
 ## [Unreleased]
 
@@ -30,7 +30,7 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [0.4.0] - 2026-04-10
 
-First published release on [PyPI](https://pypi.org/project/synth-panel/).
+First published release on [PyPI](https://pypi.org/project/synthpanel/).
 
 ### Added
 - v2 multi-round linear instruments with session reuse across rounds
@@ -57,6 +57,6 @@ First published release on [PyPI](https://pypi.org/project/synth-panel/).
 - Persona-pack persistence (`save_persona_pack`, `get_persona_pack`, `list_persona_packs`)
 - Panel result persistence and retrieval
 
-[Unreleased]: https://github.com/DataViking-Tech/synth-panel/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/DataViking-Tech/synth-panel/releases/tag/v0.4.0
-[0.3.0]: https://github.com/DataViking-Tech/synth-panel/releases/tag/v0.3.0
+[Unreleased]: https://github.com/DataViking-Tech/synthpanel/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/DataViking-Tech/synthpanel/releases/tag/v0.4.0
+[0.3.0]: https://github.com/DataViking-Tech/synthpanel/releases/tag/v0.3.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# synth-panel
+# synthpanel
 
 A lightweight, LLM-agnostic research harness for running synthetic focus groups using AI personas.
 
@@ -43,26 +43,26 @@ src/synth_panel/
 
 ```bash
 # Single prompt
-synth-panel prompt "Say hello"
+synthpanel prompt "Say hello"
 
 # Full panel run (file path or installed pack name)
-synth-panel panel run --personas examples/personas.yaml --instrument examples/survey.yaml
-synth-panel panel run --personas examples/personas.yaml --instrument pricing-discovery
+synthpanel panel run --personas examples/personas.yaml --instrument examples/survey.yaml
+synthpanel panel run --personas examples/personas.yaml --instrument pricing-discovery
 
 # v3 branching: list / show / install / graph instrument packs
-synth-panel instruments list
-synth-panel instruments graph pricing-discovery --format mermaid
+synthpanel instruments list
+synthpanel instruments graph pricing-discovery --format mermaid
 
 # MCP server (stdio, for Claude Code / Cursor / Windsurf)
-synth-panel mcp-serve
+synthpanel mcp-serve
 
 # With specific model
-synth-panel prompt "Hello" --model haiku
-synth-panel prompt "Hello" --model gemini
+synthpanel prompt "Hello" --model haiku
+synthpanel prompt "Hello" --model gemini
 
 # Output formats
-synth-panel prompt "Hello" --output-format json
-synth-panel prompt "Hello" --output-format ndjson
+synthpanel prompt "Hello" --output-format json
+synthpanel prompt "Hello" --output-format ndjson
 ```
 
 ## Development
@@ -161,14 +161,14 @@ instrument (with `route_when` clauses) instead. The boundary is intentional:
 `extend_panel` is for human-in-the-loop follow-ups; v3 routing is for
 agent-driven, instrument-authored adaptivity.
 
-Claude Code plugin: install via `/plugin install synth-panel`. Adds `/focus-group` skill.
+Claude Code plugin: install via `/plugin install synthpanel`. Adds `/focus-group` skill.
 
 Standalone MCP config for any editor:
 ```json
 {
   "mcpServers": {
     "synth_panel": {
-      "command": "synth-panel",
+      "command": "synthpanel",
       "args": ["mcp-serve"],
       "env": { "ANTHROPIC_API_KEY": "sk-..." }
     }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,11 @@
-# Contributing to synth-panel
+# Contributing to synthpanel
 
 ## Development Setup
 
 ```bash
 # Clone the repository
-git clone https://github.com/DataViking-Tech/synth-panel.git
-cd synth-panel
+git clone https://github.com/DataViking-Tech/synthpanel.git
+cd synthpanel
 
 # Create a virtual environment (using uv or standard venv)
 uv venv .venv && source .venv/bin/activate
@@ -55,7 +55,7 @@ mypy src/synth_panel/
 The MCP server uses stdio transport and is designed to be launched by an MCP-aware editor (Claude Code, Cursor, Windsurf, etc.):
 
 ```bash
-synth-panel mcp-serve
+synthpanel mcp-serve
 ```
 
 For testing outside an editor, you can pipe JSON-RPC messages to stdin. See [docs/mcp.md](docs/mcp.md) for the full tool/resource/prompt reference.

--- a/EXECUTION-PLAN-050.md
+++ b/EXECUTION-PLAN-050.md
@@ -1,10 +1,10 @@
-# synth-panel 0.5.0 — Execution Plan
+# synthpanel 0.5.0 — Execution Plan
 
-> PM: synth-panel/pm | Date: 2026-04-06
+> PM: synthpanel/pm | Date: 2026-04-06
 > Inputs: `0.5.0-VISION.md` (CPO), `0.5.0-ARCHITECTURE-REVIEW.md` (architect)
 
 The 0.5.0 "Adaptive Release" turns the orchestrator into a router. Branching
-instruments make synth-panel choose its research path from what the panel said.
+instruments make synthpanel choose its research path from what the panel said.
 Instrument packs ship the second ecosystem flywheel alongside persona packs.
 Flat output gets retired before 1.0.0.
 
@@ -190,7 +190,7 @@ Edit `synth_panel/output.py` (~40 LOC delta) plus an audit pass.
    for flat-shape assumptions; update or annotate. Architect risk R6.
 
 **Acceptance criteria:**
-- `synth-panel panel run` (no flag) emits `rounds` shape for single-round instrument
+- `synthpanel panel run` (no flag) emits `rounds` shape for single-round instrument
 - `--legacy-output` emits old shape + stderr warning
 - MCP `run_panel` always emits `rounds` shape for single-round instrument
 - All existing examples and skills work with the new shape
@@ -208,8 +208,8 @@ Edit `synth_panel/mcp/data.py` (~40 LOC delta).
 2. Manifest fields are the same for both types: `name`, `version`, `description`,
    `author`. Persona packs keep these in `manifest.yaml`; instrument packs
    keep them at top level of the instrument YAML
-3. Storage convention: `~/.synth-panel/packs/personas/<name>/` (dir) vs
-   `~/.synth-panel/packs/instruments/<name>.yaml` (file)
+3. Storage convention: `~/.synthpanel/packs/personas/<name>/` (dir) vs
+   `~/.synthpanel/packs/instruments/<name>.yaml` (file)
 4. New helpers in `data.py`: `list_instrument_packs()`, `load_instrument_pack(name)`,
    `save_instrument_pack(name, content)`
 
@@ -229,9 +229,9 @@ Edit `synth_panel/mcp/data.py` (~40 LOC delta).
 Edit `synth_panel/cli/commands.py` and `cli/parser.py` (~120 LOC delta).
 
 **What to build:**
-1. **New subcommand group: `synth-panel instruments`**
+1. **New subcommand group: `synthpanel instruments`**
    - `instruments list` — list installed packs (name, version, description)
-   - `instruments install <name>` — install from `synth-panel/instruments` repo
+   - `instruments install <name>` — install from `synthpanel/instruments` repo
    - `instruments show <name>` — print the YAML
    - `instruments graph <file-or-name>` — render Mermaid DAG to stdout (see F3-D)
 2. **`panel run --instrument <name>` accepts pack names** in addition to file paths
@@ -288,7 +288,7 @@ all five must demonstrate branching to justify the library's existence.
 5. `churn-diagnosis.yaml` — context → branch on churn-driver → probe → validation
 
 Each pack must include:
-- Top-level manifest (`name`, `version`, `description`, `author: synth-panel/community`)
+- Top-level manifest (`name`, `version`, `description`, `author: synthpanel/community`)
 - A v3 instrument with `route_when` clauses
 - Comments explaining the branching logic
 - A theme-tag hint in the synthesis prompt to mitigate R3 (architect risk):
@@ -307,7 +307,7 @@ Each pack must include:
 Add to `cli/commands.py` (~30 LOC).
 
 **What to build:**
-- `synth-panel instruments graph <file-or-name>` reads the instrument, walks
+- `synthpanel instruments graph <file-or-name>` reads the instrument, walks
   the round DAG (depends_on ∪ route_when targets), and emits a Mermaid diagram
   to stdout
 - No graphviz dependency — pure string template

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# synth-panel
+# synthpanel
 
 Open-source synthetic focus groups. Any LLM. Your terminal or your agent's tool call.
 
 Define personas in YAML. Define your research instrument in YAML. Run against any LLM — from your terminal, from a pipeline, or from an AI agent's MCP tool call. Get structured, reproducible output with full cost transparency.
 
 ```bash
-pip install synth-panel
-synth-panel panel run --personas personas.yaml --instrument survey.yaml
+pip install synthpanel
+synthpanel panel run --personas personas.yaml --instrument survey.yaml
 
 # For MCP server support (Claude Code, Cursor, Windsurf, etc.)
-pip install synth-panel[mcp]
+pip install synthpanel[mcp]
 ```
 
 ## Why
@@ -25,22 +25,22 @@ Traditional focus groups cost $5,000-$15,000 and take weeks. Synthetic panels co
 
 ```bash
 # Install from PyPI (v0.4.0+)
-pip install synth-panel
+pip install synthpanel
 
 # For MCP server support (agent integration)
-pip install synth-panel[mcp]
+pip install synthpanel[mcp]
 
 # Or install from source for the latest unreleased changes
-pip install git+https://github.com/DataViking-Tech/synth-panel.git@main
+pip install git+https://github.com/DataViking-Tech/synthpanel.git@main
 
 # Set your API key (Claude, OpenAI, Gemini, xAI, or any OpenAI-compatible provider)
 export ANTHROPIC_API_KEY="sk-..."
 
 # Run a single prompt
-synth-panel prompt "What do you think of the name Traitprint for a career app?"
+synthpanel prompt "What do you think of the name Traitprint for a career app?"
 
 # Run a full panel
-synth-panel panel run \
+synthpanel panel run \
   --personas examples/personas.yaml \
   --instrument examples/survey.yaml
 ```
@@ -130,14 +130,14 @@ loop, no hand-coded conditional flows.
 ```bash
 # The Show HN demo: ~$0.20, one command, the panel decides
 # whether to dig into pain, pricing, or alternatives.
-synth-panel panel run \
+synthpanel panel run \
   --personas examples/personas.yaml \
   --instrument pricing-discovery
 ```
 
 `pricing-discovery` is one of five bundled v3 packs (`pricing-discovery`,
 `name-test`, `feature-prioritization`, `landing-page-comprehension`,
-`churn-diagnosis`). List them with `synth-panel instruments list`.
+`churn-diagnosis`). List them with `synthpanel instruments list`.
 
 The output now carries a `path` array recording the routing decisions
 that actually fired:
@@ -149,7 +149,7 @@ discovery -> probe[themes contains price] -> probe_pricing -> validation
 Render the DAG of any instrument:
 
 ```bash
-synth-panel instruments graph pricing-discovery --format mermaid
+synthpanel instruments graph pricing-discovery --format mermaid
 ```
 
 ### Predicate Reference
@@ -213,11 +213,11 @@ also match `pricing`, `priced`, etc.
 ### `instruments` Subcommand
 
 ```bash
-synth-panel instruments list                       # bundled + installed packs
-synth-panel instruments show pricing-discovery     # full YAML body
-synth-panel instruments install ./my-pack.yaml     # add a local pack
-synth-panel instruments graph pricing-discovery    # text DAG
-synth-panel instruments graph pricing-discovery \
+synthpanel instruments list                       # bundled + installed packs
+synthpanel instruments show pricing-discovery     # full YAML body
+synthpanel instruments install ./my-pack.yaml     # add a local pack
+synthpanel instruments graph pricing-discovery    # text DAG
+synthpanel instruments graph pricing-discovery \
   --format mermaid                                 # mermaid flowchart
 ```
 
@@ -227,7 +227,7 @@ local file and then `install` it once it's stable.
 
 ## LLM Provider Support
 
-synth-panel works with any LLM provider. Set the appropriate environment variable:
+synthpanel works with any LLM provider. Set the appropriate environment variable:
 
 | Provider | Environment Variable | Model Flag |
 |----------|---------------------|------------|
@@ -239,19 +239,19 @@ synth-panel works with any LLM provider. Set the appropriate environment variabl
 
 ```bash
 # Use Claude (default)
-synth-panel panel run --personas p.yaml --instrument s.yaml
+synthpanel panel run --personas p.yaml --instrument s.yaml
 
 # Use GPT-4o
-synth-panel panel run --personas p.yaml --instrument s.yaml --model gpt-4o
+synthpanel panel run --personas p.yaml --instrument s.yaml --model gpt-4o
 
 # Use a local model via Ollama
 OPENAI_BASE_URL=http://localhost:11434/v1 \
-synth-panel panel run --personas p.yaml --instrument s.yaml --model llama3
+synthpanel panel run --personas p.yaml --instrument s.yaml --model llama3
 ```
 
 ## Architecture
 
-synth-panel is a research harness, not an LLM wrapper. It orchestrates the research workflow:
+synthpanel is a research harness, not an LLM wrapper. It orchestrates the research workflow:
 
 ```
 personas.yaml ──┐
@@ -287,10 +287,10 @@ instrument.yaml ─┘                 ├──> Panelist 2 ──> LLM ──>
 
 ## MCP Server (Agent Integration)
 
-synth-panel includes an MCP server so AI agents can run panels as tool calls:
+synthpanel includes an MCP server so AI agents can run panels as tool calls:
 
 ```bash
-synth-panel mcp-serve
+synthpanel mcp-serve
 ```
 
 Add to your editor's MCP config (Claude Code, Cursor, Windsurf, etc.):
@@ -299,7 +299,7 @@ Add to your editor's MCP config (Claude Code, Cursor, Windsurf, etc.):
 {
   "mcpServers": {
     "synth_panel": {
-      "command": "synth-panel",
+      "command": "synthpanel",
       "args": ["mcp-serve"],
       "env": { "ANTHROPIC_API_KEY": "sk-..." }
     }
@@ -322,20 +322,20 @@ probes that the original instrument didn't anticipate.
 
 ```bash
 # Human-readable (default)
-synth-panel panel run --personas p.yaml --instrument s.yaml
+synthpanel panel run --personas p.yaml --instrument s.yaml
 
 # JSON (pipe to jq, store in database)
-synth-panel panel run --personas p.yaml --instrument s.yaml --output-format json
+synthpanel panel run --personas p.yaml --instrument s.yaml --output-format json
 
 # NDJSON (streaming, one event per line)
-synth-panel panel run --personas p.yaml --instrument s.yaml --output-format ndjson
+synthpanel panel run --personas p.yaml --instrument s.yaml --output-format ndjson
 ```
 
 ## Budget Control
 
 ```bash
 # Set a dollar budget for the panel
-synth-panel panel run --personas p.yaml --instrument s.yaml --config budget.yaml
+synthpanel panel run --personas p.yaml --instrument s.yaml --config budget.yaml
 ```
 
 The cost tracker enforces soft budget limits — the current panelist completes, but no new panelists start if the budget is exceeded.
@@ -350,7 +350,7 @@ Known limitations:
 - Cultural and demographic representation has blind spots
 - Higher-order correlations between variables are poorly replicated
 
-Use synth-panel to pre-screen and iterate, then validate with real participants.
+Use synthpanel to pre-screen and iterate, then validate with real participants.
 
 ## Versions
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2,9 +2,9 @@
 
 **Version**: 1.0.0
 **Date**: 2026-04-03
-**Purpose**: Functional specification for a synthetic focus group CLI tool ("synth-panel") that orchestrates multiple LLM-powered personas to generate structured qualitative feedback.
+**Purpose**: Functional specification for a synthetic focus group CLI tool ("synthpanel") that orchestrates multiple LLM-powered personas to generate structured qualitative feedback.
 
-**Audience**: Implementers who will build synth-panel from scratch. This document describes behavioral contracts and data flows only -- no implementation details from any reference codebase.
+**Audience**: Implementers who will build synthpanel from scratch. This document describes behavioral contracts and data flows only -- no implementation details from any reference codebase.
 
 ---
 
@@ -231,7 +231,7 @@ A single turn proceeds as follows:
 
 ### Purpose
 
-Manage the lifecycle of multiple independent agent sessions working in parallel or in a coordinated workflow. For synth-panel, this means spawning one agent per panelist persona and coordinating their execution.
+Manage the lifecycle of multiple independent agent sessions working in parallel or in a coordinated workflow. For synthpanel, this means spawning one agent per panelist persona and coordinating their execution.
 
 ### Interface Contract
 
@@ -307,7 +307,7 @@ Spawning --> ReadyForPrompt --> PromptAccepted --> Running --> Finished
 ### Extension Points
 
 - Detection heuristics (trust prompts, ready cues, running cues, shell prompts) are configurable pattern lists.
-- The registry is an in-memory data structure. For synth-panel, this is sufficient -- persistent orchestration state is handled by the session persistence layer.
+- The registry is an in-memory data structure. For synthpanel, this is sufficient -- persistent orchestration state is handled by the session persistence layer.
 
 ---
 
@@ -344,7 +344,7 @@ The structured output system provides:
 
 ### Behavioral Requirements
 
-For synth-panel, the primary pattern is:
+For synthpanel, the primary pattern is:
 
 1. Define a "respond" tool whose input schema matches the desired panelist response format.
 2. Set tool_choice to "specific" with the respond tool's name.
@@ -540,7 +540,7 @@ Provide the command-line interface through which operators configure and run foc
 - `prompt <text...>`: Run a single non-interactive prompt and exit. All remaining arguments are joined as the prompt text.
 - `login`: Start an authentication flow (e.g., OAuth).
 - `logout`: Clear saved authentication credentials.
-- (Additional subcommands as needed for synth-panel: `panel run`, `panel resume`, etc.)
+- (Additional subcommands as needed for synthpanel: `panel run`, `panel resume`, etc.)
 
 **Interactive Mode** (when no subcommand is given):
 - Enter a REPL loop.
@@ -718,7 +718,7 @@ All registries (worker, team, cron) use interior mutability with mutex guards. T
 
 ### Naming Conventions for Synth-Panel
 
-When implementing these foundations for synth-panel, use domain-appropriate names:
+When implementing these foundations for synthpanel, use domain-appropriate names:
 
 | Foundation Concept | Synth-Panel Term |
 |-------------------|-----------------|
@@ -733,7 +733,7 @@ When implementing these foundations for synth-panel, use domain-appropriate name
 
 ### Minimum Viable Subset
 
-For a first working version of synth-panel, the following components are required in this order:
+For a first working version of synthpanel, the following components are required in this order:
 
 1. **LLM Client Abstraction** -- needed for everything
 2. **Structured Output** -- panelist responses must be schema-conformant
@@ -778,15 +778,15 @@ Each component must be validated against a live LLM API (Claude or OpenAI-compat
 - Verify auto-compaction triggers after exceeding the token threshold (can be set low for testing, e.g., 1000 tokens).
 
 ### CLI Framework
-- `synth-panel prompt "Say hello"` exits 0 and prints a response.
-- `synth-panel prompt "Say hello" --output-format json` outputs valid JSON with message and usage fields.
-- `synth-panel --help` prints usage information.
+- `synthpanel prompt "Say hello"` exits 0 and prints a response.
+- `synthpanel prompt "Say hello" --output-format json` outputs valid JSON with message and usage fields.
+- `synthpanel --help` prints usage information.
 - Invalid subcommand exits non-zero with an error message.
 
 ### Integration (end-to-end)
 - Define 3 personas in YAML (e.g., "skeptical CTO", "enthusiastic intern", "pragmatic PM").
 - Define a survey instrument asking "What do you think of the name 'Traitprint' for a career matching app?"
-- Run `synth-panel run --personas personas.yaml --instrument survey.yaml --model sonnet`.
+- Run `synthpanel run --personas personas.yaml --instrument survey.yaml --model sonnet`.
 - Verify: 3 structured responses returned, each conforming to the schema, each with different content reflecting the persona, total cost printed.
 
 ---

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,4 +1,4 @@
-# Releasing synth-panel
+# Releasing synthpanel
 
 ## Release flow (production PyPI)
 
@@ -12,7 +12,7 @@ Releases follow semver and are fully automated via GitHub Actions:
    - Computes the next version from the latest `v*.*.*` tag.
    - Creates and pushes a new git tag (e.g. `v0.5.0`).
    - Creates a GitHub Release with auto-generated notes.
-   - Triggers `publish.yml` which builds and publishes to [PyPI](https://pypi.org/project/synth-panel/).
+   - Triggers `publish.yml` which builds and publishes to [PyPI](https://pypi.org/project/synthpanel/).
 
 ### Manual publish
 
@@ -23,7 +23,7 @@ You can re-publish an existing tag via workflow dispatch:
 
 ## Dev builds (TestPyPI)
 
-Every merge to `main` automatically publishes a dev build to [TestPyPI](https://test.pypi.org/project/synth-panel/):
+Every merge to `main` automatically publishes a dev build to [TestPyPI](https://test.pypi.org/project/synthpanel/):
 
 - Version format: `{base_version}.dev{run_number}` (e.g. `0.4.0.dev42`).
 - Workflow: `publish-test.yml`.
@@ -33,29 +33,29 @@ Every merge to `main` automatically publishes a dev build to [TestPyPI](https://
 
 ```bash
 # Latest dev build from TestPyPI
-pip install -i https://test.pypi.org/simple/ synth-panel
+pip install -i https://test.pypi.org/simple/ synthpanel
 
 # Specific dev version
-pip install -i https://test.pypi.org/simple/ synth-panel==0.4.0.dev42
+pip install -i https://test.pypi.org/simple/ synthpanel==0.4.0.dev42
 ```
 
 > **Note:** TestPyPI may not have all dependencies. If installation fails due to
-> missing deps, install them from real PyPI first, then install synth-panel from
+> missing deps, install them from real PyPI first, then install synthpanel from
 > TestPyPI:
 >
 > ```bash
 > pip install httpx pyyaml
-> pip install -i https://test.pypi.org/simple/ --no-deps synth-panel==0.4.0.dev42
+> pip install -i https://test.pypi.org/simple/ --no-deps synthpanel==0.4.0.dev42
 > ```
 
 ## Install a release
 
 ```bash
 # Latest stable release from PyPI
-pip install synth-panel
+pip install synthpanel
 
 # Specific version
-pip install synth-panel==0.4.0
+pip install synthpanel==0.4.0
 ```
 
 ## GitHub environments

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,11 +1,11 @@
 # MCP Server Reference
 
-synth-panel ships an [MCP](https://modelcontextprotocol.io/) server so AI agents can run synthetic focus groups as tool calls. The server uses stdio transport and defaults to the `haiku` model for cheap, fast iterative use.
+synthpanel ships an [MCP](https://modelcontextprotocol.io/) server so AI agents can run synthetic focus groups as tool calls. The server uses stdio transport and defaults to the `haiku` model for cheap, fast iterative use.
 
 ## Starting the Server
 
 ```bash
-synth-panel mcp-serve
+synthpanel mcp-serve
 ```
 
 The server communicates over stdin/stdout using JSON-RPC (the MCP protocol). It is designed to be launched by an MCP-aware editor or agent framework.
@@ -20,7 +20,7 @@ Add to your MCP config (e.g., `.claude/mcp.json`, `.cursor/mcp.json`):
 {
   "mcpServers": {
     "synth_panel": {
-      "command": "synth-panel",
+      "command": "synthpanel",
       "args": ["mcp-serve"],
       "env": { "ANTHROPIC_API_KEY": "sk-..." }
     }
@@ -33,7 +33,7 @@ Set the environment variable for whichever LLM provider you want to use. See the
 ### Claude Code Plugin
 
 ```
-/plugin install synth-panel
+/plugin install synthpanel
 ```
 
 This adds the `/focus-group` skill to your Claude Code session.
@@ -140,10 +140,10 @@ For v1/v2 instruments and raw `questions` input, `path` is empty or linear and `
 
 ## Data Storage
 
-Panel results, persona packs, and instrument packs are stored under `~/.synth-panel/` (configurable via `SYNTH_PANEL_DATA_DIR`):
+Panel results, persona packs, and instrument packs are stored under `~/.synthpanel/` (configurable via `SYNTH_PANEL_DATA_DIR`):
 
 ```
-~/.synth-panel/
+~/.synthpanel/
 ├── persona_packs/          # Saved persona packs (YAML)
 ├── packs/instruments/      # Installed instrument packs (YAML)
 └── results/                # Panel results (JSON) + session data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "synth-panel"
+name = "synthpanel"
 version = "0.4.0"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
@@ -26,10 +26,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/DataViking-Tech/synth-panel"
-Repository = "https://github.com/DataViking-Tech/synth-panel"
-Issues = "https://github.com/DataViking-Tech/synth-panel/issues"
-Changelog = "https://github.com/DataViking-Tech/synth-panel/releases"
+Homepage = "https://github.com/DataViking-Tech/synthpanel"
+Repository = "https://github.com/DataViking-Tech/synthpanel"
+Issues = "https://github.com/DataViking-Tech/synthpanel/issues"
+Changelog = "https://github.com/DataViking-Tech/synthpanel/releases"
 
 [project.optional-dependencies]
 mcp = [
@@ -45,7 +45,7 @@ dev = [
 ]
 
 [project.scripts]
-synth-panel = "synth_panel.main:main"
+synthpanel = "synth_panel.main:main"
 
 [build-system]
 requires = ["setuptools>=68.0"]

--- a/skills/focus-group/SKILL.md
+++ b/skills/focus-group/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools:
   - mcp__synth_panel__list_instruments
 ---
 
-You are orchestrating a **synthetic focus group** using the synth-panel MCP tools.
+You are orchestrating a **synthetic focus group** using the synthpanel MCP tools.
 
 ## What You Do
 

--- a/src/synth_panel/__main__.py
+++ b/src/synth_panel/__main__.py
@@ -1,4 +1,4 @@
-"""Allow running synth-panel as ``python -m synth_panel``."""
+"""Allow running synthpanel as ``python -m synth_panel``."""
 
 from __future__ import annotations
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1,4 +1,4 @@
-"""Subcommand handlers for synth-panel CLI.
+"""Subcommand handlers for synthpanel CLI.
 
 Each handler receives parsed args and output format, returns an exit code.
 """
@@ -82,12 +82,12 @@ def _announce_default_model(args: argparse.Namespace) -> None:
     alias, source = _resolve_default_model()
     if source:
         print(
-            f"[synth-panel] --model not specified; using '{alias}' (detected {source}). Override with --model <name>.",
+            f"[synthpanel] --model not specified; using '{alias}' (detected {source}). Override with --model <name>.",
             file=sys.stderr,
         )
     else:
         print(
-            f"[synth-panel] --model not specified and no provider API "
+            f"[synthpanel] --model not specified and no provider API "
             f"keys detected; falling back to '{alias}'. Set one of: "
             f"{', '.join(env for env, _ in _DEFAULT_MODEL_PREFERENCE)}.",
             file=sys.stderr,
@@ -810,7 +810,7 @@ def handle_instruments_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
     if fmt is OutputFormat.TEXT:
         if not packs:
             print("No instrument packs installed.")
-            print("Install one with: synth-panel instruments install <file.yaml>")
+            print("Install one with: synthpanel instruments install <file.yaml>")
         else:
             for p in packs:
                 version = f" v{p['version']}" if p.get("version") else ""

--- a/src/synth_panel/cli/output.py
+++ b/src/synth_panel/cli/output.py
@@ -1,4 +1,4 @@
-"""Output formatting for synth-panel CLI.
+"""Output formatting for synthpanel CLI.
 
 Supports text, json, and ndjson formats per SPEC.md §8.
 """

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1,4 +1,4 @@
-"""Argument parser for synth-panel CLI.
+"""Argument parser for synthpanel CLI.
 
 Defines global arguments and subcommands per SPEC.md §8.
 """
@@ -11,7 +11,7 @@ import argparse
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser with global args and subcommands."""
     parser = argparse.ArgumentParser(
-        prog="synth-panel",
+        prog="synthpanel",
         description="Synthetic focus group CLI — orchestrate LLM-powered personas for structured qualitative feedback.",
     )
 

--- a/src/synth_panel/cli/repl.py
+++ b/src/synth_panel/cli/repl.py
@@ -1,4 +1,4 @@
-"""Interactive REPL for synth-panel.
+"""Interactive REPL for synthpanel.
 
 Entered when no subcommand is given. Supports slash commands per SPEC.md §8.
 """
@@ -50,7 +50,7 @@ def run_repl(args: argparse.Namespace, fmt: OutputFormat) -> int:
     runtime = AgentRuntime(client=client, session=session, model=model)
     state = SessionState(model=model, runtime=runtime)
 
-    print("synth-panel interactive mode. Type /help for commands, Ctrl-D to exit.")
+    print("synthpanel interactive mode. Type /help for commands, Ctrl-D to exit.")
 
     while True:
         try:

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -1,4 +1,4 @@
-"""Cost and budget tracking for synth-panel.
+"""Cost and budget tracking for synthpanel.
 
 Implements SPEC.md Section 7: token usage accumulation, model-specific
 cost estimation, budget enforcement, and human-readable summaries.
@@ -200,7 +200,7 @@ class UsageTracker:
 
     Thread-safety is *not* provided — callers must synchronise externally
     if the tracker is shared.  (The spec notes that this is sufficient for
-    the synth-panel use case.)
+    the synthpanel use case.)
     """
 
     def __init__(self) -> None:

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -1,4 +1,4 @@
-"""synth-panel CLI entry point.
+"""synthpanel CLI entry point.
 
 Implements the CLI framework from SPEC.md §8: argparse CLI, REPL loop,
 slash commands, and output formatting.

--- a/src/synth_panel/mcp/__init__.py
+++ b/src/synth_panel/mcp/__init__.py
@@ -1,6 +1,6 @@
-"""MCP server for synth-panel.
+"""MCP server for synthpanel.
 
-Exposes the synth-panel API as an MCP server with tools, resources, and
+Exposes the synthpanel API as an MCP server with tools, resources, and
 prompt templates over stdio transport.
 """
 

--- a/src/synth_panel/mcp/data.py
+++ b/src/synth_panel/mcp/data.py
@@ -1,6 +1,6 @@
 """Persistence layer for MCP persona packs and panel results.
 
-Data is stored under ~/.synth-panel/ (configurable via SYNTH_PANEL_DATA_DIR).
+Data is stored under ~/.synthpanel/ (configurable via SYNTH_PANEL_DATA_DIR).
 
 Layout::
 
@@ -30,7 +30,7 @@ import yaml
 
 def _data_dir() -> Path:
     """Return the root data directory, creating it if needed."""
-    d = Path(os.environ.get("SYNTH_PANEL_DATA_DIR", "~/.synth-panel")).expanduser()
+    d = Path(os.environ.get("SYNTH_PANEL_DATA_DIR", "~/.synthpanel")).expanduser()
     d.mkdir(parents=True, exist_ok=True)
     return d
 

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -1,4 +1,4 @@
-"""MCP server implementation for synth-panel.
+"""MCP server implementation for synthpanel.
 
 Exposes 12 tools, 4 resource URI patterns, and 3 prompt templates.
 Uses stdio transport. Default model is haiku for MCP mode.
@@ -87,7 +87,7 @@ MCP_DEFAULT_MODEL = "haiku"
 PANELIST_TIMEOUT = 30
 
 mcp = FastMCP(
-    "synth-panel",
+    "synthpanel",
     instructions=(
         "Synthetic focus group server. Run panels of AI personas to get "
         "structured qualitative feedback on products, concepts, and names."

--- a/src/synth_panel/packs/__init__.py
+++ b/src/synth_panel/packs/__init__.py
@@ -1,3 +1,3 @@
-"""Bundled persona packs shipped with synth-panel."""
+"""Bundled persona packs shipped with synthpanel."""
 
 from __future__ import annotations

--- a/src/synth_panel/packs/instruments/churn-diagnosis.yaml
+++ b/src/synth_panel/packs/instruments/churn-diagnosis.yaml
@@ -7,7 +7,7 @@ description: >
   Diagnose why a customer-shaped persona would churn from a product.
   Branches into value-failure, friction-failure, or competitive-loss
   probes based on the dominant theme in the initial diagnosis round.
-author: synth-panel
+author: synthpanel
 
 instrument:
   version: 3

--- a/src/synth_panel/packs/instruments/feature-prioritization.yaml
+++ b/src/synth_panel/packs/instruments/feature-prioritization.yaml
@@ -8,7 +8,7 @@ description: >
   Prioritize a candidate feature set against persona needs. Branches
   into trade-off probing, must-have validation, or scope-cut
   exploration depending on the initial reactions.
-author: synth-panel
+author: synthpanel
 
 instrument:
   version: 3

--- a/src/synth_panel/packs/instruments/landing-page-comprehension.yaml
+++ b/src/synth_panel/packs/instruments/landing-page-comprehension.yaml
@@ -7,7 +7,7 @@ description: >
   Test whether a landing page communicates clearly to a target persona.
   Branches into jargon-probe, audience-fit probe, or CTA-probe based
   on the dominant confusion in the initial pass.
-author: synth-panel
+author: synthpanel
 
 instrument:
   version: 3

--- a/src/synth_panel/packs/instruments/name-test.yaml
+++ b/src/synth_panel/packs/instruments/name-test.yaml
@@ -8,7 +8,7 @@ description: >
   Test 1-3 candidate names for a product or feature. Branches into
   meaning-probe, pronounce-probe, or memorability-probe depending on
   which concerns dominate the discovery round.
-author: synth-panel
+author: synthpanel
 
 instrument:
   version: 3

--- a/src/synth_panel/packs/instruments/pricing-discovery.yaml
+++ b/src/synth_panel/packs/instruments/pricing-discovery.yaml
@@ -11,7 +11,7 @@ description: >
   Discover how a target persona thinks about price for a product or
   service. Branches into pain probing, pricing tier exploration, or
   competitor comparison based on the discovery round's themes.
-author: synth-panel
+author: synthpanel
 
 instrument:
   version: 3

--- a/src/synth_panel/persistence.py
+++ b/src/synth_panel/persistence.py
@@ -1,4 +1,4 @@
-"""Session persistence for synth-panel.
+"""Session persistence for synthpanel.
 
 Implements SPEC.md Section 6: save/load in JSON and JSONL formats,
 incremental append, session forking, atomic writes, and file rotation.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the synth-panel CLI framework."""
+"""Tests for the synthpanel CLI framework."""
 
 from __future__ import annotations
 

--- a/tests/test_mcp_data.py
+++ b/tests/test_mcp_data.py
@@ -395,7 +395,7 @@ class TestInstrumentPacks:
             "name": "pricing-probe",
             "version": "1.0.0",
             "description": "Branching probe for pricing-sensitive panels",
-            "author": "synth-panel",
+            "author": "synthpanel",
             "instrument": {
                 "version": 3,
                 "rounds": [
@@ -411,7 +411,7 @@ class TestInstrumentPacks:
         listing = list_instrument_packs()
         saved = [p for p in listing if p["id"] == "pricing-probe"]
         assert len(saved) == 1
-        assert saved[0]["author"] == "synth-panel"
+        assert saved[0]["author"] == "synthpanel"
 
         loaded = load_instrument_pack("pricing-probe")
         # round-trip preserves the body


### PR DESCRIPTION
## Summary
- Renames user-facing package name from `synth-panel` to `synthpanel` across the entire repo
- Updates pyproject.toml name field and CLI entry point
- Updates README, CONTRIBUTING, CHANGELOG, docs, and CI workflows
- Python import path (`synth_panel`) remains unchanged

## Test plan
- [x] `ruff format --check` — 67 files formatted
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues (43 source files)
- [x] `pytest` — 546 passed, 88.85% coverage (>80% gate)
- [ ] CI checks pass after merge

Closes sp-4ut

🤖 Generated with [Claude Code](https://claude.com/claude-code)