### PR TITLE
feat: add Krippendorff's alpha for inter-rater reliability (sp-5on.8)

### DIFF
--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -21,11 +21,13 @@ __all__ = [
     "FrequencyRow",
     "FrequencyTable",
     "KendallWResult",
+    "KrippendorffResult",
     "bootstrap_ci",
     "borda_count",
     "chi_squared_test",
     "frequency_table",
     "kendall_w",
+    "krippendorff_alpha",
     "proportion_stat",
 ]
 
@@ -561,3 +563,207 @@ def borda_count(
     ranking = sorted(scores.keys(), key=lambda x: (-scores[x], x))
 
     return BordaResult(scores=scores, ranking=ranking, n_voters=n_voters)
+
+
+# ---------------------------------------------------------------------------
+# Krippendorff's alpha
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KrippendorffResult:
+    """Result of Krippendorff's alpha computation."""
+
+    alpha: float  # Alpha coefficient [-1, 1], typically [0, 1]
+    n_raters: int  # Number of raters (models)
+    n_items: int  # Number of items (personas)
+    n_categories: int  # Number of distinct values observed
+    level: str  # Measurement level used ("nominal", "ordinal", "interval")
+    interpretation: str  # Human-readable interpretation
+
+
+def _nominal_delta(c: object, k: object) -> float:
+    """Nominal distance: 0 if equal, 1 if different."""
+    return 0.0 if c == k else 1.0
+
+
+def _interval_delta(c: object, k: object) -> float:
+    """Interval distance: squared difference."""
+    return (float(c) - float(k)) ** 2
+
+
+def _ordinal_delta(
+    c: object,
+    k: object,
+    sorted_values: list,
+    value_counts: dict[object, float],
+) -> float:
+    """Ordinal distance per Krippendorff (2011).
+
+    d_ord(c, k) = (sum of n_g for all g where c <= g <= k
+                   - (n_c + n_k) / 2) ^ 2
+    """
+    i_c = sorted_values.index(c)
+    i_k = sorted_values.index(k)
+    if i_c > i_k:
+        i_c, i_k = i_k, i_c
+    running_sum = sum(
+        value_counts[sorted_values[g]] for g in range(i_c, i_k + 1)
+    )
+    running_sum -= (value_counts[c] + value_counts[k]) / 2
+    return running_sum**2
+
+
+def _interpret_alpha(alpha: float) -> str:
+    if alpha >= 0.80:
+        return "Strong agreement — reliable for drawing conclusions"
+    elif alpha >= 0.667:
+        return "Moderate agreement — tentative conclusions only"
+    elif alpha >= 0.40:
+        return "Weak agreement — interpret with caution"
+    else:
+        return "No meaningful agreement — model choice dominates"
+
+
+_VALID_LEVELS = frozenset({"nominal", "ordinal", "interval"})
+
+
+def krippendorff_alpha(
+    reliability_data: list[list[str | int | float | None]],
+    level_of_measurement: str = "nominal",
+) -> KrippendorffResult:
+    """Compute Krippendorff's alpha inter-rater reliability coefficient.
+
+    Uses the coincidence matrix method from Krippendorff (2011), which
+    handles missing data correctly.
+
+    Args:
+        reliability_data: Rater-by-item matrix.  Each inner list represents
+            one rater's codings across all items.  ``None`` indicates a
+            missing value.  Shape: ``[n_raters][n_items]``.
+        level_of_measurement: One of ``"nominal"``, ``"ordinal"``,
+            ``"interval"``.
+
+    Returns:
+        :class:`KrippendorffResult` with alpha, metadata, interpretation.
+
+    Raises:
+        ValueError: If *reliability_data* is empty, all values are ``None``,
+            *level_of_measurement* is invalid, or rater lists have different
+            lengths.
+    """
+    # --- Validation ---
+    if not reliability_data:
+        raise ValueError("reliability_data must not be empty")
+
+    if level_of_measurement not in _VALID_LEVELS:
+        raise ValueError(
+            f"level_of_measurement must be one of {sorted(_VALID_LEVELS)}, "
+            f"got {level_of_measurement!r}"
+        )
+
+    n_raters = len(reliability_data)
+    n_items = len(reliability_data[0])
+    if n_items == 0:
+        raise ValueError("reliability_data contains empty rater lists")
+    for i, row in enumerate(reliability_data):
+        if len(row) != n_items:
+            raise ValueError(
+                f"All rater lists must have the same length; "
+                f"rater 0 has {n_items} items but rater {i} has {len(row)}"
+            )
+
+    # --- Collect all non-None values and discover categories ---
+    all_values: list[object] = []
+    for row in reliability_data:
+        for v in row:
+            if v is not None:
+                all_values.append(v)
+
+    if not all_values:
+        raise ValueError("reliability_data contains only None values")
+
+    categories = sorted(set(all_values), key=lambda x: (isinstance(x, str), x))
+    n_categories = len(categories)
+
+    # --- Step 1: Build coincidence matrix ---
+    o: dict[tuple[object, object], float] = {}
+    for c in categories:
+        for k_val in categories:
+            o[(c, k_val)] = 0.0
+
+    for item_idx in range(n_items):
+        values_for_item = [
+            reliability_data[r][item_idx]
+            for r in range(n_raters)
+            if reliability_data[r][item_idx] is not None
+        ]
+        m_u = len(values_for_item)
+        if m_u < 2:
+            continue
+
+        for i in range(m_u):
+            for j in range(m_u):
+                if i == j:
+                    continue
+                o[(values_for_item[i], values_for_item[j])] += 1.0 / (m_u - 1)
+
+    # --- Step 2: Compute marginals ---
+    n_c: dict[object, float] = {}
+    for c in categories:
+        n_c[c] = sum(o[(c, k_val)] for k_val in categories)
+
+    n = sum(n_c.values())
+
+    if n < 2:
+        raise ValueError(
+            "Fewer than 2 pairable values — cannot compute alpha"
+        )
+
+    # --- Build delta function ---
+    if level_of_measurement == "nominal":
+
+        def delta(c: object, k_val: object) -> float:
+            return _nominal_delta(c, k_val)
+
+    elif level_of_measurement == "interval":
+
+        def delta(c: object, k_val: object) -> float:
+            return _interval_delta(c, k_val)
+
+    elif level_of_measurement == "ordinal":
+        sorted_values = sorted(categories, key=lambda x: (isinstance(x, str), x))
+
+        def delta(c: object, k_val: object) -> float:
+            return _ordinal_delta(c, k_val, sorted_values, n_c)
+
+    # --- Step 3: D_observed ---
+    d_observed = 0.0
+    for c in categories:
+        for k_val in categories:
+            if c != k_val:
+                d_observed += o[(c, k_val)] * delta(c, k_val)
+    d_observed /= n
+
+    # --- Step 4: D_expected ---
+    d_expected = 0.0
+    for c in categories:
+        for k_val in categories:
+            if c != k_val:
+                d_expected += n_c[c] * n_c[k_val] * delta(c, k_val)
+    d_expected /= n * (n - 1)
+
+    # --- Step 5: Alpha ---
+    if d_expected == 0.0:
+        alpha = 1.0  # All values identical
+    else:
+        alpha = 1.0 - d_observed / d_expected
+
+    return KrippendorffResult(
+        alpha=alpha,
+        n_raters=n_raters,
+        n_items=n_items,
+        n_categories=n_categories,
+        level=level_of_measurement,
+        interpretation=_interpret_alpha(alpha),
+    )

--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -607,9 +607,7 @@ def _ordinal_delta(
     i_k = sorted_values.index(k)
     if i_c > i_k:
         i_c, i_k = i_k, i_c
-    running_sum = sum(
-        value_counts[sorted_values[g]] for g in range(i_c, i_k + 1)
-    )
+    running_sum = sum(value_counts[sorted_values[g]] for g in range(i_c, i_k + 1))
     running_sum -= (value_counts[c] + value_counts[k]) / 2
     return running_sum**2
 
@@ -657,10 +655,7 @@ def krippendorff_alpha(
         raise ValueError("reliability_data must not be empty")
 
     if level_of_measurement not in _VALID_LEVELS:
-        raise ValueError(
-            f"level_of_measurement must be one of {sorted(_VALID_LEVELS)}, "
-            f"got {level_of_measurement!r}"
-        )
+        raise ValueError(f"level_of_measurement must be one of {sorted(_VALID_LEVELS)}, got {level_of_measurement!r}")
 
     n_raters = len(reliability_data)
     n_items = len(reliability_data[0])
@@ -669,8 +664,7 @@ def krippendorff_alpha(
     for i, row in enumerate(reliability_data):
         if len(row) != n_items:
             raise ValueError(
-                f"All rater lists must have the same length; "
-                f"rater 0 has {n_items} items but rater {i} has {len(row)}"
+                f"All rater lists must have the same length; rater 0 has {n_items} items but rater {i} has {len(row)}"
             )
 
     # --- Collect all non-None values and discover categories ---
@@ -694,9 +688,7 @@ def krippendorff_alpha(
 
     for item_idx in range(n_items):
         values_for_item = [
-            reliability_data[r][item_idx]
-            for r in range(n_raters)
-            if reliability_data[r][item_idx] is not None
+            reliability_data[r][item_idx] for r in range(n_raters) if reliability_data[r][item_idx] is not None
         ]
         m_u = len(values_for_item)
         if m_u < 2:
@@ -716,9 +708,7 @@ def krippendorff_alpha(
     n = sum(n_c.values())
 
     if n < 2:
-        raise ValueError(
-            "Fewer than 2 pairable values — cannot compute alpha"
-        )
+        raise ValueError("Fewer than 2 pairable values — cannot compute alpha")
 
     # --- Build delta function ---
     if level_of_measurement == "nominal":

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,4 +1,4 @@
-"""Tests for synth_panel.stats — sp-5on.7."""
+"""Tests for synth_panel.stats — sp-5on.7 + sp-5on.8."""
 
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ from synth_panel.stats import (
     chi_squared_test,
     frequency_table,
     kendall_w,
+    krippendorff_alpha,
     proportion_stat,
 )
 
@@ -275,3 +276,117 @@ class TestBordaCount:
     def test_inconsistent_items_rejects(self):
         with pytest.raises(ValueError):
             borda_count([{"A": 1, "B": 2}, {"A": 1, "C": 2}])
+
+
+# ---------------------------------------------------------------------------
+# krippendorff_alpha
+# ---------------------------------------------------------------------------
+
+
+class TestKrippendorffAlpha:
+    def test_perfect_agreement_nominal(self):
+        """All raters agree on every item -> alpha = 1.0."""
+        data = [
+            ["A", "B", "C", "A", "B"],
+            ["A", "B", "C", "A", "B"],
+            ["A", "B", "C", "A", "B"],
+        ]
+        result = krippendorff_alpha(data, "nominal")
+        assert result.alpha == pytest.approx(1.0)
+        assert result.level == "nominal"
+
+    def test_no_agreement_nominal(self):
+        """Systematic disagreement -> alpha near 0 or negative."""
+        data = [
+            ["A", "B", "C"],
+            ["B", "C", "A"],
+            ["C", "A", "B"],
+        ]
+        result = krippendorff_alpha(data, "nominal")
+        assert result.alpha < 0.1
+
+    def test_known_alpha_nominal(self):
+        """4 raters, 12 items, some missing data.
+        Verified against krippendorff 0.8.1 reference package: alpha = 0.871."""
+        data = [
+            [None, None, None, None, None, 3, 4, 1, 2, 1, 1, 3],
+            [1, None, 2, 1, 3, 3, 4, 3, None, None, None, None],
+            [None, None, 2, 1, 3, 3, 4, 2, 2, 1, 1, 3],
+            [1, None, 2, 1, 3, 3, 4, 2, 2, 1, 1, 3],
+        ]
+        result = krippendorff_alpha(data, "nominal")
+        assert result.alpha == pytest.approx(0.871, abs=0.01)
+        assert result.n_raters == 4
+        assert result.n_items == 12
+
+    def test_ordinal_level(self):
+        """Ordinal alpha should differ from nominal for ordered data."""
+        data = [
+            [1, 2, 3, 4, 5],
+            [1, 2, 3, 4, 5],
+            [1, 2, 3, 5, 4],  # swapped last two
+        ]
+        result_nom = krippendorff_alpha(data, "nominal")
+        result_ord = krippendorff_alpha(data, "ordinal")
+        # Ordinal should be higher: swapping adjacent ranks is a smaller
+        # disagreement in ordinal than in nominal
+        assert result_ord.alpha > result_nom.alpha
+
+    def test_interval_level(self):
+        """Interval alpha for numeric data."""
+        data = [
+            [1.0, 2.0, 3.0, 4.0],
+            [1.1, 2.1, 2.9, 4.1],
+            [0.9, 1.9, 3.1, 3.9],
+        ]
+        result = krippendorff_alpha(data, "interval")
+        assert result.alpha > 0.9  # Very close agreement
+        assert result.level == "interval"
+
+    def test_handles_missing_data(self):
+        """None values should be skipped, not crash."""
+        data = [
+            ["A", None, "C"],
+            [None, "B", "C"],
+            ["A", "B", None],
+        ]
+        result = krippendorff_alpha(data, "nominal")
+        assert isinstance(result.alpha, float)
+        assert result.n_raters == 3
+        assert result.n_items == 3
+
+    def test_all_same_value(self):
+        """All values identical -> alpha = 1.0 (D_e = 0 special case)."""
+        data = [
+            ["X", "X", "X"],
+            ["X", "X", "X"],
+        ]
+        result = krippendorff_alpha(data, "nominal")
+        assert result.alpha == pytest.approx(1.0)
+
+    def test_invalid_level_rejects(self):
+        with pytest.raises(ValueError, match="level"):
+            krippendorff_alpha([["A"]], "ratio")
+
+    def test_empty_rejects(self):
+        with pytest.raises(ValueError):
+            krippendorff_alpha([])
+
+    def test_mismatched_lengths_rejects(self):
+        with pytest.raises(ValueError):
+            krippendorff_alpha([["A", "B"], ["A"]])
+
+    def test_interpretation_strong(self):
+        data = [["A", "B", "C"]] * 5
+        result = krippendorff_alpha(data, "nominal")
+        assert "Strong" in result.interpretation or "reliable" in result.interpretation
+
+    def test_interpretation_weak(self):
+        """Low agreement should flag as weak/unreliable."""
+        data = [
+            ["A", "B", "C", "A"],
+            ["B", "C", "A", "B"],
+            ["C", "A", "B", "C"],
+        ]
+        result = krippendorff_alpha(data, "nominal")
+        assert "caution" in result.interpretation.lower() or "No meaningful" in result.interpretation


### PR DESCRIPTION
## Summary
- Adds `krippendorff_alpha()` to `src/synth_panel/stats.py` for inter-rater reliability measurement
- Supports nominal, ordinal, and interval levels of measurement
- Handles missing data via coincidence matrix method (Krippendorff 2011)
- Pure Python — no scipy/numpy required
- Fixed ruff format issue during merge

## Test plan
- [x] `ruff format --check` — 69 files formatted
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues (44 source files)
- [x] `pytest` — 590 passed, 89.41% coverage (>80% gate)
- [ ] CI checks pass after merge

Closes sp-5on.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)