### PR TITLE
feat: add cross-model convergence classification (sp-5on.12)

### DIFF
--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -882,14 +882,11 @@ def convergence_report(
         for p_idx, persona_responses in enumerate(multi_model_responses[model]):
             if len(persona_responses) != n_questions:
                 raise ValueError(
-                    f"Model {model!r} persona {p_idx} has {len(persona_responses)} "
-                    f"questions, expected {n_questions}"
+                    f"Model {model!r} persona {p_idx} has {len(persona_responses)} questions, expected {n_questions}"
                 )
 
     if len(question_texts) != n_questions:
-        raise ValueError(
-            f"question_texts has {len(question_texts)} entries but data has {n_questions} questions"
-        )
+        raise ValueError(f"question_texts has {len(question_texts)} entries but data has {n_questions} questions")
 
     findings: list[FindingConvergence] = []
 
@@ -937,8 +934,7 @@ def convergence_report(
         # Interpretation
         if level == ConvergenceLevel.STRONG:
             interpretation = (
-                f"Strong convergence (alpha={alpha_q:.2f}). "
-                f"All models agree: {majority_top} is the top choice."
+                f"Strong convergence (alpha={alpha_q:.2f}). All models agree: {majority_top} is the top choice."
             )
         elif level == ConvergenceLevel.MODERATE:
             interpretation = (

--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -11,20 +11,27 @@ from __future__ import annotations
 
 import math
 import random
+from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum
 
 __all__ = [
     "BootstrapResult",
     "BordaResult",
     "ChiSquaredResult",
+    "ConvergenceLevel",
+    "ConvergenceReport",
+    "FindingConvergence",
     "FrequencyRow",
     "FrequencyTable",
     "KendallWResult",
     "KrippendorffResult",
+    "ModelDistribution",
     "bootstrap_ci",
     "borda_count",
     "chi_squared_test",
+    "convergence_report",
     "frequency_table",
     "kendall_w",
     "krippendorff_alpha",
@@ -756,4 +763,224 @@ def krippendorff_alpha(
         n_categories=n_categories,
         level=level_of_measurement,
         interpretation=_interpret_alpha(alpha),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-model convergence/divergence classification (sp-5on.12)
+# ---------------------------------------------------------------------------
+
+
+class ConvergenceLevel(Enum):
+    """Classification of cross-model agreement on a finding."""
+
+    STRONG = "strong"  # alpha >= 0.80
+    MODERATE = "moderate"  # 0.60 <= alpha < 0.80
+    WEAK = "weak"  # 0.40 <= alpha < 0.60
+    NONE = "none"  # alpha < 0.40
+
+
+@dataclass(frozen=True)
+class ModelDistribution:
+    """Per-model response distribution for one finding."""
+
+    model: str
+    distribution: dict[str, float]  # category -> proportion
+    n: int  # Number of responses from this model
+    top_choice: str  # Modal response
+
+
+@dataclass(frozen=True)
+class FindingConvergence:
+    """Convergence assessment for a single finding/question."""
+
+    question_index: int
+    question_text: str
+    alpha: float  # Krippendorff's alpha
+    level: ConvergenceLevel
+    per_model: list[ModelDistribution]  # One per model
+    top_choice_agreement: bool  # Do all models agree on the top choice?
+    divergent_models: list[str]  # Models whose top choice differs from majority
+    interpretation: str  # Human-readable summary
+
+
+@dataclass(frozen=True)
+class ConvergenceReport:
+    """Full convergence analysis across all questions in a multi-model run."""
+
+    findings: list[FindingConvergence]
+    overall_alpha: float  # Mean alpha across all questions
+    overall_level: ConvergenceLevel  # Classification of overall alpha
+    n_convergent: int  # Findings with alpha >= 0.60
+    n_divergent: int  # Findings with alpha < 0.40
+    n_models: int
+    model_names: list[str]
+
+
+def _classify_alpha(alpha: float) -> ConvergenceLevel:
+    """Classify an alpha value into a convergence level."""
+    if alpha >= 0.80:
+        return ConvergenceLevel.STRONG
+    elif alpha >= 0.60:
+        return ConvergenceLevel.MODERATE
+    elif alpha >= 0.40:
+        return ConvergenceLevel.WEAK
+    else:
+        return ConvergenceLevel.NONE
+
+
+def convergence_report(
+    multi_model_responses: dict[str, list[list[str]]],
+    question_texts: list[str],
+    *,
+    level_of_measurement: str = "nominal",
+) -> ConvergenceReport:
+    """Classify cross-model convergence for each question in a multi-model run.
+
+    Args:
+        multi_model_responses: model_name -> list of lists.
+            Outer list: one entry per persona (length N).
+            Inner list: one response per question (length Q).
+            All models must have the same N and Q.
+
+        question_texts: List of Q question text strings (for reporting).
+
+        level_of_measurement: Passed to krippendorff_alpha.
+            "nominal" for pick-one-of-N, "ordinal" for rankings/Likert.
+
+    Returns:
+        ConvergenceReport with per-question and overall convergence.
+
+    Raises:
+        ValueError: If models have inconsistent N or Q, fewer than 2 models,
+                    or question_texts length doesn't match Q.
+    """
+    model_names = list(multi_model_responses.keys())
+    n_models = len(model_names)
+
+    if n_models < 2:
+        raise ValueError(f"Need at least 2 models, got {n_models}")
+
+    # Validate consistent shapes
+    first_model = model_names[0]
+    n_personas = len(multi_model_responses[first_model])
+
+    for model in model_names:
+        if len(multi_model_responses[model]) != n_personas:
+            raise ValueError(
+                f"Model {model!r} has {len(multi_model_responses[model])} personas, "
+                f"expected {n_personas} (from {first_model!r})"
+            )
+
+    # Determine Q from first persona of first model
+    if n_personas == 0:
+        raise ValueError("Models must have at least 1 persona")
+
+    n_questions = len(multi_model_responses[first_model][0])
+
+    for model in model_names:
+        for p_idx, persona_responses in enumerate(multi_model_responses[model]):
+            if len(persona_responses) != n_questions:
+                raise ValueError(
+                    f"Model {model!r} persona {p_idx} has {len(persona_responses)} "
+                    f"questions, expected {n_questions}"
+                )
+
+    if len(question_texts) != n_questions:
+        raise ValueError(
+            f"question_texts has {len(question_texts)} entries but data has {n_questions} questions"
+        )
+
+    findings: list[FindingConvergence] = []
+
+    for q in range(n_questions):
+        # Build ratings matrix: [M raters][N items]
+        reliability_data: list[list[str]] = []
+        for model in model_names:
+            rater_row = [multi_model_responses[model][n][q] for n in range(n_personas)]
+            reliability_data.append(rater_row)
+
+        # Compute alpha
+        alpha_result = krippendorff_alpha(reliability_data, level_of_measurement)
+        alpha_q = alpha_result.alpha
+
+        # Classify
+        level = _classify_alpha(alpha_q)
+
+        # Per-model distributions
+        per_model: list[ModelDistribution] = []
+        model_top_choices: dict[str, str] = {}
+
+        for model in model_names:
+            responses_m = [multi_model_responses[model][n][q] for n in range(n_personas)]
+            counts = Counter(responses_m)
+            total = len(responses_m)
+            distribution = {cat: cnt / total for cat, cnt in sorted(counts.items())}
+            top_choice = counts.most_common(1)[0][0]
+            model_top_choices[model] = top_choice
+
+            per_model.append(
+                ModelDistribution(
+                    model=model,
+                    distribution=distribution,
+                    n=total,
+                    top_choice=top_choice,
+                )
+            )
+
+        # Divergent model detection: majority top choice
+        top_choice_counts = Counter(model_top_choices.values())
+        majority_top = top_choice_counts.most_common(1)[0][0]
+        divergent = [m for m in model_names if model_top_choices[m] != majority_top]
+        top_choice_agreement = len(divergent) == 0
+
+        # Interpretation
+        if level == ConvergenceLevel.STRONG:
+            interpretation = (
+                f"Strong convergence (alpha={alpha_q:.2f}). "
+                f"All models agree: {majority_top} is the top choice."
+            )
+        elif level == ConvergenceLevel.MODERATE:
+            interpretation = (
+                f"Moderate convergence (alpha={alpha_q:.2f}). "
+                f"Models mostly agree on {majority_top} but with some variation."
+            )
+        elif level == ConvergenceLevel.WEAK:
+            interpretation = (
+                f"Weak convergence (alpha={alpha_q:.2f}). "
+                f"Interpret with caution. {divergent} disagree with the majority."
+            )
+        else:
+            interpretation = (
+                f"No convergence (alpha={alpha_q:.2f}). "
+                f"Model choice dominates this finding. {divergent} diverge. Not reliable."
+            )
+
+        findings.append(
+            FindingConvergence(
+                question_index=q,
+                question_text=question_texts[q],
+                alpha=alpha_q,
+                level=level,
+                per_model=per_model,
+                top_choice_agreement=top_choice_agreement,
+                divergent_models=divergent,
+                interpretation=interpretation,
+            )
+        )
+
+    # Overall metrics
+    overall_alpha = sum(f.alpha for f in findings) / len(findings)
+    overall_level = _classify_alpha(overall_alpha)
+    n_convergent = sum(1 for f in findings if f.alpha >= 0.60)
+    n_divergent = sum(1 for f in findings if f.alpha < 0.40)
+
+    return ConvergenceReport(
+        findings=findings,
+        overall_alpha=overall_alpha,
+        overall_level=overall_level,
+        n_convergent=n_convergent,
+        n_divergent=n_divergent,
+        n_models=n_models,
+        model_names=model_names,
     )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,13 +1,18 @@
-"""Tests for synth_panel.stats — sp-5on.7 + sp-5on.8."""
+"""Tests for synth_panel.stats — sp-5on.7 + sp-5on.8 + sp-5on.12."""
 
 from __future__ import annotations
 
 import pytest
 
 from synth_panel.stats import (
+    ConvergenceLevel,
+    ConvergenceReport,
+    FindingConvergence,
+    ModelDistribution,
     bootstrap_ci,
     borda_count,
     chi_squared_test,
+    convergence_report,
     frequency_table,
     kendall_w,
     krippendorff_alpha,
@@ -390,3 +395,133 @@ class TestKrippendorffAlpha:
         ]
         result = krippendorff_alpha(data, "nominal")
         assert "caution" in result.interpretation.lower() or "No meaningful" in result.interpretation
+
+
+# ---------------------------------------------------------------------------
+# convergence_report (sp-5on.12)
+# ---------------------------------------------------------------------------
+
+
+class TestConvergenceReport:
+    def test_perfect_agreement(self):
+        """All models give identical responses -> strong convergence."""
+        responses = {
+            "model_a": [["B", "A"], ["B", "A"], ["B", "A"]],
+            "model_b": [["B", "A"], ["B", "A"], ["B", "A"]],
+            "model_c": [["B", "A"], ["B", "A"], ["B", "A"]],
+        }
+        result = convergence_report(
+            responses,
+            ["Q1", "Q2"],
+        )
+        assert result.overall_level == ConvergenceLevel.STRONG
+        assert result.overall_alpha == pytest.approx(1.0)
+        assert result.n_convergent == 2
+        assert result.n_divergent == 0
+        for f in result.findings:
+            assert f.top_choice_agreement is True
+            assert f.divergent_models == []
+
+    def test_total_disagreement(self):
+        """Models systematically disagree -> no convergence."""
+        # 3 models, 6 personas, 1 question.
+        # Model A always says X, Model B always says Y, Model C always says Z.
+        responses = {
+            "model_a": [["X"]] * 6,
+            "model_b": [["Y"]] * 6,
+            "model_c": [["Z"]] * 6,
+        }
+        result = convergence_report(responses, ["Q1"])
+        assert result.overall_level == ConvergenceLevel.NONE
+        assert result.overall_alpha < 0.1
+        assert result.n_divergent == 1
+
+    def test_partial_convergence(self):
+        """Two models agree, one diverges on some questions."""
+        # Q1: all agree on B. Q2: model_c diverges.
+        responses = {
+            "model_a": [["B", "X"], ["B", "X"], ["B", "X"], ["B", "X"]],
+            "model_b": [["B", "X"], ["B", "X"], ["B", "X"], ["B", "X"]],
+            "model_c": [["B", "Y"], ["B", "Y"], ["B", "Y"], ["B", "Y"]],
+        }
+        result = convergence_report(responses, ["Q1", "Q2"])
+        # Q1: all agree, alpha = 1.0
+        assert result.findings[0].level == ConvergenceLevel.STRONG
+        assert result.findings[0].top_choice_agreement is True
+        # Q2: model_c diverges completely
+        assert result.findings[1].alpha < 0.5
+        assert "model_c" in result.findings[1].divergent_models
+
+    def test_divergent_model_identified(self):
+        """The divergent model should be named."""
+        responses = {
+            "gemini": [["A"]] * 5,
+            "haiku": [["A"]] * 5,
+            "gpt4o": [["B"]] * 5,
+        }
+        result = convergence_report(responses, ["Q1"])
+        assert "gpt4o" in result.findings[0].divergent_models
+        assert "gemini" not in result.findings[0].divergent_models
+
+    def test_per_model_distributions(self):
+        """Per-model distribution should reflect actual response proportions."""
+        responses = {
+            "model_a": [["X"], ["X"], ["Y"], ["X"]],
+            "model_b": [["X"], ["Y"], ["Y"], ["Y"]],
+        }
+        result = convergence_report(responses, ["Q1"])
+        for md in result.findings[0].per_model:
+            if md.model == "model_a":
+                assert md.distribution["X"] == pytest.approx(0.75)
+                assert md.top_choice == "X"
+            if md.model == "model_b":
+                assert md.distribution["Y"] == pytest.approx(0.75)
+                assert md.top_choice == "Y"
+
+    def test_ordinal_level(self):
+        """Should pass ordinal level_of_measurement through to alpha."""
+        responses = {
+            "m1": [["1", "2"], ["1", "2"], ["1", "2"]],
+            "m2": [["1", "2"], ["1", "2"], ["2", "1"]],
+        }
+        result = convergence_report(
+            responses, ["Q1", "Q2"],
+            level_of_measurement="ordinal",
+        )
+        assert isinstance(result.overall_alpha, float)
+
+    def test_fewer_than_2_models_rejects(self):
+        with pytest.raises(ValueError, match="model"):
+            convergence_report({"only_one": [["A"]]}, ["Q1"])
+
+    def test_inconsistent_n_rejects(self):
+        """Models must have the same number of personas."""
+        with pytest.raises(ValueError):
+            convergence_report(
+                {"m1": [["A"], ["A"]], "m2": [["A"]]},
+                ["Q1"],
+            )
+
+    def test_inconsistent_q_rejects(self):
+        """Models must have the same number of questions per persona."""
+        with pytest.raises(ValueError):
+            convergence_report(
+                {"m1": [["A", "B"]], "m2": [["A"]]},
+                ["Q1", "Q2"],
+            )
+
+    def test_question_texts_length_mismatch_rejects(self):
+        with pytest.raises(ValueError):
+            convergence_report(
+                {"m1": [["A"]], "m2": [["A"]]},
+                ["Q1", "Q2"],  # 2 texts but only 1 question in data
+            )
+
+    def test_report_metadata(self):
+        responses = {
+            "gemini": [["A"], ["B"]],
+            "haiku": [["A"], ["B"]],
+        }
+        result = convergence_report(responses, ["Q1"])
+        assert result.n_models == 2
+        assert set(result.model_names) == {"gemini", "haiku"}

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -482,7 +482,8 @@ class TestConvergenceReport:
             "m2": [["1", "2"], ["1", "2"], ["2", "1"]],
         }
         result = convergence_report(
-            responses, ["Q1", "Q2"],
+            responses,
+            ["Q1", "Q2"],
             level_of_measurement="ordinal",
         )
         assert isinstance(result.overall_alpha, float)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -6,9 +6,6 @@ import pytest
 
 from synth_panel.stats import (
     ConvergenceLevel,
-    ConvergenceReport,
-    FindingConvergence,
-    ModelDistribution,
     bootstrap_ci,
     borda_count,
     chi_squared_test,


### PR DESCRIPTION
## Summary

- Adds cross-model convergence/divergence classification to stats module
- Uses Krippendorff's alpha to classify findings as CONVERGENT/MODERATE/DIVERGENT/CONFLICTING
- **Issue**: sp-5on.12
- **Polecat**: furiosa
- **Tests**: 626 passed, 20 skipped (verified by refinery)

---
*Created by Gas Town Refinery*