### PR TITLE
feat: add rich metadata output for synthbench integration (sp-meta)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -17,6 +17,7 @@ from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cost import ZERO_USAGE, TokenUsage, estimate_cost, format_summary, lookup_pricing
 from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
+from synth_panel.metadata import PanelTimer, build_metadata
 from synth_panel.orchestrator import run_panel_parallel
 from synth_panel.persistence import Session
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
@@ -342,6 +343,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             return 1
 
     client = LLMClient()
+    timer = PanelTimer()
 
     # Run all panelists in parallel via the orchestrator
     panelist_results, _registry, _sessions = run_panel_parallel(
@@ -420,7 +422,22 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         total_usage = panelist_usage
         total_cost_est = panelist_cost_est
 
+    timer.stop()
     synthesis_dict = synthesis_result.to_dict() if synthesis_result else None
+
+    metadata = build_metadata(
+        panelist_model=model,
+        synthesis_model=getattr(args, "synthesis_model", None),
+        panelist_usage=panelist_usage,
+        panelist_cost=panelist_cost_est,
+        synthesis_usage=synthesis_result.usage if synthesis_result else None,
+        synthesis_cost=synthesis_result.cost if synthesis_result else None,
+        total_usage=total_usage,
+        total_cost=total_cost_est,
+        persona_count=len(personas),
+        question_count=len(questions),
+        timer=timer,
+    )
 
     # Output results
     banner = _build_invalid_banner(failure_stats, threshold, strict=strict, strict_violation=strict_violation)
@@ -513,6 +530,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 "model": model,
                 "persona_count": len(personas),
                 "question_count": len(questions),
+                "metadata": metadata,
             }
         else:
             extra = _build_rounds_shape(
@@ -525,6 +543,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 model=model,
                 persona_count=len(personas),
                 question_count=len(questions),
+                metadata=metadata,
             )
         # Surface failure stats + run validity in structured output so
         # downstream consumers (MCP, CI) can gate on it without parsing text.
@@ -666,6 +685,7 @@ def _build_rounds_shape(
     model: str,
     persona_count: int,
     question_count: int,
+    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the rounds-shaped panel output payload.
 
@@ -676,7 +696,7 @@ def _build_rounds_shape(
     single-round case — the final synthesis goes at the top level.
     """
     round_name = instrument.rounds[0].name if instrument.rounds else "default"
-    return {
+    result: dict[str, Any] = {
         "rounds": [
             {
                 "name": round_name,
@@ -694,6 +714,9 @@ def _build_rounds_shape(
         "persona_count": persona_count,
         "question_count": question_count,
     }
+    if metadata is not None:
+        result["metadata"] = metadata
+    return result
 
 
 def handle_pack_list(args: argparse.Namespace, fmt: OutputFormat) -> int:

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -71,6 +71,7 @@ from synth_panel.mcp.data import (
 from synth_panel.mcp.data import (
     save_persona_pack as _data_save_persona_pack,
 )
+from synth_panel.metadata import PanelTimer, build_metadata
 from synth_panel.orchestrator import (
     MultiRoundResult,
     PanelistResult,
@@ -229,6 +230,7 @@ async def _run_panel_async_instrument(
 ) -> dict[str, Any]:
     """Run a (possibly branching) instrument and return v3-shaped response."""
     total = len(personas)
+    timer = PanelTimer()
     await ctx.report_progress(0, total)
 
     mr: MultiRoundResult = await asyncio.wait_for(
@@ -269,10 +271,41 @@ async def _run_panel_async_instrument(
     pricing, _ = lookup_pricing(model)
     total_cost = estimate_cost(mr.usage, pricing)
 
+    timer.stop()
+
     final_synth_dict = (
         mr.final_synthesis.to_dict()
         if mr.final_synthesis is not None and hasattr(mr.final_synthesis, "to_dict")
         else None
+    )
+
+    # Compute per-model cost breakdown for metadata
+    panelist_usage = ZERO_USAGE
+    for rr in mr.rounds:
+        for pr in rr.panelist_results:
+            panelist_usage = panelist_usage + pr.usage
+    panelist_cost_est = estimate_cost(panelist_usage, pricing)
+
+    synthesis_usage_for_meta: CostTokenUsage | None = None
+    synthesis_cost_for_meta = None
+    if mr.final_synthesis is not None and hasattr(mr.final_synthesis, "usage"):
+        synthesis_usage_for_meta = mr.final_synthesis.usage
+        synth_model = getattr(mr.final_synthesis, "model", model)
+        synth_pricing, _ = lookup_pricing(synth_model)
+        synthesis_cost_for_meta = estimate_cost(synthesis_usage_for_meta, synth_pricing)
+
+    inst_metadata = build_metadata(
+        panelist_model=model,
+        synthesis_model=getattr(mr.final_synthesis, "model", None) if mr.final_synthesis else None,
+        panelist_usage=panelist_usage,
+        panelist_cost=panelist_cost_est,
+        synthesis_usage=synthesis_usage_for_meta,
+        synthesis_cost=synthesis_cost_for_meta,
+        total_usage=mr.usage,
+        total_cost=total_cost,
+        persona_count=len(personas),
+        question_count=total_question_count,
+        timer=timer,
     )
 
     result_id = save_panel_result(
@@ -299,6 +332,7 @@ async def _run_panel_async_instrument(
         # Back-compat: ``results`` mirrors the terminal round's flat panelist
         # list so v1/v2 callers see the same shape they did pre-0.5.0.
         "results": flat_results,
+        "metadata": inst_metadata,
     }
 
 
@@ -315,6 +349,7 @@ async def _run_panel_async(
 ) -> dict[str, Any]:
     """Run panel via asyncio.to_thread with progress notifications."""
     total = len(personas)
+    timer = PanelTimer()
     await ctx.report_progress(0, total)
 
     # Run the blocking panel execution in a thread
@@ -335,15 +370,32 @@ async def _run_panel_async(
     await ctx.report_progress(total, total)
 
     # Compute total cost (panelist + synthesis)
+    synthesis_usage_obj: CostTokenUsage | None = None
+    synthesis_cost_obj = None
     if synthesis_dict:
-        synthesis_usage = CostTokenUsage.from_dict(synthesis_dict["usage"])
+        synthesis_usage_obj = CostTokenUsage.from_dict(synthesis_dict["usage"])
         synthesis_pricing, _ = lookup_pricing(synthesis_dict.get("model"))
-        synthesis_cost_est = estimate_cost(synthesis_usage, synthesis_pricing)
-        total_usage = panelist_usage + synthesis_usage
-        total_cost = panelist_cost + synthesis_cost_est
+        synthesis_cost_obj = estimate_cost(synthesis_usage_obj, synthesis_pricing)
+        total_usage = panelist_usage + synthesis_usage_obj
+        total_cost = panelist_cost + synthesis_cost_obj
     else:
         total_usage = panelist_usage
         total_cost = panelist_cost
+
+    timer.stop()
+    metadata = build_metadata(
+        panelist_model=model,
+        synthesis_model=synthesis_dict.get("model") if synthesis_dict else None,
+        panelist_usage=panelist_usage,
+        panelist_cost=panelist_cost,
+        synthesis_usage=synthesis_usage_obj,
+        synthesis_cost=synthesis_cost_obj,
+        total_usage=total_usage,
+        total_cost=total_cost,
+        persona_count=len(personas),
+        question_count=len(questions),
+        timer=timer,
+    )
 
     # Save result
     result_id = save_panel_result(
@@ -373,6 +425,7 @@ async def _run_panel_async(
         ],
         "path": [],
         "warnings": [],
+        "metadata": metadata,
     }
 
 

--- a/src/synth_panel/metadata.py
+++ b/src/synth_panel/metadata.py
@@ -1,0 +1,149 @@
+"""Rich metadata for synthpanel JSON output (synthbench integration).
+
+Builds the top-level ``metadata`` key that synthbench consumes for
+reproducibility tracking, cost attribution, and run provenance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import time
+from typing import Any
+
+from synth_panel.cost import CostEstimate, TokenUsage, lookup_pricing
+from synth_panel.llm.aliases import resolve_alias
+
+
+def _get_synthpanel_version() -> str:
+    """Return the installed synthpanel version."""
+    try:
+        from importlib.metadata import version
+
+        return version("synth-panel")
+    except Exception:
+        from synth_panel import __version__
+
+        return __version__
+
+
+def _get_python_version() -> str:
+    return platform.python_version()
+
+
+def build_config_hash(config: dict[str, Any]) -> str:
+    """SHA256 of deterministically serialized config for reproducibility."""
+    serialized = json.dumps(config, sort_keys=True, default=str)
+    return hashlib.sha256(serialized.encode()).hexdigest()
+
+
+class PanelTimer:
+    """Wall-clock timer for panel execution."""
+
+    def __init__(self) -> None:
+        self._start = time.monotonic()
+        self._end: float | None = None
+
+    def stop(self) -> None:
+        self._end = time.monotonic()
+
+    @property
+    def total_seconds(self) -> float:
+        end = self._end if self._end is not None else time.monotonic()
+        return round(end - self._start, 2)
+
+
+def build_metadata(
+    *,
+    panelist_model: str,
+    synthesis_model: str | None = None,
+    panelist_usage: TokenUsage,
+    panelist_cost: CostEstimate,
+    synthesis_usage: TokenUsage | None = None,
+    synthesis_cost: CostEstimate | None = None,
+    total_usage: TokenUsage,
+    total_cost: CostEstimate,
+    persona_count: int,
+    question_count: int,
+    timer: PanelTimer | None = None,
+) -> dict[str, Any]:
+    """Build the ``metadata`` dict for synthbench integration.
+
+    Parameters correspond to data already available at the call site in
+    both CLI and MCP output paths — no new tracking infrastructure is
+    required.
+    """
+    resolved_panelist = resolve_alias(panelist_model)
+    resolved_synthesis = resolve_alias(synthesis_model) if synthesis_model else resolved_panelist
+
+    # -- generation_params --
+    generation_params: dict[str, Any] = {
+        "temperature": None,
+        "top_p": None,
+        "max_tokens": 4096,
+    }
+
+    # -- models --
+    models: dict[str, str] = {
+        "panelist": resolved_panelist,
+        "synthesis": resolved_synthesis,
+    }
+
+    # -- cost --
+    _panelist_pricing, _ = lookup_pricing(panelist_model)
+    per_model: dict[str, Any] = {
+        resolved_panelist: {
+            "tokens": panelist_usage.total_tokens,
+            "cost_usd": round(panelist_cost.total_cost, 6),
+        },
+    }
+    if synthesis_usage is not None and synthesis_cost is not None and resolved_synthesis != resolved_panelist:
+        per_model[resolved_synthesis] = {
+            "tokens": synthesis_usage.total_tokens,
+            "cost_usd": round(synthesis_cost.total_cost, 6),
+        }
+    elif synthesis_usage is not None and synthesis_cost is not None:
+        # Same model — merge into existing entry
+        existing = per_model[resolved_panelist]
+        existing["tokens"] += synthesis_usage.total_tokens
+        existing["cost_usd"] = round(existing["cost_usd"] + synthesis_cost.total_cost, 6)
+
+    cost: dict[str, Any] = {
+        "total_tokens": total_usage.total_tokens,
+        "total_cost_usd": round(total_cost.total_cost, 6),
+        "per_model": per_model,
+    }
+
+    # -- timing --
+    timing: dict[str, float] = {}
+    if timer is not None:
+        total_secs = timer.total_seconds
+        timing = {
+            "total_seconds": total_secs,
+            "per_panelist_avg": round(total_secs / max(persona_count, 1), 2),
+        }
+
+    # -- version --
+    version: dict[str, str] = {
+        "synthpanel": _get_synthpanel_version(),
+        "python": _get_python_version(),
+    }
+
+    # -- config_hash --
+    config_for_hash: dict[str, Any] = {
+        "panelist_model": resolved_panelist,
+        "synthesis_model": resolved_synthesis,
+        "persona_count": persona_count,
+        "question_count": question_count,
+        "generation_params": generation_params,
+    }
+
+    return {
+        "generation_params": generation_params,
+        "models": models,
+        "cost": cost,
+        "timing": timing,
+        "version": version,
+        "config_hash": build_config_hash(config_for_hash),
+    }

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,245 @@
+"""Tests for synth_panel.metadata — rich metadata for synthbench integration."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from synth_panel.cost import CostEstimate, TokenUsage, estimate_cost, lookup_pricing
+from synth_panel.metadata import PanelTimer, build_config_hash, build_metadata
+
+
+class TestBuildConfigHash:
+    def test_deterministic(self):
+        config = {"model": "haiku", "persona_count": 3}
+        h1 = build_config_hash(config)
+        h2 = build_config_hash(config)
+        assert h1 == h2
+
+    def test_order_independent(self):
+        h1 = build_config_hash({"a": 1, "b": 2})
+        h2 = build_config_hash({"b": 2, "a": 1})
+        assert h1 == h2
+
+    def test_different_configs_different_hashes(self):
+        h1 = build_config_hash({"model": "haiku"})
+        h2 = build_config_hash({"model": "sonnet"})
+        assert h1 != h2
+
+    def test_sha256_length(self):
+        h = build_config_hash({"x": 1})
+        assert len(h) == 64
+
+
+class TestPanelTimer:
+    def test_total_seconds(self):
+        timer = PanelTimer()
+        time.sleep(0.05)
+        timer.stop()
+        assert timer.total_seconds >= 0.04
+        assert timer.total_seconds < 1.0
+
+    def test_stop_freezes_time(self):
+        timer = PanelTimer()
+        timer.stop()
+        t1 = timer.total_seconds
+        time.sleep(0.05)
+        t2 = timer.total_seconds
+        assert t1 == t2
+
+
+class TestBuildMetadata:
+    def _make_usage(self, inp: int = 100, out: int = 50) -> TokenUsage:
+        return TokenUsage(input_tokens=inp, output_tokens=out)
+
+    def _make_cost(self, usage: TokenUsage, model: str = "haiku") -> CostEstimate:
+        pricing, _ = lookup_pricing(model)
+        return estimate_cost(usage, pricing)
+
+    def test_basic_structure(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=3,
+            question_count=5,
+        )
+        assert "generation_params" in meta
+        assert "models" in meta
+        assert "cost" in meta
+        assert "timing" in meta
+        assert "version" in meta
+        assert "config_hash" in meta
+
+    def test_generation_params_defaults(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        gp = meta["generation_params"]
+        assert gp["temperature"] is None
+        assert gp["top_p"] is None
+        assert gp["max_tokens"] == 4096
+
+    def test_models_resolved(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        meta = build_metadata(
+            panelist_model="haiku",
+            synthesis_model="sonnet",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        models = meta["models"]
+        # Aliases are resolved to canonical model names
+        assert models["panelist"] != "haiku"
+        assert "claude" in models["panelist"]
+        assert models["synthesis"] != "sonnet"
+        assert "claude" in models["synthesis"]
+
+    def test_cost_breakdown(self):
+        p_usage = self._make_usage(100, 50)
+        s_usage = self._make_usage(200, 100)
+        p_cost = self._make_cost(p_usage, "haiku")
+        s_cost = self._make_cost(s_usage, "sonnet")
+        total_usage = p_usage + s_usage
+        total_cost = p_cost + s_cost
+        meta = build_metadata(
+            panelist_model="haiku",
+            synthesis_model="sonnet",
+            panelist_usage=p_usage,
+            panelist_cost=p_cost,
+            synthesis_usage=s_usage,
+            synthesis_cost=s_cost,
+            total_usage=total_usage,
+            total_cost=total_cost,
+            persona_count=2,
+            question_count=3,
+        )
+        cost_meta = meta["cost"]
+        assert cost_meta["total_tokens"] == total_usage.total_tokens
+        assert cost_meta["total_cost_usd"] > 0
+        assert len(cost_meta["per_model"]) == 2
+
+    def test_cost_same_model_merged(self):
+        p_usage = self._make_usage(100, 50)
+        s_usage = self._make_usage(200, 100)
+        p_cost = self._make_cost(p_usage, "haiku")
+        s_cost = self._make_cost(s_usage, "haiku")
+        total_usage = p_usage + s_usage
+        total_cost = p_cost + s_cost
+        meta = build_metadata(
+            panelist_model="haiku",
+            synthesis_model="haiku",
+            panelist_usage=p_usage,
+            panelist_cost=p_cost,
+            synthesis_usage=s_usage,
+            synthesis_cost=s_cost,
+            total_usage=total_usage,
+            total_cost=total_cost,
+            persona_count=2,
+            question_count=3,
+        )
+        # Same model — should be merged into one entry
+        assert len(meta["cost"]["per_model"]) == 1
+
+    def test_timing_with_timer(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        timer = PanelTimer()
+        time.sleep(0.05)
+        timer.stop()
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=3,
+            question_count=1,
+            timer=timer,
+        )
+        assert meta["timing"]["total_seconds"] >= 0.04
+        assert meta["timing"]["per_panelist_avg"] >= 0.01
+
+    def test_timing_empty_without_timer(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        assert meta["timing"] == {}
+
+    def test_version_present(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        assert "synthpanel" in meta["version"]
+        assert "python" in meta["version"]
+        assert "." in meta["version"]["python"]
+
+    def test_config_hash_stable(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        kwargs = dict(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=2,
+            question_count=3,
+        )
+        m1 = build_metadata(**kwargs)
+        m2 = build_metadata(**kwargs)
+        assert m1["config_hash"] == m2["config_hash"]
+
+    def test_json_serializable(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        timer = PanelTimer()
+        timer.stop()
+        meta = build_metadata(
+            panelist_model="haiku",
+            synthesis_model="sonnet",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=2,
+            question_count=3,
+            timer=timer,
+        )
+        # Must be JSON-serializable without errors
+        serialized = json.dumps(meta)
+        parsed = json.loads(serialized)
+        assert parsed["models"]["panelist"] == meta["models"]["panelist"]


### PR DESCRIPTION
## Summary

- Adds top-level `metadata` key to panel run JSON output containing generation params, models, cost, timing, version, and config hash
- Provides the contract interface that synthbench needs for integration

- **Issue**: sp-meta
- **Polecat**: capable
- **Branch**: polecat/capable-mntkqqln
- **Tests**: 682 passed (verified by refinery)

---
*Created by Gas Town Refinery*