### PR TITLE
feat: add multi-model ensemble with per-persona model routing (sp-blend)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -74,6 +74,81 @@ def _resolve_model(args: argparse.Namespace) -> str:
     return alias
 
 
+def parse_models_spec(spec: str) -> list[tuple[str, float]]:
+    """Parse a --models spec string into [(model, weight)] pairs.
+
+    Format: "haiku:0.5,gemini-2.5-flash:0.5"
+    Weights must be positive and are normalized to sum to 1.0.
+    """
+    pairs: list[tuple[str, float]] = []
+    for entry in spec.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            raise ValueError(f"Invalid model spec entry '{entry}': expected 'model:weight' (e.g. 'haiku:0.5')")
+        model_part, weight_str = entry.rsplit(":", 1)
+        model_part = model_part.strip()
+        weight_str = weight_str.strip()
+        if not model_part:
+            raise ValueError(f"Empty model name in spec entry '{entry}'")
+        try:
+            weight = float(weight_str)
+        except ValueError as exc:
+            raise ValueError(f"Invalid weight '{weight_str}' in spec entry '{entry}': must be a number") from exc
+        if weight <= 0:
+            raise ValueError(f"Weight must be positive, got {weight} for model '{model_part}'")
+        pairs.append((model_part, weight))
+    if not pairs:
+        raise ValueError("Empty --models spec")
+    return pairs
+
+
+def assign_models_to_personas(
+    personas: list[dict[str, Any]],
+    model_spec: list[tuple[str, float]],
+    default_model: str,
+) -> dict[str, str]:
+    """Assign models to personas based on weighted spec and YAML overrides.
+
+    Resolution order: persona YAML 'model' field > weighted assignment > default.
+    Returns a dict mapping persona name → resolved model.
+    """
+    # Personas with YAML model overrides are pre-assigned
+    needs_assignment: list[str] = []
+    result: dict[str, str] = {}
+    for p in personas:
+        name = p.get("name", "Anonymous")
+        if p.get("model"):
+            result[name] = p["model"]
+        else:
+            needs_assignment.append(name)
+
+    if not needs_assignment:
+        return result
+
+    # Normalize weights
+    total_weight = sum(w for _, w in model_spec)
+    normalized = [(m, w / total_weight) for m, w in model_spec]
+
+    # Assign proportionally: distribute personas across models by weight
+    remaining = len(needs_assignment)
+    assigned_idx = 0
+    for i, (model, weight) in enumerate(normalized):
+        if i == len(normalized) - 1:
+            # Last model gets all remaining to avoid rounding gaps
+            count = remaining
+        else:
+            count = max(0, round(weight * len(needs_assignment)))
+            remaining -= count
+        for _ in range(count):
+            if assigned_idx < len(needs_assignment):
+                result[needs_assignment[assigned_idx]] = model
+                assigned_idx += 1
+
+    return result
+
+
 def _announce_default_model(args: argparse.Namespace) -> None:
     """Print the auto-selected default model to stderr.
 
@@ -291,7 +366,15 @@ def _load_schema(value: str) -> dict[str, Any]:
 
 def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run a panel: load personas + instrument, run panelists in parallel."""
-    _announce_default_model(args)
+    # Validate mutual exclusivity of --model and --models
+    has_model = getattr(args, "model", None)
+    has_models = getattr(args, "models", None)
+    if has_model and has_models:
+        print("Error: --model and --models are mutually exclusive.", file=sys.stderr)
+        return 1
+
+    if not has_models:
+        _announce_default_model(args)
     model = _resolve_model(args)
 
     try:
@@ -369,6 +452,26 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     temperature: float | None = getattr(args, "temperature", None)
     top_p: float | None = getattr(args, "top_p", None)
 
+    # ── sp-blend: multi-model ensemble ───────────────────────────────────
+    # Parse --models spec and build per-persona model assignments.
+    # Resolution order: persona YAML 'model' > --models weighted > --model.
+    persona_models: dict[str, str] | None = None
+    if has_models:
+        try:
+            model_spec = parse_models_spec(has_models)
+        except ValueError as exc:
+            print(f"Error parsing --models: {exc}", file=sys.stderr)
+            return 1
+        persona_models = assign_models_to_personas(personas, model_spec, model)
+        # Use the first model in the spec as the "primary" for cost fallback
+        if not has_model:
+            model = model_spec[0][0]
+    elif not has_models:
+        # Even without --models, respect per-persona YAML model overrides
+        yaml_overrides = {p.get("name", "Anonymous"): p["model"] for p in personas if p.get("model")}
+        if yaml_overrides:
+            persona_models = yaml_overrides
+
     client = LLMClient()
     timer = PanelTimer()
 
@@ -384,6 +487,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         extract_schema=extract_schema,
         temperature=temperature,
         top_p=top_p,
+        persona_models=persona_models,
     )
 
     # Build output results and aggregate panelist usage
@@ -391,17 +495,20 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     panelist_usage = ZERO_USAGE
 
     for pr in panelist_results:
-        pricing, is_estimated = lookup_pricing(model)
+        # Use per-panelist model for accurate cost tracking
+        pr_model = pr.model or model
+        pricing, is_estimated = lookup_pricing(pr_model)
         persona_cost = estimate_cost(pr.usage, pricing)
-        results.append(
-            {
-                "persona": pr.persona_name,
-                "responses": pr.responses,
-                "usage": pr.usage.to_dict(),
-                "cost": persona_cost.format_usd(),
-                "error": pr.error,
-            }
-        )
+        result_dict: dict[str, Any] = {
+            "persona": pr.persona_name,
+            "responses": pr.responses,
+            "usage": pr.usage.to_dict(),
+            "cost": persona_cost.format_usd(),
+            "error": pr.error,
+        }
+        if pr.model:
+            result_dict["model"] = pr.model
+        results.append(result_dict)
         panelist_usage = panelist_usage + pr.usage
 
     # ── Failure analysis (sp-2hg) ──────────────────────────────────────

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -85,6 +85,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a YAML file defining the survey/instrument.",
     )
     panel_run_parser.add_argument(
+        "--models",
+        default=None,
+        metavar="SPEC",
+        help=(
+            "Multi-model ensemble spec: comma-separated model:weight pairs. "
+            "E.g. 'haiku:0.5,gemini-2.5-flash:0.5'. Personas are assigned "
+            "models proportionally by weight. Mutually exclusive with --model."
+        ),
+    )
+    panel_run_parser.add_argument(
         "--schema",
         default=None,
         metavar="SCHEMA",

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -126,17 +126,19 @@ def _run_panel_sync(
     panelist_usage = ZERO_USAGE
     result_dicts: list[dict[str, Any]] = []
     for pr in panelist_results:
-        pricing, _ = lookup_pricing(model)
+        pr_model = pr.model or model
+        pricing, _ = lookup_pricing(pr_model)
         persona_cost = estimate_cost(pr.usage, pricing)
-        result_dicts.append(
-            {
-                "persona": pr.persona_name,
-                "responses": pr.responses,
-                "usage": pr.usage.to_dict(),
-                "cost": persona_cost.format_usd(),
-                "error": pr.error,
-            }
-        )
+        rd: dict[str, Any] = {
+            "persona": pr.persona_name,
+            "responses": pr.responses,
+            "usage": pr.usage.to_dict(),
+            "cost": persona_cost.format_usd(),
+            "error": pr.error,
+        }
+        if pr.model:
+            rd["model"] = pr.model
+        result_dicts.append(rd)
         panelist_usage = panelist_usage + pr.usage
 
     pricing, _ = lookup_pricing(model)
@@ -206,15 +208,19 @@ def _run_multi_round_sync(
 
 
 def _format_panelist_result(pr: PanelistResult, model: str) -> dict[str, Any]:
-    pricing, _ = lookup_pricing(model)
+    pr_model = pr.model or model
+    pricing, _ = lookup_pricing(pr_model)
     persona_cost = estimate_cost(pr.usage, pricing)
-    return {
+    rd: dict[str, Any] = {
         "persona": pr.persona_name,
         "responses": pr.responses,
         "usage": pr.usage.to_dict(),
         "cost": persona_cost.format_usd(),
         "error": pr.error,
     }
+    if pr.model:
+        rd["model"] = pr.model
+    return rd
 
 
 async def _run_panel_async_instrument(

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -243,6 +243,7 @@ class PanelistResult:
     responses: list[dict[str, Any]]
     usage: TokenUsage
     error: str | None = None
+    model: str | None = None
 
 
 @dataclass
@@ -458,6 +459,7 @@ def _run_panelist(
             persona_name=name,
             responses=responses,
             usage=tracker.cumulative_usage,
+            model=model,
         )
         return result, session
 
@@ -474,6 +476,7 @@ def _run_panelist(
             responses=responses,
             usage=tracker.cumulative_usage,
             error=str(exc),
+            model=model,
         ), session
 
 
@@ -490,6 +493,7 @@ def run_panel_parallel(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    persona_models: dict[str, str] | None = None,
 ) -> tuple[list[PanelistResult], WorkerRegistry, dict[str, Session]]:
     """Run all panelists in parallel and return ordered results.
 
@@ -497,7 +501,7 @@ def run_panel_parallel(
         client: Shared LLM client (must be thread-safe for concurrent sends).
         personas: List of persona definitions.
         questions: List of question definitions from the instrument.
-        model: Model alias to use for all panelists.
+        model: Default model alias (used when no per-persona override exists).
         system_prompt_fn: Builds system prompt from a persona dict.
         question_prompt_fn: Builds question text from a question dict.
         max_workers: Max concurrent threads. Defaults to number of personas.
@@ -512,6 +516,8 @@ def run_panel_parallel(
             each text response is followed by a second LLM call that extracts
             structured data matching this schema. The result is stored under
             an ``extraction`` key alongside the raw ``response``.
+        persona_models: Optional mapping of persona name → model override.
+            Resolution order: persona_models[name] > model (global default).
 
     Returns:
         Tuple of (ordered results matching persona order, registry,
@@ -537,6 +543,8 @@ def run_panel_parallel(
         for idx, (persona, worker_id) in enumerate(zip(personas, worker_ids)):
             name = persona.get("name", "Anonymous")
             existing_session = (sessions or {}).get(name)
+            # Resolve per-persona model: persona_models mapping > global default
+            effective_model = (persona_models or {}).get(name, model)
             future = executor.submit(
                 _run_panelist,
                 registry,
@@ -544,7 +552,7 @@ def run_panel_parallel(
                 client,
                 persona,
                 questions,
-                model,
+                effective_model,
                 system_prompt_fn,
                 question_prompt_fn,
                 response_schema,
@@ -570,6 +578,7 @@ def run_panel_parallel(
                     responses=[],
                     usage=ZERO_USAGE,
                     error=str(exc),
+                    model=model,
                 )
 
     # All slots should be filled; cast away None
@@ -612,6 +621,7 @@ def run_multi_round_panel(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    persona_models: dict[str, str] | None = None,
 ) -> MultiRoundResult:
     """Execute a (possibly branching) multi-round panel run.
 
@@ -670,6 +680,7 @@ def run_multi_round_panel(
             extract_schema=extract_schema,
             temperature=temperature,
             top_p=top_p,
+            persona_models=persona_models,
         )
 
         synthesis = synthesize_round_fn(client, panelist_results, current.questions, model=model)

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -78,12 +78,14 @@ def patched_panel(monkeypatch):
         extract_schema=None,
         temperature=None,
         top_p=None,
+        persona_models=None,
     ):
         results = [
             PanelistResult(
                 persona_name=p.get("name", "anon"),
                 responses=[{"q": q.get("text", ""), "a": "ok"} for q in questions],
                 usage=ZERO_USAGE,
+                model=(persona_models or {}).get(p.get("name", "anon"), model),
             )
             for p in personas
         ]

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,279 @@
+"""Tests for multi-model ensemble: per-persona model routing (sp-blend)."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from synth_panel.cli.commands import assign_models_to_personas, parse_models_spec
+from synth_panel.cli.parser import build_parser
+from synth_panel.cost import ZERO_USAGE
+from synth_panel.llm.models import (
+    CompletionResponse,
+    StopReason,
+    TextBlock,
+)
+from synth_panel.llm.models import (
+    TokenUsage as LLMTokenUsage,
+)
+from synth_panel.orchestrator import PanelistResult, run_panel_parallel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_text_response(text: str = "Hello!", usage: LLMTokenUsage | None = None) -> CompletionResponse:
+    return CompletionResponse(
+        id="resp-1",
+        model="claude-sonnet",
+        content=[TextBlock(text=text)],
+        stop_reason=StopReason.END_TURN,
+        usage=usage or LLMTokenUsage(input_tokens=10, output_tokens=5),
+    )
+
+
+def _simple_system_prompt(persona: dict[str, Any]) -> str:
+    return f"You are {persona.get('name', 'Anonymous')}."
+
+
+def _simple_question_prompt(question: dict[str, Any]) -> str:
+    if isinstance(question, dict):
+        return question.get("text", str(question))
+    return str(question)
+
+
+def _make_mock_client(responses: list[CompletionResponse] | None = None) -> MagicMock:
+    client = MagicMock()
+    if responses:
+        lock = threading.Lock()
+        resp_list = list(responses)
+
+        def thread_safe_send(request):
+            with lock:
+                if resp_list:
+                    return resp_list.pop(0)
+            return _make_text_response("fallback")
+
+        client.send = MagicMock(side_effect=thread_safe_send)
+    else:
+        client.send = MagicMock(return_value=_make_text_response())
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_models_spec
+# ---------------------------------------------------------------------------
+
+
+class TestParseModelsSpec:
+    def test_basic_two_models(self):
+        result = parse_models_spec("haiku:0.5,gemini-2.5-flash:0.5")
+        assert result == [("haiku", 0.5), ("gemini-2.5-flash", 0.5)]
+
+    def test_single_model(self):
+        result = parse_models_spec("haiku:1.0")
+        assert result == [("haiku", 1.0)]
+
+    def test_three_models_unequal_weights(self):
+        result = parse_models_spec("haiku:0.5,sonnet:0.3,gemini:0.2")
+        assert len(result) == 3
+        assert result[0] == ("haiku", 0.5)
+        assert result[1] == ("sonnet", 0.3)
+        assert result[2] == ("gemini", 0.2)
+
+    def test_whitespace_tolerance(self):
+        result = parse_models_spec(" haiku : 0.5 , gemini : 0.5 ")
+        assert result == [("haiku", 0.5), ("gemini", 0.5)]
+
+    def test_missing_weight_raises(self):
+        with pytest.raises(ValueError, match="expected 'model:weight'"):
+            parse_models_spec("haiku")
+
+    def test_invalid_weight_raises(self):
+        with pytest.raises(ValueError, match="must be a number"):
+            parse_models_spec("haiku:abc")
+
+    def test_zero_weight_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            parse_models_spec("haiku:0")
+
+    def test_negative_weight_raises(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            parse_models_spec("haiku:-1")
+
+    def test_empty_spec_raises(self):
+        with pytest.raises(ValueError, match="Empty --models spec"):
+            parse_models_spec("")
+
+    def test_empty_model_name_raises(self):
+        with pytest.raises(ValueError, match="Empty model name"):
+            parse_models_spec(":0.5")
+
+
+# ---------------------------------------------------------------------------
+# Tests: assign_models_to_personas
+# ---------------------------------------------------------------------------
+
+
+class TestAssignModelsToPersonas:
+    def test_even_split_two_models(self):
+        personas = [{"name": f"P{i}"} for i in range(10)]
+        spec = [("haiku", 0.5), ("gemini", 0.5)]
+        result = assign_models_to_personas(personas, spec, "sonnet")
+        haiku_count = sum(1 for v in result.values() if v == "haiku")
+        gemini_count = sum(1 for v in result.values() if v == "gemini")
+        assert haiku_count == 5
+        assert gemini_count == 5
+
+    def test_uneven_split(self):
+        personas = [{"name": f"P{i}"} for i in range(10)]
+        spec = [("haiku", 0.7), ("gemini", 0.3)]
+        result = assign_models_to_personas(personas, spec, "sonnet")
+        haiku_count = sum(1 for v in result.values() if v == "haiku")
+        gemini_count = sum(1 for v in result.values() if v == "gemini")
+        assert haiku_count == 7
+        assert gemini_count == 3
+
+    def test_yaml_override_takes_precedence(self):
+        personas = [
+            {"name": "Alice", "model": "opus"},
+            {"name": "Bob"},
+            {"name": "Charlie"},
+        ]
+        spec = [("haiku", 0.5), ("gemini", 0.5)]
+        result = assign_models_to_personas(personas, spec, "sonnet")
+        assert result["Alice"] == "opus"
+        # Bob and Charlie get weighted assignment
+        assert result["Bob"] in ("haiku", "gemini")
+        assert result["Charlie"] in ("haiku", "gemini")
+
+    def test_all_yaml_overrides(self):
+        personas = [
+            {"name": "Alice", "model": "opus"},
+            {"name": "Bob", "model": "haiku"},
+        ]
+        spec = [("gemini", 1.0)]
+        result = assign_models_to_personas(personas, spec, "sonnet")
+        assert result["Alice"] == "opus"
+        assert result["Bob"] == "haiku"
+
+    def test_single_persona(self):
+        personas = [{"name": "Solo"}]
+        spec = [("haiku", 0.5), ("gemini", 0.5)]
+        result = assign_models_to_personas(personas, spec, "sonnet")
+        assert len(result) == 1
+        assert result["Solo"] in ("haiku", "gemini")
+
+    def test_all_assigned_to_single_model(self):
+        personas = [{"name": f"P{i}"} for i in range(5)]
+        spec = [("haiku", 1.0)]
+        result = assign_models_to_personas(personas, spec, "sonnet")
+        assert all(v == "haiku" for v in result.values())
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI parser --models
+# ---------------------------------------------------------------------------
+
+
+class TestParserModelsFlag:
+    def test_models_flag_parsed(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml", "--models", "haiku:0.5,gemini:0.5"]
+        )
+        assert args.models == "haiku:0.5,gemini:0.5"
+
+    def test_models_default_none(self):
+        parser = build_parser()
+        args = parser.parse_args(["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"])
+        assert args.models is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: orchestrator per-persona model routing
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorPersonaModels:
+    def test_persona_models_routing(self):
+        """Each panelist result records its assigned model."""
+        client = _make_mock_client()
+        personas = [
+            {"name": "Alice"},
+            {"name": "Bob"},
+        ]
+        questions = [{"text": "Hello?"}]
+        persona_models = {"Alice": "haiku", "Bob": "gemini"}
+
+        results, _reg, _sess = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            persona_models=persona_models,
+        )
+
+        result_map = {r.persona_name: r for r in results}
+        assert result_map["Alice"].model == "haiku"
+        assert result_map["Bob"].model == "gemini"
+
+    def test_default_model_when_no_persona_models(self):
+        """Without persona_models, all panelists use the global model."""
+        client = _make_mock_client()
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Hello?"}]
+
+        results, _reg, _sess = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+        )
+
+        for r in results:
+            assert r.model == "sonnet"
+
+    def test_partial_persona_models(self):
+        """Personas not in persona_models dict fall back to global model."""
+        client = _make_mock_client()
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Hello?"}]
+        persona_models = {"Alice": "haiku"}
+
+        results, _reg, _sess = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+            persona_models=persona_models,
+        )
+
+        result_map = {r.persona_name: r for r in results}
+        assert result_map["Alice"].model == "haiku"
+        assert result_map["Bob"].model == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# Tests: PanelistResult model field
+# ---------------------------------------------------------------------------
+
+
+class TestPanelistResultModel:
+    def test_model_field_default_none(self):
+        pr = PanelistResult(persona_name="Test", responses=[], usage=ZERO_USAGE)
+        assert pr.model is None
+
+    def test_model_field_set(self):
+        pr = PanelistResult(persona_name="Test", responses=[], usage=ZERO_USAGE, model="haiku")
+        assert pr.model == "haiku"


### PR DESCRIPTION
## Summary

- Adds `--models` flag for multi-model ensemble runs with weighted model assignment
- Per-persona model routing via YAML `model` field or `--models` spec
- 23 new tests in test_ensemble.py

- **Issue**: sp-blend
- **Polecat**: furiosa
- **Branch**: polecat/furiosa-mntks5h4
- **Tests**: 705 passed (verified by refinery, 6 conflicts resolved)

---
*Created by Gas Town Refinery*