### PR TITLE
feat: add profile system for named YAML parameter sets (sp-prof)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -149,6 +149,47 @@ def assign_models_to_personas(
     return result
 
 
+def _load_profile(args: argparse.Namespace) -> tuple[Any, int | None]:
+    """Load and apply a profile from --profile or --config.
+
+    Returns ``(profile_or_None, error_exit_code_or_None)``. On error,
+    the message is already printed to stderr and the caller should return
+    the exit code.
+    """
+    from synth_panel.profiles import (
+        Profile,
+        apply_profile_to_args,
+        load_profile_by_name,
+        load_profile_from_path,
+    )
+
+    profile_name = getattr(args, "profile", None)
+    config_path = getattr(args, "config", None)
+
+    if profile_name and config_path:
+        print("Error: --profile and --config are mutually exclusive.", file=sys.stderr)
+        return None, 1
+
+    profile: Profile | None = None
+    if profile_name:
+        try:
+            profile = load_profile_by_name(profile_name)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error loading profile: {exc}", file=sys.stderr)
+            return None, 1
+    elif config_path:
+        try:
+            profile = load_profile_from_path(config_path)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error loading config: {exc}", file=sys.stderr)
+            return None, 1
+
+    if profile is not None:
+        apply_profile_to_args(profile, args)
+
+    return profile, None
+
+
 def _announce_default_model(args: argparse.Namespace) -> None:
     """Print the auto-selected default model to stderr.
 
@@ -366,6 +407,12 @@ def _load_schema(value: str) -> dict[str, Any]:
 
 def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run a panel: load personas + instrument, run panelists in parallel."""
+    # ── sp-prof: profile loading ──────────────────────────────────────
+    # Load profile defaults before anything else so CLI flags can override.
+    profile, profile_err = _load_profile(args)
+    if profile_err is not None:
+        return profile_err
+
     # Validate mutual exclusivity of --model and --models
     has_model = getattr(args, "model", None)
     has_models = getattr(args, "models", None)
@@ -579,6 +626,11 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         question_count=len(questions),
         timer=timer,
     )
+
+    # sp-prof: inject profile info into metadata for synthbench
+    if profile is not None:
+        metadata["profile"] = profile.name
+        metadata["profile_hash"] = profile.config_hash()
 
     # Output results
     banner = _build_invalid_banner(failure_stats, threshold, strict=strict, strict_violation=strict_violation)

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -37,7 +37,17 @@ def build_parser() -> argparse.ArgumentParser:
         "--config",
         default=None,
         metavar="PATH",
-        help="Path to a configuration file.",
+        help="Path to a YAML profile/configuration file.",
+    )
+    parser.add_argument(
+        "--profile",
+        default=None,
+        metavar="NAME",
+        help=(
+            "Named profile to load defaults from. Searches bundled profiles, "
+            "./profiles/, and ~/.synthpanel/profiles/. CLI flags override "
+            "profile values."
+        ),
     )
     parser.add_argument(
         "--output-format",

--- a/src/synth_panel/cli/repl.py
+++ b/src/synth_panel/cli/repl.py
@@ -6,6 +6,7 @@ Entered when no subcommand is given. Supports slash commands per SPEC.md §8.
 from __future__ import annotations
 
 import argparse
+from typing import Any
 
 from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cli.slash import dispatch_slash
@@ -17,7 +18,7 @@ from synth_panel.runtime import AgentRuntime
 class SessionState:
     """Mutable state maintained during an interactive session."""
 
-    __slots__ = ("compacted_count", "last_usage", "model", "runtime", "turn_count")
+    __slots__ = ("compacted_count", "last_usage", "model", "profile", "profile_overrides", "runtime", "turn_count")
 
     def __init__(self, model: str | None = None, runtime: AgentRuntime | None = None) -> None:
         self.turn_count: int = 0
@@ -25,6 +26,8 @@ class SessionState:
         self.model: str | None = model
         self.last_usage: dict[str, int] | None = None
         self.runtime: AgentRuntime | None = runtime
+        self.profile: Any = None
+        self.profile_overrides: dict[str, Any] | None = None
 
 
 PROMPT_CHAR = "\u276f "  # ❯

--- a/src/synth_panel/cli/slash.py
+++ b/src/synth_panel/cli/slash.py
@@ -85,10 +85,41 @@ def _cmd_permissions(state: SessionState, argv: list[str], fmt: OutputFormat) ->
 
 
 def _cmd_config(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:
-    """Inspect configuration."""
-    # TODO: wire to config system
-    section = argv[0] if argv else "all"
-    emit(fmt, message=f"[stub] Config inspection ({section}) not yet implemented.")
+    """Display active profile and available profiles."""
+    from synth_panel.profiles import list_available_profiles
+
+    lines: list[str] = []
+
+    # Show active profile if set
+    active_profile = getattr(state, "profile", None)
+    if active_profile is not None:
+        lines.append(f"Active profile: {active_profile.name}")
+        lines.append(f"  Source: {active_profile.source_path or 'unknown'}")
+        lines.append(f"  Hash:   {active_profile.config_hash()}")
+        profile_dict = active_profile.to_dict()
+        for key, val in profile_dict.items():
+            if key == "name":
+                continue
+            lines.append(f"  {key}: {val}")
+    else:
+        lines.append("No active profile (using CLI defaults)")
+
+    # Show overrides
+    overrides = getattr(state, "profile_overrides", None)
+    if overrides:
+        lines.append("\nCLI overrides applied on top of profile:")
+        for key, val in overrides.items():
+            lines.append(f"  {key}: {val}")
+
+    # List available profiles
+    available = list_available_profiles()
+    if available:
+        lines.append("\nAvailable profiles:")
+        for p in available:
+            marker = " *" if active_profile and p["name"] == active_profile.name else ""
+            lines.append(f"  {p['name']:<16s} ({p['source']}){marker}")
+
+    emit(fmt, message="\n".join(lines))
 
 
 def _cmd_memory(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:

--- a/src/synth_panel/packs/profiles/consumer.yaml
+++ b/src/synth_panel/packs/profiles/consumer.yaml
@@ -1,0 +1,9 @@
+# Consumer research profile — fast, cost-effective runs with moderate diversity.
+name: consumer
+model: haiku
+temperature: 0.7
+top_p: null
+synthesis_model: null
+synthesis_temperature: null
+prompt_template: null
+models: null

--- a/src/synth_panel/packs/profiles/default.yaml
+++ b/src/synth_panel/packs/profiles/default.yaml
@@ -1,0 +1,9 @@
+# Default profile — matches synthpanel's built-in behavior.
+name: default
+model: null
+temperature: null
+top_p: null
+synthesis_model: null
+synthesis_temperature: null
+prompt_template: null
+models: null

--- a/src/synth_panel/packs/profiles/research.yaml
+++ b/src/synth_panel/packs/profiles/research.yaml
@@ -1,0 +1,9 @@
+# Research profile — high-diversity multi-model ensemble for thorough analysis.
+name: research
+model: null
+temperature: 1.0
+top_p: null
+synthesis_model: null
+synthesis_temperature: null
+prompt_template: null
+models: "haiku:0.5,gemini:0.5"

--- a/src/synth_panel/profiles.py
+++ b/src/synth_panel/profiles.py
@@ -1,0 +1,203 @@
+"""Profile system for named YAML parameter sets.
+
+A profile provides default values for CLI flags (model, temperature, etc.)
+that can be loaded by name or path. CLI flags override profile values.
+
+Resolution order: CLI flags > --config/--profile > built-in defaults.
+
+Search order for ``--profile NAME``:
+  1. Bundled profiles (package data: ``src/synth_panel/packs/profiles/``)
+  2. ``./profiles/NAME.yaml`` (working directory)
+  3. ``~/.synthpanel/profiles/NAME.yaml`` (user home)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class Profile:
+    """A named set of default parameter values."""
+
+    name: str
+    model: str | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    synthesis_model: str | None = None
+    synthesis_temperature: float | None = None
+    prompt_template: str | None = None
+    models: str | None = None  # multi-model spec, e.g. "haiku:0.5,gemini:0.5"
+    source_path: str | None = field(default=None, repr=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dict (omitting None values and source_path)."""
+        d: dict[str, Any] = {"name": self.name}
+        if self.model is not None:
+            d["model"] = self.model
+        if self.temperature is not None:
+            d["temperature"] = self.temperature
+        if self.top_p is not None:
+            d["top_p"] = self.top_p
+        if self.synthesis_model is not None:
+            d["synthesis_model"] = self.synthesis_model
+        if self.synthesis_temperature is not None:
+            d["synthesis_temperature"] = self.synthesis_temperature
+        if self.prompt_template is not None:
+            d["prompt_template"] = self.prompt_template
+        if self.models is not None:
+            d["models"] = self.models
+        return d
+
+    def config_hash(self) -> str:
+        """SHA256 hash of the profile for reproducibility tracking."""
+        serialized = json.dumps(self.to_dict(), sort_keys=True)
+        return hashlib.sha256(serialized.encode()).hexdigest()[:16]
+
+
+def _bundled_profiles_dir() -> Path:
+    """Return the path to bundled profiles in package data."""
+    return Path(__file__).parent / "packs" / "profiles"
+
+
+def _cwd_profiles_dir() -> Path:
+    """Return the profiles directory relative to cwd."""
+    return Path.cwd() / "profiles"
+
+
+def _user_profiles_dir() -> Path:
+    """Return the user-level profiles directory."""
+    return Path.home() / ".synthpanel" / "profiles"
+
+
+def load_profile_by_name(name: str) -> Profile:
+    """Load a profile by name from the search path.
+
+    Search order:
+      1. Bundled profiles (package data)
+      2. ./profiles/NAME.yaml
+      3. ~/.synthpanel/profiles/NAME.yaml
+
+    Raises FileNotFoundError if no matching profile is found.
+    """
+    # Normalize: strip .yaml extension if provided
+    if name.endswith(".yaml") or name.endswith(".yml"):
+        name = Path(name).stem
+
+    candidates = [
+        _bundled_profiles_dir() / f"{name}.yaml",
+        _cwd_profiles_dir() / f"{name}.yaml",
+        _user_profiles_dir() / f"{name}.yaml",
+    ]
+    for path in candidates:
+        if path.exists():
+            return _load_profile_from_path(path)
+
+    searched = ", ".join(str(p.parent) for p in candidates)
+    raise FileNotFoundError(f"Profile '{name}' not found. Searched: {searched}")
+
+
+def load_profile_from_path(path: str) -> Profile:
+    """Load a profile from an arbitrary file path (--config)."""
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    return _load_profile_from_path(p)
+
+
+def _load_profile_from_path(path: Path) -> Profile:
+    """Parse a YAML file into a Profile."""
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Profile must be a YAML mapping, got {type(data).__name__}")
+    return Profile(
+        name=data.get("name", path.stem),
+        model=data.get("model"),
+        temperature=_opt_float(data.get("temperature")),
+        top_p=_opt_float(data.get("top_p")),
+        synthesis_model=data.get("synthesis_model"),
+        synthesis_temperature=_opt_float(data.get("synthesis_temperature")),
+        prompt_template=data.get("prompt_template"),
+        models=data.get("models"),
+        source_path=str(path),
+    )
+
+
+def _opt_float(val: Any) -> float | None:
+    """Convert a value to float, treating None as None."""
+    if val is None:
+        return None
+    return float(val)
+
+
+def apply_profile_to_args(profile: Profile, args: Any) -> dict[str, Any]:
+    """Apply profile defaults to argparse args, without overriding explicit CLI flags.
+
+    Returns a dict of which profile fields were applied (for /config display).
+    """
+    applied: dict[str, Any] = {}
+
+    # model: only if --model not given AND --models not given
+    if profile.model and not getattr(args, "model", None) and not getattr(args, "models", None):
+        args.model = profile.model
+        applied["model"] = profile.model
+
+    # temperature
+    if profile.temperature is not None and getattr(args, "temperature", None) is None:
+        args.temperature = profile.temperature
+        applied["temperature"] = profile.temperature
+
+    # top_p
+    if profile.top_p is not None and getattr(args, "top_p", None) is None:
+        args.top_p = profile.top_p
+        applied["top_p"] = profile.top_p
+
+    # synthesis_model
+    if profile.synthesis_model and not getattr(args, "synthesis_model", None):
+        args.synthesis_model = profile.synthesis_model
+        applied["synthesis_model"] = profile.synthesis_model
+
+    # synthesis_temperature
+    if profile.synthesis_temperature is not None and getattr(args, "synthesis_temperature", None) is None:
+        args.synthesis_temperature = profile.synthesis_temperature
+        applied["synthesis_temperature"] = profile.synthesis_temperature
+
+    # prompt_template
+    if profile.prompt_template and not getattr(args, "prompt_template", None):
+        args.prompt_template = profile.prompt_template
+        applied["prompt_template"] = profile.prompt_template
+
+    # models (multi-model spec): only if --models not given AND --model not given
+    if profile.models and not getattr(args, "models", None) and not getattr(args, "model", None):
+        args.models = profile.models
+        applied["models"] = profile.models
+
+    return applied
+
+
+def list_available_profiles() -> list[dict[str, str]]:
+    """List all discoverable profiles across all search paths."""
+    seen: set[str] = set()
+    results: list[dict[str, str]] = []
+    for label, directory in [
+        ("bundled", _bundled_profiles_dir()),
+        ("local", _cwd_profiles_dir()),
+        ("user", _user_profiles_dir()),
+    ]:
+        if not directory.exists():
+            continue
+        for f in sorted(directory.glob("*.yaml")):
+            name = f.stem
+            if name not in seen:
+                seen.add(name)
+                results.append({"name": name, "source": label, "path": str(f)})
+    return results

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,264 @@
+"""Tests for the profile system (sp-prof)."""
+
+from __future__ import annotations
+
+import argparse
+import textwrap
+
+import pytest
+
+from synth_panel.profiles import (
+    Profile,
+    apply_profile_to_args,
+    list_available_profiles,
+    load_profile_by_name,
+    load_profile_from_path,
+)
+
+# --- Profile dataclass ---
+
+
+class TestProfile:
+    def test_to_dict_minimal(self):
+        p = Profile(name="test")
+        assert p.to_dict() == {"name": "test"}
+
+    def test_to_dict_full(self):
+        p = Profile(
+            name="full",
+            model="haiku",
+            temperature=0.7,
+            top_p=0.9,
+            synthesis_model="sonnet",
+            synthesis_temperature=0.3,
+            prompt_template="tpl.j2",
+            models="haiku:0.5,gemini:0.5",
+        )
+        d = p.to_dict()
+        assert d["name"] == "full"
+        assert d["model"] == "haiku"
+        assert d["temperature"] == 0.7
+        assert d["top_p"] == 0.9
+        assert d["synthesis_model"] == "sonnet"
+        assert d["synthesis_temperature"] == 0.3
+        assert d["prompt_template"] == "tpl.j2"
+        assert d["models"] == "haiku:0.5,gemini:0.5"
+
+    def test_config_hash_deterministic(self):
+        p = Profile(name="test", model="haiku", temperature=0.7)
+        h1 = p.config_hash()
+        h2 = p.config_hash()
+        assert h1 == h2
+        assert len(h1) == 16  # truncated sha256
+
+    def test_config_hash_differs_for_different_profiles(self):
+        p1 = Profile(name="a", model="haiku")
+        p2 = Profile(name="b", model="sonnet")
+        assert p1.config_hash() != p2.config_hash()
+
+
+# --- Loading from path ---
+
+
+class TestLoadFromPath:
+    def test_load_valid_profile(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            name: my-profile
+            model: haiku
+            temperature: 0.7
+            top_p: 0.9
+            synthesis_model: sonnet
+            synthesis_temperature: 0.3
+        """)
+        f = tmp_path / "profile.yaml"
+        f.write_text(yaml_content)
+
+        p = load_profile_from_path(str(f))
+        assert p.name == "my-profile"
+        assert p.model == "haiku"
+        assert p.temperature == 0.7
+        assert p.top_p == 0.9
+        assert p.synthesis_model == "sonnet"
+        assert p.synthesis_temperature == 0.3
+        assert p.source_path == str(f)
+
+    def test_load_minimal_profile(self, tmp_path):
+        f = tmp_path / "bare.yaml"
+        f.write_text("name: bare\n")
+        p = load_profile_from_path(str(f))
+        assert p.name == "bare"
+        assert p.model is None
+        assert p.temperature is None
+
+    def test_load_empty_file(self, tmp_path):
+        f = tmp_path / "empty.yaml"
+        f.write_text("")
+        p = load_profile_from_path(str(f))
+        assert p.name == "empty"  # derives name from stem
+
+    def test_load_nonexistent_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_profile_from_path("/nonexistent/path.yaml")
+
+    def test_load_non_mapping_raises(self, tmp_path):
+        f = tmp_path / "bad.yaml"
+        f.write_text("- item1\n- item2\n")
+        with pytest.raises(ValueError, match="YAML mapping"):
+            load_profile_from_path(str(f))
+
+    def test_null_values_parse_as_none(self, tmp_path):
+        yaml_content = textwrap.dedent("""\
+            name: nulls
+            model: null
+            temperature: null
+            top_p: null
+        """)
+        f = tmp_path / "nulls.yaml"
+        f.write_text(yaml_content)
+        p = load_profile_from_path(str(f))
+        assert p.model is None
+        assert p.temperature is None
+        assert p.top_p is None
+
+
+# --- Loading by name ---
+
+
+class TestLoadByName:
+    def test_bundled_default_exists(self):
+        p = load_profile_by_name("default")
+        assert p.name == "default"
+
+    def test_bundled_consumer_exists(self):
+        p = load_profile_by_name("consumer")
+        assert p.name == "consumer"
+        assert p.model == "haiku"
+        assert p.temperature == 0.7
+
+    def test_bundled_research_exists(self):
+        p = load_profile_by_name("research")
+        assert p.name == "research"
+        assert p.temperature == 1.0
+        assert p.models == "haiku:0.5,gemini:0.5"
+
+    def test_nonexistent_profile_raises(self):
+        with pytest.raises(FileNotFoundError, match="not found"):
+            load_profile_by_name("nonexistent-profile-xyz")
+
+    def test_strip_yaml_extension(self):
+        p = load_profile_by_name("default.yaml")
+        assert p.name == "default"
+
+    def test_local_profiles_dir(self, tmp_path, monkeypatch):
+        """Profiles in ./profiles/ are found."""
+        profiles_dir = tmp_path / "profiles"
+        profiles_dir.mkdir()
+        (profiles_dir / "local-test.yaml").write_text("name: local-test\nmodel: opus\n")
+        monkeypatch.chdir(tmp_path)
+        p = load_profile_by_name("local-test")
+        assert p.name == "local-test"
+        assert p.model == "opus"
+
+
+# --- apply_profile_to_args ---
+
+
+class TestApplyProfile:
+    def _make_args(self, **kwargs):
+        ns = argparse.Namespace()
+        ns.model = None
+        ns.models = None
+        ns.temperature = None
+        ns.top_p = None
+        ns.synthesis_model = None
+        ns.synthesis_temperature = None
+        ns.prompt_template = None
+        for k, v in kwargs.items():
+            setattr(ns, k, v)
+        return ns
+
+    def test_applies_all_defaults(self):
+        profile = Profile(
+            name="test",
+            model="haiku",
+            temperature=0.7,
+            synthesis_model="sonnet",
+        )
+        args = self._make_args()
+        applied = apply_profile_to_args(profile, args)
+
+        assert args.model == "haiku"
+        assert args.temperature == 0.7
+        assert args.synthesis_model == "sonnet"
+        assert applied == {"model": "haiku", "temperature": 0.7, "synthesis_model": "sonnet"}
+
+    def test_cli_flags_override_profile(self):
+        profile = Profile(name="test", model="haiku", temperature=0.7)
+        args = self._make_args(model="opus", temperature=1.5)
+        applied = apply_profile_to_args(profile, args)
+
+        assert args.model == "opus"  # CLI wins
+        assert args.temperature == 1.5  # CLI wins
+        assert applied == {}  # nothing was applied from profile
+
+    def test_partial_override(self):
+        profile = Profile(name="test", model="haiku", temperature=0.7, top_p=0.9)
+        args = self._make_args(temperature=1.0)
+        applied = apply_profile_to_args(profile, args)
+
+        assert args.model == "haiku"  # from profile
+        assert args.temperature == 1.0  # CLI override
+        assert args.top_p == 0.9  # from profile
+        assert "temperature" not in applied
+
+    def test_models_spec_applied(self):
+        profile = Profile(name="test", models="haiku:0.5,gemini:0.5")
+        args = self._make_args()
+        applied = apply_profile_to_args(profile, args)
+        assert args.models == "haiku:0.5,gemini:0.5"
+        assert applied["models"] == "haiku:0.5,gemini:0.5"
+
+    def test_models_not_applied_when_model_set(self):
+        profile = Profile(name="test", models="haiku:0.5,gemini:0.5")
+        args = self._make_args(model="opus")
+        applied = apply_profile_to_args(profile, args)
+        assert args.models is None  # not applied
+        assert "models" not in applied
+
+
+# --- list_available_profiles ---
+
+
+class TestListProfiles:
+    def test_includes_bundled(self):
+        profiles = list_available_profiles()
+        names = [p["name"] for p in profiles]
+        assert "default" in names
+        assert "consumer" in names
+        assert "research" in names
+
+    def test_bundled_source(self):
+        profiles = list_available_profiles()
+        for p in profiles:
+            if p["name"] == "default":
+                assert p["source"] == "bundled"
+                break
+
+
+# --- CLI parser integration ---
+
+
+class TestParserProfile:
+    def test_profile_flag_parsed(self):
+        from synth_panel.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["--profile", "consumer", "prompt", "hello"])
+        assert args.profile == "consumer"
+
+    def test_profile_default_none(self):
+        from synth_panel.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["prompt", "hello"])
+        assert args.profile is None


### PR DESCRIPTION
## Summary
- Adds a profile system for named YAML parameter sets (`--profile NAME`, `--config PATH`)
- Resolution order: CLI flags > --config/--profile > default.yaml
- Ships with default, consumer, and research profiles
- Profile name + config_hash included in JSON output metadata for synthbench integration

Resolves sp-prof

## Test plan
- [x] 730 tests passing, 88.64% coverage
- [x] ruff format + ruff check clean
- [x] Rebased cleanly on main (no conflicts)