### PR TITLE
feat: wire /permissions, /memory slash commands and ship 3 bundled instrument packs (sp-stubs)

### DIFF
--- a/examples/instruments/general_survey.yaml
+++ b/examples/instruments/general_survey.yaml
@@ -1,0 +1,40 @@
+# general_survey: broad opinion survey for smoke-testing panel setups.
+#
+# Usage:
+#   synthpanel panel run --personas examples/personas.yaml --instrument examples/instruments/general_survey.yaml
+#
+# This is also available as a bundled pack (no file path needed):
+#   synthpanel panel run --personas examples/personas.yaml --instrument general-survey
+instrument:
+  version: 3
+  rounds:
+    - name: survey
+      questions:
+        - text: >
+            How do you feel about the pace of technology change in your
+            industry?  Is it exciting, overwhelming, or somewhere in
+            between?
+          response_schema:
+            type: text
+        - text: >
+            Describe your ideal work environment.  Remote, in-office,
+            hybrid — and why?
+          response_schema:
+            type: text
+        - text: >
+            What single tool or app could you not live without in your
+            daily work?
+          response_schema:
+            type: text
+        - text: >
+            If you could change one thing about how your team
+            communicates, what would it be?
+          response_schema:
+            type: text
+        - text: >
+            What trend — in your field or in the broader world — are
+            you most optimistic about right now?
+          response_schema:
+            type: text
+      route_when:
+        - else: __end__

--- a/examples/instruments/market_research.yaml
+++ b/examples/instruments/market_research.yaml
@@ -1,0 +1,43 @@
+# market_research: competitive preference, purchase intent, pricing sensitivity.
+#
+# Usage:
+#   synthpanel panel run --personas examples/personas.yaml --instrument examples/instruments/market_research.yaml --var problem="expense tracking"
+#
+# Also available as a bundled pack:
+#   synthpanel panel run --personas examples/personas.yaml --instrument market-research --var problem="expense tracking"
+instrument:
+  version: 3
+  rounds:
+    - name: research
+      questions:
+        - text: >
+            When you think about solving {problem}, what existing
+            products or services come to mind first?  What draws you
+            to each?
+          response_schema:
+            type: text
+        - text: >
+            How do you typically evaluate a new product in this space?
+            What factors matter most — price, features, brand trust,
+            peer recommendations?
+          response_schema:
+            type: text
+        - text: >
+            Imagine a new solution that addressed your top frustration
+            perfectly.  How much would you expect to pay per month for
+            it?  At what price point would you say "no way"?
+          response_schema:
+            type: text
+        - text: >
+            If you were choosing between two products that both solved
+            your problem, what would be the deciding factor for you?
+          response_schema:
+            type: text
+        - text: >
+            How likely are you to switch from your current solution to
+            a new one in the next six months?  What would need to be
+            true for you to make the switch?
+          response_schema:
+            type: text
+      route_when:
+        - else: __end__

--- a/examples/instruments/product_feedback.yaml
+++ b/examples/instruments/product_feedback.yaml
@@ -1,0 +1,40 @@
+# product_feedback: NPS + feature satisfaction + open-ended follow-up.
+#
+# Usage:
+#   synthpanel panel run --personas examples/personas.yaml --instrument examples/instruments/product_feedback.yaml --var product="Acme Widget"
+#
+# Also available as a bundled pack:
+#   synthpanel panel run --personas examples/personas.yaml --instrument product-feedback --var product="Acme Widget"
+instrument:
+  version: 3
+  rounds:
+    - name: feedback
+      questions:
+        - text: >
+            On a scale of 0 to 10, how likely are you to recommend
+            {product} to a friend or colleague?  Please explain your
+            score.
+          response_schema:
+            type: text
+        - text: >
+            How satisfied are you with the core functionality of
+            {product}?  What works well and what feels incomplete?
+          response_schema:
+            type: text
+        - text: >
+            How would you rate the onboarding experience?  Was it
+            easy to get started, or did you hit friction?
+          response_schema:
+            type: text
+        - text: >
+            Think about the last time {product} saved you significant
+            time or effort.  What were you doing?
+          response_schema:
+            type: text
+        - text: >
+            If you could wave a magic wand and change one thing about
+            {product}, what would it be and why?
+          response_schema:
+            type: text
+      route_when:
+        - else: __end__

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1041,23 +1041,33 @@ def handle_instruments_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
 def handle_instruments_install(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Install an instrument pack from a YAML file (or bundled name)."""
-    from synth_panel.mcp.data import save_instrument_pack
+    from synth_panel.mcp.data import load_instrument_pack, save_instrument_pack
 
     source = args.source
-    if not Path(source).exists():
-        print(
-            f"Error: source file not found: {source}\n"
-            f"(bundled instrument packs are not yet shipped — pass a "
-            f"YAML file path)",
-            file=sys.stderr,
-        )
-        return 1
+    data: dict | None = None
 
-    try:
-        data = _load_yaml(source)
-    except (FileNotFoundError, ValueError) as exc:
-        print(f"Error loading file: {exc}", file=sys.stderr)
-        return 1
+    if Path(source).exists():
+        try:
+            data = _load_yaml(source)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error loading file: {exc}", file=sys.stderr)
+            return 1
+    else:
+        # Try loading as a bundled pack name.
+        try:
+            data = load_instrument_pack(source)
+        except FileNotFoundError:
+            from synth_panel.mcp.data import list_instrument_packs
+
+            bundled = [p["id"] for p in list_instrument_packs() if p.get("source") == "bundled"]
+            hint = ", ".join(bundled) if bundled else "(none)"
+            print(
+                f"Error: '{source}' is not a file path or known bundled pack.\n"
+                f"Available bundled packs: {hint}\n"
+                f"Or pass a YAML file path.",
+                file=sys.stderr,
+            )
+            return 1
 
     if not isinstance(data, dict):
         print("Error: instrument pack file must be a YAML mapping", file=sys.stderr)

--- a/src/synth_panel/cli/repl.py
+++ b/src/synth_panel/cli/repl.py
@@ -18,9 +18,25 @@ from synth_panel.runtime import AgentRuntime
 class SessionState:
     """Mutable state maintained during an interactive session."""
 
-    __slots__ = ("compacted_count", "last_usage", "model", "profile", "profile_overrides", "runtime", "turn_count")
+    __slots__ = (
+        "compacted_count",
+        "config_path",
+        "last_usage",
+        "model",
+        "permission_mode",
+        "profile",
+        "profile_overrides",
+        "runtime",
+        "turn_count",
+    )
 
-    def __init__(self, model: str | None = None, runtime: AgentRuntime | None = None) -> None:
+    def __init__(
+        self,
+        model: str | None = None,
+        runtime: AgentRuntime | None = None,
+        permission_mode: str = "full-access",
+        config_path: str | None = None,
+    ) -> None:
         self.turn_count: int = 0
         self.compacted_count: int = 0
         self.model: str | None = model
@@ -28,6 +44,8 @@ class SessionState:
         self.runtime: AgentRuntime | None = runtime
         self.profile: Any = None
         self.profile_overrides: dict[str, Any] | None = None
+        self.permission_mode: str = permission_mode
+        self.config_path: str | None = config_path
 
 
 PROMPT_CHAR = "\u276f "  # ❯
@@ -51,7 +69,12 @@ def run_repl(args: argparse.Namespace, fmt: OutputFormat) -> int:
     client = LLMClient()
     session = Session()
     runtime = AgentRuntime(client=client, session=session, model=model)
-    state = SessionState(model=model, runtime=runtime)
+    state = SessionState(
+        model=model,
+        runtime=runtime,
+        permission_mode=getattr(args, "permission_mode", "full-access") or "full-access",
+        config_path=getattr(args, "config", None),
+    )
 
     print("synthpanel interactive mode. Type /help for commands, Ctrl-D to exit.")
 

--- a/src/synth_panel/cli/slash.py
+++ b/src/synth_panel/cli/slash.py
@@ -75,13 +75,23 @@ def _cmd_model(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:
         emit(fmt, message=f"Current model: {state.model or '(default)'}")
 
 
+_VALID_PERMISSION_MODES = {"read-only", "workspace-write", "full-access"}
+
+
 def _cmd_permissions(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:
     """Show or switch the permission mode."""
-    # TODO: wire to permission state
     if argv:
-        emit(fmt, message=f"[stub] Permission mode set to: {argv[0]}")
+        mode = argv[0]
+        if mode not in _VALID_PERMISSION_MODES:
+            emit(
+                fmt,
+                message=(f"Invalid permission mode: {mode}\nValid modes: {', '.join(sorted(_VALID_PERMISSION_MODES))}"),
+            )
+            return
+        state.permission_mode = mode
+        emit(fmt, message=f"Permission mode set to: {mode}")
     else:
-        emit(fmt, message="[stub] Current permission mode: full-access")
+        emit(fmt, message=f"Current permission mode: {state.permission_mode}")
 
 
 def _cmd_config(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:
@@ -124,8 +134,25 @@ def _cmd_config(state: SessionState, argv: list[str], fmt: OutputFormat) -> None
 
 def _cmd_memory(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:
     """Show loaded instruction/memory files."""
-    # TODO: wire to memory system
-    emit(fmt, message="[stub] No instruction/memory files loaded.")
+    from pathlib import Path
+
+    files: list[str] = []
+
+    if state.config_path:
+        p = Path(state.config_path)
+        if p.exists():
+            files.append(f"  --config: {p} ({p.stat().st_size} bytes)")
+        else:
+            files.append(f"  --config: {state.config_path} (not found)")
+
+    claude_md = Path.cwd() / "CLAUDE.md"
+    if claude_md.exists():
+        files.append(f"  CLAUDE.md: {claude_md} ({claude_md.stat().st_size} bytes)")
+
+    if files:
+        emit(fmt, message="Loaded configuration files:\n" + "\n".join(files))
+    else:
+        emit(fmt, message="No configuration files loaded.")
 
 
 def _cmd_clear(state: SessionState, argv: list[str], fmt: OutputFormat) -> None:

--- a/src/synth_panel/packs/instruments/general-survey.yaml
+++ b/src/synth_panel/packs/instruments/general-survey.yaml
@@ -1,0 +1,46 @@
+# general-survey: broad opinion survey covering technology attitudes,
+# work preferences, and daily habits.  Good for testing panel setups.
+#
+# Single-round v3 instrument (no branching).  Themes emitted by the
+# synthesizer are not routed — all five questions run for every panelist.
+name: general-survey
+version: 1
+description: >
+  Five general opinion questions covering technology attitudes,
+  work preferences, and daily habits.  Useful as a smoke-test for
+  new persona packs or model configurations.
+author: synthpanel
+
+instrument:
+  version: 3
+  rounds:
+    - name: survey
+      questions:
+        - text: >
+            How do you feel about the pace of technology change in your
+            industry?  Is it exciting, overwhelming, or somewhere in
+            between?
+          response_schema:
+            type: text
+        - text: >
+            Describe your ideal work environment.  Remote, in-office,
+            hybrid — and why?
+          response_schema:
+            type: text
+        - text: >
+            What single tool or app could you not live without in your
+            daily work?
+          response_schema:
+            type: text
+        - text: >
+            If you could change one thing about how your team
+            communicates, what would it be?
+          response_schema:
+            type: text
+        - text: >
+            What trend — in your field or in the broader world — are
+            you most optimistic about right now?
+          response_schema:
+            type: text
+      route_when:
+        - else: __end__

--- a/src/synth_panel/packs/instruments/market-research.yaml
+++ b/src/synth_panel/packs/instruments/market-research.yaml
@@ -1,0 +1,50 @@
+# market-research: competitive preference, purchase intent, and
+# pricing sensitivity probes.
+#
+# Single-round v3 instrument (no branching).  Helps gauge how a persona
+# evaluates alternatives and thinks about willingness-to-pay before a
+# product launch or repositioning.
+name: market-research
+version: 1
+description: >
+  Competitive preference, purchase intent, and pricing sensitivity
+  questions.  Useful for pre-launch positioning research or competitive
+  analysis.
+author: synthpanel
+
+instrument:
+  version: 3
+  rounds:
+    - name: research
+      questions:
+        - text: >
+            When you think about solving {problem}, what existing
+            products or services come to mind first?  What draws you
+            to each?
+          response_schema:
+            type: text
+        - text: >
+            How do you typically evaluate a new product in this space?
+            What factors matter most — price, features, brand trust,
+            peer recommendations?
+          response_schema:
+            type: text
+        - text: >
+            Imagine a new solution that addressed your top frustration
+            perfectly.  How much would you expect to pay per month for
+            it?  At what price point would you say "no way"?
+          response_schema:
+            type: text
+        - text: >
+            If you were choosing between two products that both solved
+            your problem, what would be the deciding factor for you?
+          response_schema:
+            type: text
+        - text: >
+            How likely are you to switch from your current solution to
+            a new one in the next six months?  What would need to be
+            true for you to make the switch?
+          response_schema:
+            type: text
+      route_when:
+        - else: __end__

--- a/src/synth_panel/packs/instruments/product-feedback.yaml
+++ b/src/synth_panel/packs/instruments/product-feedback.yaml
@@ -1,0 +1,46 @@
+# product-feedback: NPS + feature satisfaction + open-ended follow-up.
+#
+# Single-round v3 instrument (no branching).  Covers Net Promoter Score,
+# three feature-level satisfaction probes, and one open-ended improvement
+# question.  Suitable for post-launch or quarterly check-in panels.
+name: product-feedback
+version: 1
+description: >
+  NPS question, three feature satisfaction probes, and one open-ended
+  improvement question.  Ideal for post-launch or quarterly product
+  check-ins.
+author: synthpanel
+
+instrument:
+  version: 3
+  rounds:
+    - name: feedback
+      questions:
+        - text: >
+            On a scale of 0 to 10, how likely are you to recommend
+            {product} to a friend or colleague?  Please explain your
+            score.
+          response_schema:
+            type: text
+        - text: >
+            How satisfied are you with the core functionality of
+            {product}?  What works well and what feels incomplete?
+          response_schema:
+            type: text
+        - text: >
+            How would you rate the onboarding experience?  Was it
+            easy to get started, or did you hit friction?
+          response_schema:
+            type: text
+        - text: >
+            Think about the last time {product} saved you significant
+            time or effort.  What were you doing?
+          response_schema:
+            type: text
+        - text: >
+            If you could wave a magic wand and change one thing about
+            {product}, what would it be and why?
+          response_schema:
+            type: text
+      route_when:
+        - else: __end__


### PR DESCRIPTION
## Summary
- Wires up `/permissions` and `/memory` slash commands (previously stubs)
- Ships 3 bundled instrument packs: general-survey, market-research, product-feedback
- Adds corresponding example instruments

Resolves sp-stubs

## Merge notes
- 1 trivial conflict resolved in `repl.py` (non-overlapping `SessionState` fields from sp-prof merge)

## Test plan
- [x] 730 tests passing, 88.19% coverage
- [x] ruff format + ruff check clean
- [x] Rebased cleanly on main (post sp-prof merge)