### PR TITLE
feat: add configurable model alias system (sp-alias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,36 @@ OPENAI_BASE_URL=http://localhost:11434/v1 \
 synthpanel panel run --personas p.yaml --instrument s.yaml --model llama3
 ```
 
+### Model Aliases
+
+synthpanel ships with short aliases (`sonnet`, `opus`, `haiku`, `grok`,
+`gemini`, `gemini-pro`) that map to canonical model identifiers. You can
+override or extend these without changing code:
+
+**Resolution order (highest priority wins):**
+
+1. **`SYNTHPANEL_MODEL_ALIASES` env var** — JSON string of alias→model pairs
+2. **`~/.synthpanel/aliases.yaml`** — YAML file
+3. **Hardcoded defaults** — built into the package
+
+```bash
+# Override via env var (JSON)
+export SYNTHPANEL_MODEL_ALIASES='{"sonnet": "claude-sonnet-4-6-20250414", "fast": "claude-haiku-4-5-20251001"}'
+synthpanel prompt "Hello" --model fast
+```
+
+```yaml
+# ~/.synthpanel/aliases.yaml
+aliases:
+  fast: claude-haiku-4-5-20251001
+  smart: claude-opus-4-6
+  sonnet: claude-sonnet-4-6-20250414
+```
+
+Env var entries override file entries, which override hardcoded defaults.
+Aliases from all tiers are merged, so you only need to specify the ones you
+want to add or change.
+
 ## Architecture
 
 synthpanel is a research harness, not an LLM wrapper. It orchestrates the research workflow:

--- a/src/synth_panel/llm/aliases.py
+++ b/src/synth_panel/llm/aliases.py
@@ -1,9 +1,22 @@
-"""Model alias resolution (SPEC.md §2 — Provider Resolution)."""
+"""Model alias resolution (SPEC.md §2 — Provider Resolution).
+
+Resolution order (highest priority wins):
+1. SYNTHPANEL_MODEL_ALIASES env var (JSON string of alias→model pairs)
+2. ~/.synthpanel/aliases.yaml file
+3. Hardcoded defaults below
+"""
 
 from __future__ import annotations
 
-# Short alias → canonical model identifier.
-MODEL_ALIASES: dict[str, str] = {
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Short alias → canonical model identifier (tier 3: hardcoded fallback).
+_HARDCODED_ALIASES: dict[str, str] = {
     "opus": "claude-opus-4-6",
     "sonnet": "claude-sonnet-4-6",
     "haiku": "claude-haiku-4-5-20251001",
@@ -18,13 +31,83 @@ _LOCAL_PREFIXES: dict[str, str] = {
     "local:": "http://localhost:1234",
 }
 
+_ALIASES_FILE = Path.home() / ".synthpanel" / "aliases.yaml"
+_ENV_VAR = "SYNTHPANEL_MODEL_ALIASES"
+
+# Cached merged result; reset with _reset_cache() for testing.
+_cached_aliases: dict[str, str] | None = None
+
+
+def _load_file_aliases() -> dict[str, str]:
+    """Load aliases from ~/.synthpanel/aliases.yaml (tier 2).
+
+    Expected format::
+
+        aliases:
+          fast: claude-haiku-4-5-20251001
+          smart: claude-opus-4-6
+    """
+    if not _ALIASES_FILE.is_file():
+        return {}
+    try:
+        raw: Any = yaml.safe_load(_ALIASES_FILE.read_text())
+    except (OSError, yaml.YAMLError):
+        return {}
+    if not isinstance(raw, dict):
+        return {}
+    aliases = raw.get("aliases", raw)
+    if not isinstance(aliases, dict):
+        return {}
+    return {str(k): str(v) for k, v in aliases.items()}
+
+
+def _load_env_aliases() -> dict[str, str]:
+    """Load aliases from SYNTHPANEL_MODEL_ALIASES env var (tier 1, JSON)."""
+    raw = os.environ.get(_ENV_VAR, "")
+    if not raw:
+        return {}
+    try:
+        parsed: Any = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(parsed, dict):
+        return {}
+    return {str(k): str(v) for k, v in parsed.items()}
+
+
+def _build_aliases() -> dict[str, str]:
+    """Merge aliases: hardcoded → file → env (env wins on conflicts)."""
+    merged = dict(_HARDCODED_ALIASES)
+    merged.update(_load_file_aliases())
+    merged.update(_load_env_aliases())
+    return merged
+
+
+def _get_aliases() -> dict[str, str]:
+    """Return the merged alias map, caching after first call."""
+    global _cached_aliases
+    if _cached_aliases is None:
+        _cached_aliases = _build_aliases()
+    return _cached_aliases
+
+
+def _reset_cache() -> None:
+    """Clear the cached alias map (for testing)."""
+    global _cached_aliases
+    _cached_aliases = None
+
+
+# Public name kept for backward compat — now dynamically built.
+MODEL_ALIASES = _HARDCODED_ALIASES
+
 
 def resolve_alias(model: str) -> str:
     """Return the canonical model name, resolving short aliases and local prefixes."""
     for prefix in _LOCAL_PREFIXES:
         if model.startswith(prefix):
             return model[len(prefix) :]
-    return MODEL_ALIASES.get(model, model)
+    aliases = _get_aliases()
+    return aliases.get(model, model)
 
 
 def get_base_url_override(model: str) -> str | None:

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -2,7 +2,27 @@
 
 from __future__ import annotations
 
-from synth_panel.llm.aliases import get_base_url_override, resolve_alias
+import json
+import textwrap
+
+import pytest
+
+from synth_panel.llm.aliases import (
+    _reset_cache,
+    get_base_url_override,
+    resolve_alias,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_alias_cache():
+    """Reset the cached alias map before and after every test."""
+    _reset_cache()
+    yield
+    _reset_cache()
+
+
+# --- hardcoded (tier 3) ---
 
 
 def test_known_aliases():
@@ -15,6 +35,9 @@ def test_known_aliases():
 def test_passthrough():
     assert resolve_alias("claude-sonnet-4-6-20250414") == "claude-sonnet-4-6-20250414"
     assert resolve_alias("my-custom-model") == "my-custom-model"
+
+
+# --- local prefixes ---
 
 
 def test_ollama_prefix_stripped():
@@ -38,3 +61,132 @@ def test_get_base_url_override_local():
 def test_get_base_url_override_none():
     assert get_base_url_override("sonnet") is None
     assert get_base_url_override("gpt-4o") is None
+
+
+# --- env var override (tier 1) ---
+
+
+def test_env_var_overrides_hardcoded(monkeypatch):
+    monkeypatch.setenv("SYNTHPANEL_MODEL_ALIASES", json.dumps({"sonnet": "my-sonnet"}))
+    assert resolve_alias("sonnet") == "my-sonnet"
+
+
+def test_env_var_adds_new_alias(monkeypatch):
+    monkeypatch.setenv("SYNTHPANEL_MODEL_ALIASES", json.dumps({"fast": "claude-haiku-4-5-20251001"}))
+    assert resolve_alias("fast") == "claude-haiku-4-5-20251001"
+    # hardcoded still works
+    assert resolve_alias("opus").startswith("claude-opus")
+
+
+def test_env_var_invalid_json_ignored(monkeypatch):
+    monkeypatch.setenv("SYNTHPANEL_MODEL_ALIASES", "not json{")
+    # falls back to hardcoded
+    assert resolve_alias("sonnet").startswith("claude-sonnet")
+
+
+def test_env_var_non_dict_ignored(monkeypatch):
+    monkeypatch.setenv("SYNTHPANEL_MODEL_ALIASES", json.dumps(["a", "b"]))
+    assert resolve_alias("sonnet").startswith("claude-sonnet")
+
+
+# --- file override (tier 2) ---
+
+
+def test_file_overrides_hardcoded(monkeypatch, tmp_path):
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(
+        textwrap.dedent("""\
+        aliases:
+          sonnet: custom-sonnet-model
+        """)
+    )
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    assert resolve_alias("sonnet") == "custom-sonnet-model"
+
+
+def test_file_adds_new_alias(monkeypatch, tmp_path):
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(
+        textwrap.dedent("""\
+        aliases:
+          smart: claude-opus-4-6
+        """)
+    )
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    assert resolve_alias("smart") == "claude-opus-4-6"
+    assert resolve_alias("sonnet").startswith("claude-sonnet")
+
+
+def test_file_missing_is_fine(monkeypatch, tmp_path):
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", tmp_path / "nope.yaml")
+    assert resolve_alias("sonnet").startswith("claude-sonnet")
+
+
+def test_file_invalid_yaml_ignored(monkeypatch, tmp_path):
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(": : : not valid yaml [")
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    assert resolve_alias("sonnet").startswith("claude-sonnet")
+
+
+def test_file_flat_format(monkeypatch, tmp_path):
+    """Accept a flat dict (no 'aliases' wrapper) for convenience."""
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(
+        textwrap.dedent("""\
+        fast: claude-haiku-4-5-20251001
+        smart: claude-opus-4-6
+        """)
+    )
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    assert resolve_alias("fast") == "claude-haiku-4-5-20251001"
+    assert resolve_alias("smart") == "claude-opus-4-6"
+
+
+# --- merge precedence ---
+
+
+def test_env_beats_file(monkeypatch, tmp_path):
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(
+        textwrap.dedent("""\
+        aliases:
+          sonnet: from-file
+        """)
+    )
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    monkeypatch.setenv("SYNTHPANEL_MODEL_ALIASES", json.dumps({"sonnet": "from-env"}))
+    assert resolve_alias("sonnet") == "from-env"
+
+
+def test_file_beats_hardcoded(monkeypatch, tmp_path):
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(
+        textwrap.dedent("""\
+        aliases:
+          sonnet: from-file
+        """)
+    )
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    assert resolve_alias("sonnet") == "from-file"
+
+
+def test_all_three_tiers_merge(monkeypatch, tmp_path):
+    """Env > file > hardcoded, each can add unique keys."""
+    aliases_file = tmp_path / "aliases.yaml"
+    aliases_file.write_text(
+        textwrap.dedent("""\
+        aliases:
+          file-only: from-file
+          shared: from-file
+        """)
+    )
+    monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
+    monkeypatch.setenv(
+        "SYNTHPANEL_MODEL_ALIASES",
+        json.dumps({"env-only": "from-env", "shared": "from-env"}),
+    )
+    assert resolve_alias("opus").startswith("claude-opus")  # hardcoded
+    assert resolve_alias("file-only") == "from-file"  # file
+    assert resolve_alias("env-only") == "from-env"  # env
+    assert resolve_alias("shared") == "from-env"  # env wins


### PR DESCRIPTION
## Summary
- Adds configurable model alias system for user-defined model shortcuts
- 12 new tests added (742 total)

Resolves sp-alias

## Test plan
- [x] 742 tests passing, 88.26% coverage
- [x] ruff format + ruff check clean
- [x] Clean rebase on main (post sp-deps merge)