### PR TITLE
chore: tighten mypy config — enable disallow_untyped_defs, re-enable 6 error codes (sp-mypy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,16 +99,10 @@ known-first-party = ["synth_panel"]
 [tool.mypy]
 python_version = "3.10"
 warn_unused_configs = true
-disallow_untyped_defs = false
-check_untyped_defs = false
+disallow_untyped_defs = true
+check_untyped_defs = true
 ignore_missing_imports = true
 files = ["src/synth_panel"]
 disable_error_code = [
     "import-untyped",
-    "no-any-return",
-    "union-attr",
-    "arg-type",
-    "return-value",
-    "assignment",
-    "var-annotated",
 ]

--- a/src/synth_panel/aggregation.py
+++ b/src/synth_panel/aggregation.py
@@ -178,7 +178,7 @@ def robustness_report(
     if not scorable:
         raise ValueError("no groups with both an original and variants")
 
-    n_questions = max(len(g.original.responses) for g in scorable)
+    n_questions = max(len(g.original.responses) for g in scorable if g.original is not None)
 
     findings: list[FindingRobustness] = []
     per_persona_all: dict[str, list[float]] = {}
@@ -187,10 +187,11 @@ def robustness_report(
         per_persona: dict[str, float] = {}
 
         for group in scorable:
-            if qi >= len(group.original.responses):
+            original = group.original
+            if original is None or qi >= len(original.responses):
                 continue
 
-            ref = extract(group.original.responses[qi])
+            ref = extract(original.responses[qi])
 
             k = 0
             agreements = 0

--- a/src/synth_panel/cli/repl.py
+++ b/src/synth_panel/cli/repl.py
@@ -12,7 +12,7 @@ from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cli.slash import dispatch_slash
 from synth_panel.llm.client import LLMClient
 from synth_panel.persistence import Session
-from synth_panel.runtime import AgentRuntime
+from synth_panel.runtime import AgentRuntime, TurnSummary
 
 
 class SessionState:
@@ -51,7 +51,7 @@ class SessionState:
 PROMPT_CHAR = "\u276f "  # ❯
 
 
-def _extract_response_text(summary) -> str:
+def _extract_response_text(summary: TurnSummary) -> str:
     """Extract plain text from a TurnSummary's assistant messages."""
     parts: list[str] = []
     for msg in summary.assistant_messages:

--- a/src/synth_panel/llm/providers/_openai_format.py
+++ b/src/synth_panel/llm/providers/_openai_format.py
@@ -20,6 +20,7 @@ from synth_panel.llm.models import (
     TokenUsage,
     ToolChoiceKind,
     ToolInvocationBlock,
+    ToolResultBlock,
 )
 
 # ---------------------------------------------------------------------------
@@ -79,7 +80,7 @@ def build_openai_body(
             ]
         else:
             # Check for tool result blocks
-            tool_results = [b for b in msg.content if hasattr(b, "tool_use_id")]
+            tool_results = [b for b in msg.content if isinstance(b, ToolResultBlock)]
             if tool_results:
                 # OpenAI uses role=tool for tool results
                 for tr in tool_results:

--- a/src/synth_panel/llm/providers/anthropic.py
+++ b/src/synth_panel/llm/providers/anthropic.py
@@ -21,6 +21,7 @@ from synth_panel.llm.models import (
     TokenUsage,
     ToolChoiceKind,
     ToolInvocationBlock,
+    ToolResultBlock,
 )
 from synth_panel.llm.providers.base import LLMProvider, ProviderConfig
 
@@ -60,7 +61,7 @@ def _build_content_blocks(blocks: list[ContentBlock]) -> list[dict[str, Any]]:
                     "input": b.input,
                 }
             )
-        elif hasattr(b, "tool_use_id"):  # ToolResultBlock
+        elif isinstance(b, ToolResultBlock):
             content = [{"type": "text", "text": c.text} for c in b.content]
             out.append(
                 {

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -80,7 +80,7 @@ from synth_panel.orchestrator import (
     run_panel_parallel,
 )
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
-from synth_panel.synthesis import synthesize_panel
+from synth_panel.synthesis import SynthesisResult, synthesize_panel
 
 logger = logging.getLogger(__name__)
 
@@ -186,7 +186,7 @@ def _run_multi_round_sync(
         questions: list[dict[str, Any]],
         *,
         model: str,
-    ):
+    ) -> SynthesisResult:
         return synthesize_panel(
             c,
             panelist_results,

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -319,6 +319,8 @@ def _run_panelist(
     responses: list[dict[str, Any]] = []
     t0 = _time.monotonic()
     logger.info("panelist %s starting (model=%s, questions=%d)", name, model, len(questions))
+    if session is None:
+        session = Session()
 
     try:
         # Transition: spawning → ready_for_prompt
@@ -329,8 +331,6 @@ def _run_panelist(
         registry.transition(worker_id, WorkerStatus.PROMPT_ACCEPTED, "prompt received")
         registry.transition(worker_id, WorkerStatus.RUNNING, "executing questions")
 
-        if session is None:
-            session = Session()
         runtime = AgentRuntime(
             client=client,
             session=session,
@@ -366,20 +366,20 @@ def _run_panelist(
 
                     # Build messages from session history for structured extraction
                     messages = [InputMessage(role="user", content=[TextBlock(text=question_text)])]
-                    result = structured_engine.extract(
+                    struct_result = structured_engine.extract(
                         model=model,
                         max_tokens=4096,
                         messages=messages,
                         config=structured_config,
                         system=system_prompt,
                     )
-                    tracker.record_turn(_convert_llm_usage(result.response.usage))
+                    tracker.record_turn(_convert_llm_usage(struct_result.response.usage))
                     responses.append(
                         {
                             "question": question_text,
-                            "response": result.data,
+                            "response": struct_result.data,
                             "structured": True,
-                            "is_fallback": result.is_fallback,
+                            "is_fallback": struct_result.is_fallback,
                         }
                     )
                 else:

--- a/src/synth_panel/runtime.py
+++ b/src/synth_panel/runtime.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Literal, Protocol, cast, runtime_checkable
 
 from synth_panel.cost import ZERO_USAGE, TokenUsage, UsageTracker
 from synth_panel.llm.client import LLMClient
 from synth_panel.llm.models import (
     CompletionRequest,
     CompletionResponse,
+    ContentBlock,
     InputMessage,
     TextBlock,
     ToolChoice,
@@ -191,7 +192,7 @@ def _session_messages_to_input(messages: list[ConversationMessage]) -> list[Inpu
                 )
             )
         elif msg.role in ("user", "assistant"):
-            content_blocks = []
+            content_blocks: list[ContentBlock] = []
             for block in msg.content:
                 btype = block.get("type", "text")
                 if btype == "text":
@@ -212,7 +213,7 @@ def _session_messages_to_input(messages: list[ConversationMessage]) -> list[Inpu
                             is_error=block.get("is_error", False),
                         )
                     )
-            result.append(InputMessage(role=msg.role, content=content_blocks))
+            result.append(InputMessage(role=cast(Literal["user", "assistant"], msg.role), content=content_blocks))
     return result
 
 

--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -17,6 +17,7 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
+from typing import Any
 
 __all__ = [
     "BootstrapResult",
@@ -170,7 +171,7 @@ class BootstrapResult:
     method: str = "BCa"
 
 
-def proportion_stat(value) -> Callable:
+def proportion_stat(value: object) -> Callable[[list[object]], float]:
     """Return a stat function that computes the proportion of *value* in data."""
 
     def _fn(data: list) -> float:
@@ -180,8 +181,8 @@ def proportion_stat(value) -> Callable:
 
 
 def bootstrap_ci(
-    data: list[float],
-    stat_fn: Callable,
+    data: list[Any],
+    stat_fn: Callable[..., float],
     *,
     confidence: float = 0.95,
     n_resamples: int = 2000,
@@ -313,9 +314,9 @@ def chi_squared_test(
     if not observed:
         raise ValueError("observed must not be empty")
 
-    for k, v in observed.items():
-        if v < 0:
-            raise ValueError(f"observed count for {k!r} is negative: {v}")
+    for k, count in observed.items():
+        if count < 0:
+            raise ValueError(f"observed count for {k!r} is negative: {count}")
 
     k_cats = len(observed)
     total = sum(observed.values())
@@ -603,7 +604,7 @@ def _nominal_delta(c: object, k: object) -> float:
 
 def _interval_delta(c: object, k: object) -> float:
     """Interval distance: squared difference."""
-    return (float(c) - float(k)) ** 2
+    return (float(c) - float(k)) ** 2  # type: ignore[arg-type]
 
 
 def _ordinal_delta(
@@ -899,9 +900,9 @@ def convergence_report(
 
     for q in range(n_questions):
         # Build ratings matrix: [M raters][N items]
-        reliability_data: list[list[str]] = []
+        reliability_data: list[list[str | int | float | None]] = []
         for model in model_names:
-            rater_row = [multi_model_responses[model][n][q] for n in range(n_personas)]
+            rater_row: list[str | int | float | None] = [multi_model_responses[model][n][q] for n in range(n_personas)]
             reliability_data.append(rater_row)
 
         # Compute alpha

--- a/src/synth_panel/templates.py
+++ b/src/synth_panel/templates.py
@@ -45,6 +45,8 @@ class _SafeFormatter(string.Formatter):
     def get_field(self, field_name: str, args: tuple, kwargs: dict) -> tuple[Any, str]:  # type: ignore[override]
         # Block dotted/bracket attribute access to prevent injection
         # Only allow simple key lookups
+        first: str | int
+        rest: Any
         first, rest = field_name, iter([])
         try:
             import _string


### PR DESCRIPTION
## Summary
- Tightens mypy configuration: enables `disallow_untyped_defs`, re-enables 6 error codes
- Type annotation improvements across 10 files

Resolves sp-mypy

## Merge notes
- 1 trivial conflict resolved in `orchestrator.py` (combining logging from sp-log with session null check from sp-mypy)

## Test plan
- [x] 742 tests passing, 88.28% coverage
- [x] ruff format + ruff check clean
- [x] Rebased on main (post sp-log merge)