### PR TITLE
chore: tighten mypy - enable disallow_untyped_defs, fix type errors (sp-mypy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,8 @@ known-first-party = ["synth_panel"]
 [tool.mypy]
 python_version = "3.10"
 warn_unused_configs = true
-disallow_untyped_defs = false
-check_untyped_defs = false
+disallow_untyped_defs = true
+check_untyped_defs = true
 ignore_missing_imports = true
 files = ["src/synth_panel"]
 disable_error_code = [
@@ -108,7 +108,4 @@ disable_error_code = [
     "no-any-return",
     "union-attr",
     "arg-type",
-    "return-value",
-    "assignment",
-    "var-annotated",
 ]

--- a/src/synth_panel/cli/repl.py
+++ b/src/synth_panel/cli/repl.py
@@ -51,7 +51,7 @@ class SessionState:
 PROMPT_CHAR = "\u276f "  # ❯
 
 
-def _extract_response_text(summary) -> str:
+def _extract_response_text(summary: Any) -> str:
     """Extract plain text from a TurnSummary's assistant messages."""
     parts: list[str] = []
     for msg in summary.assistant_messages:

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -80,7 +80,7 @@ from synth_panel.orchestrator import (
     run_panel_parallel,
 )
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
-from synth_panel.synthesis import synthesize_panel
+from synth_panel.synthesis import SynthesisResult, synthesize_panel
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +201,7 @@ def _run_multi_round_sync(
         questions: list[dict[str, Any]],
         *,
         model: str,
-    ):
+    ) -> SynthesisResult:
         return synthesize_panel(
             c,
             panelist_results,

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -309,7 +309,7 @@ def _run_panelist(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
-) -> tuple[PanelistResult, Session]:
+) -> tuple[PanelistResult, Session | None]:
     """Execute a single panelist's full interview. Runs in a worker thread.
 
     Manages the worker lifecycle: spawning → ready → running → finished/failed.
@@ -469,13 +469,13 @@ def _run_panelist(
             tracker.cumulative_usage.total_tokens,
         )
 
-        result = PanelistResult(
+        panelist_result = PanelistResult(
             persona_name=name,
             responses=responses,
             usage=tracker.cumulative_usage,
             model=model,
         )
-        return result, session
+        return panelist_result, session
 
     except Exception as exc:
         elapsed = _time.monotonic() - t0
@@ -594,8 +594,9 @@ def run_panel_parallel(
             try:
                 result, sess = future.result()
                 results[idx] = result
-                with session_lock:
-                    out_sessions[result.persona_name] = sess
+                if sess is not None:
+                    with session_lock:
+                        out_sessions[result.persona_name] = sess
             except Exception as exc:
                 name = personas[idx].get("name", "Anonymous")
                 results[idx] = PanelistResult(

--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -170,7 +170,7 @@ class BootstrapResult:
     method: str = "BCa"
 
 
-def proportion_stat(value) -> Callable:
+def proportion_stat(value: object) -> Callable[[list[object]], float]:
     """Return a stat function that computes the proportion of *value* in data."""
 
     def _fn(data: list) -> float:
@@ -313,9 +313,9 @@ def chi_squared_test(
     if not observed:
         raise ValueError("observed must not be empty")
 
-    for k, v in observed.items():
-        if v < 0:
-            raise ValueError(f"observed count for {k!r} is negative: {v}")
+    for k, count in observed.items():
+        if count < 0:
+            raise ValueError(f"observed count for {k!r} is negative: {count}")
 
     k_cats = len(observed)
     total = sum(observed.values())

--- a/src/synth_panel/templates.py
+++ b/src/synth_panel/templates.py
@@ -45,6 +45,8 @@ class _SafeFormatter(string.Formatter):
     def get_field(self, field_name: str, args: tuple, kwargs: dict) -> tuple[Any, str]:  # type: ignore[override]
         # Block dotted/bracket attribute access to prevent injection
         # Only allow simple key lookups
+        first: Any
+        rest: Any
         first, rest = field_name, iter([])
         try:
             import _string


### PR DESCRIPTION
## Summary

- Enables `disallow_untyped_defs=true` in mypy config
- Adds type annotations to untyped functions across the codebase
- Re-enables previously disabled mypy error codes incrementally
- All tests pass (748 passed, 20 skipped)

**Issue**: sp-mypy
**Polecat**: dag
**Branch**: polecat/dag-mnty9uvd

---
*Merged by Gas Town Refinery*