### PR TITLE
fix: sanitize result_id in save/load_panel_sessions (sp-sessions)

### DIFF
--- a/src/synth_panel/mcp/data.py
+++ b/src/synth_panel/mcp/data.py
@@ -371,6 +371,7 @@ def save_panel_sessions(
     Returns the sessions directory path.
     """
 
+    _validate_pack_id(result_id)
     sdir = _sessions_dir(result_id)
     for persona_name, session in sessions.items():
         # Sanitise persona name for use as filename
@@ -388,6 +389,7 @@ def load_panel_sessions(result_id: str) -> dict[str, Session]:
     """
     from synth_panel.persistence import Session
 
+    _validate_pack_id(result_id)
     sdir = _results_dir() / f"{result_id}.sessions"
     if not sdir.exists():
         raise FileNotFoundError(f"No sessions found for result: {result_id}")


### PR DESCRIPTION
## Summary

- Add `_validate_pack_id(result_id)` call in `save_panel_sessions` and `load_panel_sessions` to close path traversal gap
- Same fix pattern as the existing `get/update_panel_result` sanitization

**Issue**: sp-sessions
**Polecat**: capable
**Branch**: polecat/capable-mnu8okib
**Tests**: 742 passed (88% coverage), all quality checks green

---
*Merged by Gas Town Refinery*