### PR TITLE
fix: thread-safe sentiment_cache in orchestrator (sp-sentcache)

### DIFF
--- a/src/synth_panel/conditions.py
+++ b/src/synth_panel/conditions.py
@@ -9,8 +9,10 @@ via json.dumps before condition evaluation.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
+import threading
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -18,6 +20,9 @@ if TYPE_CHECKING:
     from synth_panel.llm.client import LLMClient
 
 log = logging.getLogger(__name__)
+
+# A no-op context manager used when no lock is supplied.
+_noop_lock = contextlib.nullcontext()
 
 # ---------------------------------------------------------------------------
 # Evaluator registry
@@ -55,6 +60,7 @@ def _eval_sentiment(
     response_text: str,
     client: LLMClient,
     sentiment_cache: dict[str, str] | None = None,
+    sentiment_cache_lock: threading.Lock | None = None,
 ) -> bool:
     """Classify response sentiment via a haiku LLM call.
 
@@ -64,6 +70,8 @@ def _eval_sentiment(
         client: LLM client for making the classification call.
         sentiment_cache: Optional cache mapping response_text -> sentiment.
             Avoids duplicate LLM calls for the same response.
+        sentiment_cache_lock: Optional lock protecting sentiment_cache
+            mutations across ThreadPoolExecutor workers.
 
     Returns:
         True if the classified sentiment matches *target*.
@@ -72,11 +80,13 @@ def _eval_sentiment(
 
     target = target.lower().strip()
 
-    # Check cache first
-    if sentiment_cache is not None and response_text in sentiment_cache:
-        cached = sentiment_cache[response_text]
-        log.debug("sentiment cache hit: %r -> %s", response_text[:40], cached)
-        return cached == target
+    # Check cache first (under lock when shared across threads)
+    if sentiment_cache is not None:
+        with sentiment_cache_lock or _noop_lock:
+            if response_text in sentiment_cache:
+                cached = sentiment_cache[response_text]
+                log.debug("sentiment cache hit: %r -> %s", response_text[:40], cached)
+                return cached == target
 
     prompt = _SENTIMENT_PROMPT.format(text=response_text)
     request = CompletionRequest(
@@ -96,9 +106,10 @@ def _eval_sentiment(
         )
         classification = "neutral"
 
-    # Populate cache
+    # Populate cache (under lock when shared across threads)
     if sentiment_cache is not None:
-        sentiment_cache[response_text] = classification
+        with sentiment_cache_lock or _noop_lock:
+            sentiment_cache[response_text] = classification
 
     return classification == target
 
@@ -114,6 +125,7 @@ def evaluate_condition(
     *,
     client: LLMClient | None = None,
     sentiment_cache: dict[str, str] | None = None,
+    sentiment_cache_lock: threading.Lock | None = None,
 ) -> bool:
     """Evaluate whether a follow-up should fire.
 
@@ -129,6 +141,8 @@ def evaluate_condition(
         client: Optional LLM client, required for ``response_sentiment``.
         sentiment_cache: Optional cache to avoid duplicate LLM calls for
             the same response text.
+        sentiment_cache_lock: Optional lock protecting sentiment_cache
+            mutations across ThreadPoolExecutor workers.
 
     Returns:
         True if the follow-up should be asked.
@@ -153,7 +167,7 @@ def evaluate_condition(
             # Graceful degradation: no client → default to True
             log.debug("response_sentiment: no client, defaulting to True")
             return True
-        return _eval_sentiment(arg, response_text, client, sentiment_cache)
+        return _eval_sentiment(arg, response_text, client, sentiment_cache, sentiment_cache_lock)
 
     evaluator = EVALUATORS.get(ctype)
     if evaluator is None:

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -306,6 +306,7 @@ def _run_panelist(
     response_schema: dict[str, Any] | None = None,
     session: Session | None = None,
     sentiment_cache: dict[str, str] | None = None,
+    sentiment_cache_lock: threading.Lock | None = None,
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
@@ -441,6 +442,7 @@ def _run_panelist(
                     last_response,
                     client=client,
                     sentiment_cache=sentiment_cache,
+                    sentiment_cache_lock=sentiment_cache_lock,
                 ):
                     continue
                 try:
@@ -542,6 +544,7 @@ def run_panel_parallel(
     registry = WorkerRegistry()
     effective_workers = max_workers or len(personas)
     sentiment_cache: dict[str, str] = {}
+    sentiment_cache_lock = threading.Lock()
     request_id = uuid.uuid4().hex[:12]
     logger.info(
         "[%s] panel starting: %d personas, %d questions, model=%s, workers=%d",
@@ -583,6 +586,7 @@ def run_panel_parallel(
                 response_schema,
                 existing_session,
                 sentiment_cache,
+                sentiment_cache_lock,
                 extract_schema,
                 temperature,
                 top_p,

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import MagicMock
 
 from synth_panel.conditions import evaluate_condition, normalize_follow_up
@@ -209,6 +210,30 @@ class TestResponseSentiment:
             sentiment_cache=cache,
         )
         assert client.send.call_count == 1  # No additional call
+
+    def test_cache_with_lock(self):
+        """Cache works correctly when a lock is supplied."""
+        client = _mock_client("positive")
+        cache: dict[str, str] = {}
+        lock = threading.Lock()
+        evaluate_condition(
+            "response_sentiment: positive",
+            "great stuff",
+            client=client,
+            sentiment_cache=cache,
+            sentiment_cache_lock=lock,
+        )
+        assert cache["great stuff"] == "positive"
+        assert client.send.call_count == 1
+        # Second call uses cache (via lock)
+        evaluate_condition(
+            "response_sentiment: positive",
+            "great stuff",
+            client=client,
+            sentiment_cache=cache,
+            sentiment_cache_lock=lock,
+        )
+        assert client.send.call_count == 1
 
     def test_unexpected_classification_defaults_neutral(self):
         client = _mock_client("ambivalent")  # not a valid sentiment


### PR DESCRIPTION
## Summary

- Add thread-safety to `sentiment_cache` in orchestrator
- Closes path for race conditions in concurrent panel execution

**Issue**: sp-sentcache
**Polecat**: dag
**Branch**: polecat/dag-mnu8pakq
**Tests**: 743 passed (88% coverage), all quality checks green

---
*Merged by Gas Town Refinery*