### PR TITLE
fix: sanitize PR title in auto-tag command (sp-taginject)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -145,7 +145,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$NEW_TAG" -m "Release $NEW_TAG (PR #${PR_NUMBER}: ${PR_TITLE})"
+          MSG=$(printf 'Release %s (PR #%s: %s)' "$NEW_TAG" "$PR_NUMBER" "$PR_TITLE")
+          git tag -a "$NEW_TAG" -m "$MSG"
           git push origin "$NEW_TAG"
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
- Replace direct shell interpolation of `PR_TITLE` in `git tag -a -m` with `printf %s` to prevent shell metacharacters in PR titles from being interpreted
- Defense-in-depth: while env vars are safer than `${{ }}` in `run:`, printf with `%s` format specifiers adds an additional safety layer

## Test plan
- [x] YAML syntax validated
- [x] Diff is minimal — single change to `.github/workflows/auto-tag.yml` line 148
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)