### PR TITLE
feat: bundled extraction schemas and per-question extraction_schema in instrument YAML (sp-5on.2)

### DIFF
--- a/src/synth_panel/instrument.py
+++ b/src/synth_panel/instrument.py
@@ -41,6 +41,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from synth_panel.structured.schemas import is_known_schema
+
 END_SENTINEL = "__end__"
 
 
@@ -85,6 +87,36 @@ class InstrumentError(ValueError):
     """Raised when an instrument definition is invalid."""
 
 
+def _validate_questions(questions: list[dict[str, Any]], context: str) -> None:
+    """Validate extraction_schema on questions.
+
+    String values are checked against the bundled schema registry.
+    Dict values are accepted as inline JSON Schemas without further
+    validation. Other types raise :class:`InstrumentError`.
+
+    Args:
+        questions: List of question dicts to validate.
+        context: Human-readable location for error messages
+            (e.g. ``"v1 instrument"`` or ``"round 'discovery'"``).
+    """
+    for i, q in enumerate(questions):
+        if not isinstance(q, dict):
+            continue
+        es = q.get("extraction_schema")
+        if es is None:
+            continue
+        if isinstance(es, str):
+            if not is_known_schema(es):
+                from synth_panel.structured.schemas import SchemaNotFoundError
+
+                raise InstrumentError(str(SchemaNotFoundError(es)))
+        elif not isinstance(es, dict):
+            raise InstrumentError(
+                f"{context} question[{i}]: extraction_schema must be a string (schema name) or mapping, "
+                f"got {type(es).__name__}"
+            )
+
+
 def parse_instrument(data: dict[str, Any]) -> Instrument:
     """Parse a raw instrument dict into a validated Instrument.
 
@@ -108,6 +140,7 @@ def _parse_v1(data: dict[str, Any], version: int) -> Instrument:
     questions = data["questions"]
     if not isinstance(questions, list) or not questions:
         raise InstrumentError("'questions' must be a non-empty list")
+    _validate_questions(questions, "v1 instrument")
     return Instrument(
         version=version,
         rounds=[Round(name="default", questions=questions)],
@@ -138,6 +171,7 @@ def _parse_rounds(data: dict[str, Any], version: int) -> Instrument:
         questions = raw.get("questions")
         if not isinstance(questions, list) or not questions:
             raise InstrumentError(f"Round '{name}' must have a non-empty 'questions' list")
+        _validate_questions(questions, f"round '{name}'")
 
         depends_on = raw.get("depends_on")
         if depends_on is not None and not isinstance(depends_on, str):

--- a/src/synth_panel/structured/schemas.py
+++ b/src/synth_panel/structured/schemas.py
@@ -1,0 +1,105 @@
+"""Bundled extraction schemas for structured data extraction.
+
+Each schema is a JSON Schema dict suitable for use with
+:class:`~synth_panel.structured.output.StructuredOutputConfig`.
+
+The registry supports lookup by name (``get_schema``) and
+enumeration (``list_schemas``).  Unknown names raise
+:class:`SchemaNotFoundError` at load time so instruments fail
+fast rather than silently skipping extraction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Bundled schemas
+# ---------------------------------------------------------------------------
+
+RANKING_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "ranked": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "rank": {"type": "integer"},
+                    "reasoning": {"type": "string"},
+                },
+                "required": ["name", "rank"],
+            },
+        },
+    },
+    "required": ["ranked"],
+}
+
+LIKERT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "rating": {"type": "integer"},
+        "reasoning": {"type": "string"},
+    },
+    "required": ["rating"],
+}
+
+YES_NO_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "answer": {"type": "boolean"},
+        "reasoning": {"type": "string"},
+    },
+    "required": ["answer"],
+}
+
+PICK_ONE_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "choice": {"type": "string"},
+        "reasoning": {"type": "string"},
+    },
+    "required": ["choice"],
+}
+
+_REGISTRY: dict[str, dict[str, Any]] = {
+    "ranking": RANKING_SCHEMA,
+    "likert": LIKERT_SCHEMA,
+    "yes_no": YES_NO_SCHEMA,
+    "pick_one": PICK_ONE_SCHEMA,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class SchemaNotFoundError(ValueError):
+    """Raised when a schema name is not in the registry."""
+
+    def __init__(self, name: str) -> None:
+        known = ", ".join(sorted(_REGISTRY))
+        super().__init__(f"Unknown extraction schema: {name!r} (known: {known})")
+        self.name = name
+
+
+def get_schema(name: str) -> dict[str, Any]:
+    """Return a bundled extraction schema by name.
+
+    Raises :class:`SchemaNotFoundError` if *name* is not registered.
+    """
+    if name not in _REGISTRY:
+        raise SchemaNotFoundError(name)
+    return _REGISTRY[name]
+
+
+def list_schemas() -> list[dict[str, Any]]:
+    """Return metadata for all registered extraction schemas."""
+    return [{"name": name, "schema": schema} for name, schema in sorted(_REGISTRY.items())]
+
+
+def is_known_schema(name: str) -> bool:
+    """Return True if *name* is a registered extraction schema."""
+    return name in _REGISTRY

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -423,3 +423,120 @@ class TestV3Branching:
                     ],
                 }
             )
+
+
+# ---------------------------------------------------------------------------
+# extraction_schema per question
+# ---------------------------------------------------------------------------
+
+
+class TestExtractionSchema:
+    def test_v1_string_schema_name_accepted(self):
+        """Known schema names pass validation."""
+        data = {
+            "version": 1,
+            "questions": [
+                {"text": "Rate this", "extraction_schema": "likert"},
+            ],
+        }
+        inst = parse_instrument(data)
+        assert inst.questions[0]["extraction_schema"] == "likert"
+
+    def test_v1_inline_dict_schema_accepted(self):
+        """Inline dict schemas pass validation without registry lookup."""
+        schema = {"type": "object", "properties": {"score": {"type": "integer"}}}
+        data = {
+            "version": 1,
+            "questions": [
+                {"text": "Score it", "extraction_schema": schema},
+            ],
+        }
+        inst = parse_instrument(data)
+        assert inst.questions[0]["extraction_schema"] == schema
+
+    def test_v1_unknown_schema_name_rejected(self):
+        """Unknown schema names raise InstrumentError at parse time."""
+        data = {
+            "version": 1,
+            "questions": [
+                {"text": "Q?", "extraction_schema": "nonexistent"},
+            ],
+        }
+        with pytest.raises(InstrumentError, match="Unknown extraction schema.*nonexistent"):
+            parse_instrument(data)
+
+    def test_v1_invalid_type_rejected(self):
+        """Non-string, non-dict extraction_schema raises InstrumentError."""
+        data = {
+            "version": 1,
+            "questions": [
+                {"text": "Q?", "extraction_schema": 42},
+            ],
+        }
+        with pytest.raises(InstrumentError, match="extraction_schema must be a string"):
+            parse_instrument(data)
+
+    def test_v1_no_extraction_schema_ok(self):
+        """Questions without extraction_schema parse fine."""
+        data = {"version": 1, "questions": [{"text": "Hello?"}]}
+        inst = parse_instrument(data)
+        assert "extraction_schema" not in inst.questions[0]
+
+    def test_rounds_schema_name_validated(self):
+        """extraction_schema in round questions is validated."""
+        data = {
+            "version": 3,
+            "rounds": [
+                {
+                    "name": "intro",
+                    "questions": [
+                        {"text": "Yes or no?", "extraction_schema": "yes_no"},
+                    ],
+                    "route_when": [{"else": "__end__"}],
+                },
+            ],
+        }
+        inst = parse_instrument(data)
+        assert inst.rounds[0].questions[0]["extraction_schema"] == "yes_no"
+
+    def test_rounds_unknown_schema_rejected(self):
+        """Unknown schema names in round questions raise InstrumentError."""
+        data = {
+            "version": 3,
+            "rounds": [
+                {
+                    "name": "intro",
+                    "questions": [
+                        {"text": "Q?", "extraction_schema": "bogus"},
+                    ],
+                    "route_when": [{"else": "__end__"}],
+                },
+            ],
+        }
+        with pytest.raises(InstrumentError, match="Unknown extraction schema.*bogus"):
+            parse_instrument(data)
+
+    def test_mixed_questions_some_with_schema(self):
+        """Only questions with extraction_schema are validated."""
+        data = {
+            "version": 1,
+            "questions": [
+                {"text": "Open ended"},
+                {"text": "Pick one", "extraction_schema": "pick_one"},
+                {"text": "Rank them", "extraction_schema": "ranking"},
+            ],
+        }
+        inst = parse_instrument(data)
+        assert len(inst.questions) == 3
+        assert inst.questions[1]["extraction_schema"] == "pick_one"
+        assert inst.questions[2]["extraction_schema"] == "ranking"
+
+    def test_all_bundled_schema_names_accepted(self):
+        """All four bundled schema names pass validation."""
+        for name in ("ranking", "likert", "yes_no", "pick_one"):
+            data = {
+                "version": 1,
+                "questions": [{"text": "Q?", "extraction_schema": name}],
+            }
+            inst = parse_instrument(data)
+            assert inst.questions[0]["extraction_schema"] == name

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,0 +1,91 @@
+"""Tests for bundled extraction schema registry."""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_panel.structured.schemas import (
+    LIKERT_SCHEMA,
+    PICK_ONE_SCHEMA,
+    RANKING_SCHEMA,
+    YES_NO_SCHEMA,
+    SchemaNotFoundError,
+    get_schema,
+    is_known_schema,
+    list_schemas,
+)
+
+
+class TestGetSchema:
+    def test_ranking(self):
+        assert get_schema("ranking") is RANKING_SCHEMA
+        assert "ranked" in get_schema("ranking")["properties"]
+
+    def test_likert(self):
+        assert get_schema("likert") is LIKERT_SCHEMA
+        assert "rating" in get_schema("likert")["properties"]
+
+    def test_yes_no(self):
+        assert get_schema("yes_no") is YES_NO_SCHEMA
+        assert "answer" in get_schema("yes_no")["properties"]
+
+    def test_pick_one(self):
+        assert get_schema("pick_one") is PICK_ONE_SCHEMA
+        assert "choice" in get_schema("pick_one")["properties"]
+
+    def test_unknown_raises(self):
+        with pytest.raises(SchemaNotFoundError, match="nonexistent"):
+            get_schema("nonexistent")
+
+    def test_error_lists_known_schemas(self):
+        with pytest.raises(SchemaNotFoundError, match="likert") as exc_info:
+            get_schema("nope")
+        assert exc_info.value.name == "nope"
+
+
+class TestListSchemas:
+    def test_returns_all_four(self):
+        schemas = list_schemas()
+        names = {s["name"] for s in schemas}
+        assert names == {"ranking", "likert", "yes_no", "pick_one"}
+
+    def test_entries_have_schema_key(self):
+        for entry in list_schemas():
+            assert "schema" in entry
+            assert isinstance(entry["schema"], dict)
+
+
+class TestIsKnownSchema:
+    def test_known(self):
+        assert is_known_schema("ranking") is True
+        assert is_known_schema("likert") is True
+        assert is_known_schema("yes_no") is True
+        assert is_known_schema("pick_one") is True
+
+    def test_unknown(self):
+        assert is_known_schema("nonexistent") is False
+
+
+class TestSchemaStructure:
+    """Verify each schema is a valid JSON Schema object with required fields."""
+
+    @pytest.mark.parametrize("name", ["ranking", "likert", "yes_no", "pick_one"])
+    def test_is_object_type(self, name: str):
+        schema = get_schema(name)
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "required" in schema
+
+    def test_ranking_items_structure(self):
+        items = RANKING_SCHEMA["properties"]["ranked"]["items"]
+        assert "name" in items["properties"]
+        assert "rank" in items["properties"]
+
+    def test_likert_rating_is_integer(self):
+        assert LIKERT_SCHEMA["properties"]["rating"]["type"] == "integer"
+
+    def test_yes_no_answer_is_boolean(self):
+        assert YES_NO_SCHEMA["properties"]["answer"]["type"] == "boolean"
+
+    def test_pick_one_choice_is_string(self):
+        assert PICK_ONE_SCHEMA["properties"]["choice"]["type"] == "string"


### PR DESCRIPTION
## Summary

- Add bundled extraction schemas and per-question `extraction_schema` support in instrument YAML

**Issue**: sp-5on.2
**Polecat**: dag
**Branch**: polecat/dag-sp5on2
**Tests**: 770 passed (88% coverage), all quality checks green

---
*Merged by Gas Town Refinery*