### PR TITLE
feat: add --variants N flag to panel run CLI (sp-5on.15)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -21,6 +21,7 @@ from synth_panel.llm.client import LLMClient
 from synth_panel.metadata import PanelTimer, build_metadata
 from synth_panel.orchestrator import run_panel_parallel
 from synth_panel.persistence import Session
+from synth_panel.perturbation import generate_panel_variants
 from synth_panel.prompts import (
     build_question_prompt,
     load_prompt_template,
@@ -529,6 +530,30 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     client = LLMClient()
     timer = PanelTimer()
+
+    # ── sp-5on.15: variant expansion ─────────────────────────────────
+    variants_k = getattr(args, "variants", None)
+    if variants_k is not None:
+        if variants_k < 1 or variants_k > 20:
+            print("Error: --variants must be between 1 and 20.", file=sys.stderr)
+            return 1
+        orig_count = len(personas)
+        total = variants_k * orig_count
+        print(
+            f"Generating {variants_k} variants for {orig_count} personas ({total} total sessions)...",
+            file=sys.stderr,
+        )
+        variant_sets = generate_panel_variants(
+            personas,
+            client,
+            k=variants_k,
+            model=model,
+        )
+        personas = [v.persona for vs in variant_sets for v in vs.variants]
+        print(
+            f"Variant expansion complete: {len(personas)} variant personas ready.",
+            file=sys.stderr,
+        )
 
     # Run all panelists in parallel via the orchestrator
     panelist_results, _registry, _sessions = run_panel_parallel(

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -255,6 +255,19 @@ def build_parser() -> argparse.ArgumentParser:
             "conflicts)."
         ),
     )
+    panel_run_parser.add_argument(
+        "--variants",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Generate N LLM-perturbed variants per persona before running "
+            "the panel. The original personas are replaced by N*M variants "
+            "(M = number of personas). Each variant perturbs one axis "
+            "(trait swap, mood context, demographic shift, background "
+            "rephrase). Requires an LLM call per variant."
+        ),
+    )
 
     # pack
     pack_parser = subparsers.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1469,3 +1469,130 @@ instrument:
         err = capsys.readouterr().err
         assert rc == 1
         assert "Error" in err
+
+
+# --- Variants flag tests (sp-5on.15) -----------------------------------------
+
+
+class TestVariantsFlag:
+    def test_parser_accepts_variants(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--instrument",
+                "i.yaml",
+                "--variants",
+                "3",
+            ]
+        )
+        assert args.variants == 3
+
+    def test_parser_variants_default_is_none(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--instrument",
+                "i.yaml",
+            ]
+        )
+        assert args.variants is None
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
+    @patch("synth_panel.cli.commands.generate_panel_variants")
+    def test_variants_expands_personas(
+        self,
+        mock_gen_variants,
+        mock_client_cls,
+        mock_runtime_cls,
+        mock_synth,
+        capsys,
+        tmp_path,
+    ):
+        from synth_panel.perturbation import PersonaVariant, PerturbationAxis, PerturbationRecord, VariantSet
+
+        mock_runtime = MagicMock()
+        mock_runtime.run_turn.return_value = _mock_turn_summary("variant answer")
+        mock_runtime_cls.return_value = mock_runtime
+        mock_synth.return_value = _mock_synthesis_result()
+
+        # Build 2 variants for 1 persona
+        base = {"name": "Alice", "age": 30}
+        record = PerturbationRecord(
+            axis=PerturbationAxis.TRAIT_SWAP,
+            original_field="personality_traits",
+            original_value="analytical",
+            perturbed_value="intuitive",
+            change_description="swapped trait",
+        )
+        v0 = PersonaVariant(
+            persona=dict(base, name="Alice (v0)"),
+            source_persona_name="Alice",
+            variant_index=0,
+            perturbation=record,
+        )
+        v1 = PersonaVariant(
+            persona=dict(base, name="Alice (v1)"),
+            source_persona_name="Alice",
+            variant_index=1,
+            perturbation=record,
+        )
+        mock_gen_variants.return_value = [VariantSet(source_persona=base, variants=[v0, v1])]
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n    age: 30\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: What?\n")
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--variants",
+                "2",
+            ]
+        )
+        assert code == 0
+        mock_gen_variants.assert_called_once()
+        call_args = mock_gen_variants.call_args
+        assert call_args.kwargs["k"] == 2
+
+        err = capsys.readouterr().err
+        assert "Generating 2 variants for 1 personas" in err
+        assert "Variant expansion complete" in err
+
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_variants_out_of_range_returns_error(self, mock_client_cls, capsys, tmp_path):
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: What?\n")
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--variants",
+                "25",
+            ]
+        )
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "--variants must be between 1 and 20" in err


### PR DESCRIPTION
## Summary
- Add `--variants N` flag to `panel run` CLI subcommand
- Before running the panel, expands original personas into N*M LLM-perturbed variants using `generate_panel_variants()` from the perturbation module
- Progress output to stderr: variant generation count and completion message
- Validates N is between 1 and 20, returns error otherwise
- 4 new tests: parser acceptance, default None, mock expansion count, out-of-range error

## Test plan
- [x] `ruff check` passes on all 3 changed files
- [x] `ruff format --check` passes on all 3 changed files
- [x] Tests follow existing `TestPanelRun` mocking patterns
- [ ] CI passes on this PR (Python 3.10+ required for tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)