### PR TITLE
chore: add pip caching to all CI workflow jobs (sp-pipcache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: pip install -e ".[dev,mcp]"
@@ -36,6 +37,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: pip install -e ".[dev,mcp]"
@@ -51,6 +53,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: pip install -e ".[dev,mcp]"
@@ -75,6 +78,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+          cache: pip
 
       - name: Install dependencies
         run: pip install -e ".[dev,mcp]"
@@ -90,6 +94,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Install dependencies
         run: pip install -e ".[dev,mcp]"

--- a/.github/workflows/publish-test.yml
+++ b/.github/workflows/publish-test.yml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Generate dev version
         id: version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: Update pyproject.toml version to match tag
         env:


### PR DESCRIPTION
## Summary
- Add `cache: pip` to all 7 `actions/setup-python` steps across `ci.yml` (5 jobs), `publish.yml` (1 job), and `publish-test.yml` (1 job)
- Avoids cold pip install on every CI job, saving ~30-60s per run

## Test plan
- [x] All 3 YAML files validate
- [x] 7/7 setup-python steps now have `cache: pip`
- [ ] CI passes on this PR (first run will be a cache miss, subsequent runs benefit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)