### PR TITLE
feat: add MCP run_panel extract_schema parameter (sp-5on.3)

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -161,8 +161,7 @@ def _resolve_extract_schema(
         if value not in EXTRACT_SCHEMA_REGISTRY:
             names = ", ".join(sorted(EXTRACT_SCHEMA_REGISTRY))
             raise ValueError(
-                f"Unknown extract_schema name {value!r}. "
-                f"Available: {names}. Or pass an inline JSON Schema dict."
+                f"Unknown extract_schema name {value!r}. Available: {names}. Or pass an inline JSON Schema dict."
             )
         return EXTRACT_SCHEMA_REGISTRY[value]
     raise TypeError(f"extract_schema must be a string or dict, got {type(value).__name__}")

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -96,6 +96,78 @@ PANELIST_TIMEOUT = 30
 MAX_PERSONAS = 100
 MAX_QUESTIONS = 50
 
+# Built-in extraction schema registry — keyed by short name.
+EXTRACT_SCHEMA_REGISTRY: dict[str, dict[str, Any]] = {
+    "sentiment": {
+        "type": "object",
+        "properties": {
+            "sentiment": {
+                "type": "string",
+                "enum": ["positive", "negative", "neutral", "mixed"],
+                "description": "Overall sentiment of the response.",
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": "Confidence score (0-1) for the sentiment classification.",
+            },
+        },
+        "required": ["sentiment", "confidence"],
+    },
+    "themes": {
+        "type": "object",
+        "properties": {
+            "themes": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Key themes or topics mentioned in the response.",
+            },
+            "primary_theme": {
+                "type": "string",
+                "description": "The single most dominant theme.",
+            },
+        },
+        "required": ["themes", "primary_theme"],
+    },
+    "rating": {
+        "type": "object",
+        "properties": {
+            "rating": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": "Numeric rating (1-10) implied by the response.",
+            },
+            "explanation": {
+                "type": "string",
+                "description": "Brief rationale for the assigned rating.",
+            },
+        },
+        "required": ["rating", "explanation"],
+    },
+}
+
+
+def _resolve_extract_schema(
+    value: str | dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Resolve extract_schema: pass dicts through, look up strings in the registry."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        if value not in EXTRACT_SCHEMA_REGISTRY:
+            names = ", ".join(sorted(EXTRACT_SCHEMA_REGISTRY))
+            raise ValueError(
+                f"Unknown extract_schema name {value!r}. "
+                f"Available: {names}. Or pass an inline JSON Schema dict."
+            )
+        return EXTRACT_SCHEMA_REGISTRY[value]
+    raise TypeError(f"extract_schema must be a string or dict, got {type(value).__name__}")
+
+
 mcp = FastMCP(
     "synthpanel",
     instructions=(
@@ -699,7 +771,7 @@ async def run_panel(
     temperature: float | None = None,
     top_p: float | None = None,
     persona_models: dict[str, str] | None = None,
-    extract_schema: dict[str, Any] | None = None,
+    extract_schema: str | dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
     variants: int | None = None,
     ctx: Context = None,
@@ -755,7 +827,9 @@ async def run_panel(
         top_p: Nucleus sampling threshold (0.0-1.0) for panelist responses.
         persona_models: Per-persona model overrides. Maps persona name to
             model alias (e.g. {"Sarah Chen": "sonnet", "Mike": "haiku"}).
-        extract_schema: JSON Schema for structured extraction from responses.
+        extract_schema: Schema for post-hoc structured extraction from
+            free-text responses. Pass a built-in name ("sentiment",
+            "themes", "rating") or an inline JSON Schema dict.
         synthesis_temperature: Sampling temperature for the synthesis step.
             Independent of the panelist temperature.
         variants: Number of persona variants to generate per persona for
@@ -768,6 +842,12 @@ async def run_panel(
     if variants_k < 0 or variants_k > 20:
         return json.dumps({"error": "variants must be between 0 and 20."})
     logger.info("run_panel: model=%s synthesis=%s variants=%d", model, synthesis, variants_k)
+
+    # Resolve extract_schema name → dict before threading to orchestrator.
+    try:
+        resolved_extract_schema = _resolve_extract_schema(extract_schema)
+    except (ValueError, TypeError) as exc:
+        return json.dumps({"error": str(exc)})
     merged = list(personas) if personas else []
     if pack_id is not None:
         pack = _data_get_persona_pack(pack_id)
@@ -818,7 +898,7 @@ async def run_panel(
             temperature=temperature,
             top_p=top_p,
             persona_models=persona_models,
-            extract_schema=extract_schema,
+            extract_schema=resolved_extract_schema,
             synthesis_temperature=synthesis_temperature,
         )
         return json.dumps(result, indent=2)
@@ -838,7 +918,7 @@ async def run_panel(
         temperature=temperature,
         top_p=top_p,
         persona_models=persona_models,
-        extract_schema=extract_schema,
+        extract_schema=resolved_extract_schema,
         synthesis_temperature=synthesis_temperature,
         variants=variants_k,
     )

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -274,6 +274,84 @@ class TestRunPanelPackId:
 
 
 # ---------------------------------------------------------------------------
+# run_panel extract_schema parameter
+# ---------------------------------------------------------------------------
+
+
+class TestRunPanelExtractSchema:
+    """Test run_panel's extract_schema parameter (string name and inline dict)."""
+
+    @pytest.mark.asyncio
+    async def test_inline_dict_schema_passed_through(self):
+        """An inline dict extract_schema is forwarded to the async runner."""
+        schema = {
+            "type": "object",
+            "properties": {"mood": {"type": "string"}},
+            "required": ["mood"],
+        }
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": []}
+            await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "How do you feel?"}],
+                    "extract_schema": schema,
+                },
+            )
+            kwargs = mock_run.call_args[1]
+            assert kwargs["extract_schema"] == schema
+
+    @pytest.mark.asyncio
+    async def test_string_name_resolves_to_registry_schema(self):
+        """A string extract_schema resolves to the built-in registry entry."""
+        from synth_panel.mcp.server import EXTRACT_SCHEMA_REGISTRY
+
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": []}
+            await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "How do you feel?"}],
+                    "extract_schema": "sentiment",
+                },
+            )
+            kwargs = mock_run.call_args[1]
+            assert kwargs["extract_schema"] == EXTRACT_SCHEMA_REGISTRY["sentiment"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_name_returns_error(self):
+        """An unrecognised schema name returns a JSON error (not an exception)."""
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "extract_schema": "nonexistent",
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "nonexistent" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_none_schema_passes_none(self):
+        """Omitting extract_schema passes None to the async runner."""
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": []}
+            await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                },
+            )
+            kwargs = mock_run.call_args[1]
+            assert kwargs["extract_schema"] is None
+
+
+# ---------------------------------------------------------------------------
 # Prompt templates
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds extract_schema parameter to MCP run_panel tool
- Issue: sp-5on.3
- Polecat: capable
- Branch: polecat/capable-extract
- Tests: Passed (verified by refinery — 806 passed, lint clean, mypy clean)

---
*Created by Gas Town Refinery*