### PR TITLE
feat: add opt-in structured JSON logging (sp-jsonlog)

### DIFF
--- a/src/synth_panel/logging_config.py
+++ b/src/synth_panel/logging_config.py
@@ -7,12 +7,20 @@ is resolved from (in priority order):
 1. Explicit *verbosity* argument (``"debug"`` / ``"warning"``).
 2. ``SYNTHPANEL_LOG_LEVEL`` environment variable.
 3. Default: ``INFO``.
+
+Output format is controlled by ``SYNTHPANEL_LOG_FORMAT``:
+
+- ``"text"`` (default): human-readable plaintext lines.
+- ``"json"``: one JSON object per line with keys
+  ``level``, ``logger``, ``timestamp``, ``message``.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
+from datetime import datetime, timezone
 
 _LOG_FORMAT = "%(asctime)s %(name)s %(levelname)s %(message)s"
 
@@ -21,6 +29,28 @@ _VERBOSITY_MAP: dict[str, int] = {
     "warning": logging.WARNING,
     "info": logging.INFO,
 }
+
+
+class _JSONFormatter(logging.Formatter):
+    """Emit one JSON object per log record."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        return json.dumps(
+            {
+                "level": record.levelname,
+                "logger": record.name,
+                "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+                "message": record.getMessage(),
+            },
+            ensure_ascii=False,
+        )
+
+
+def _make_formatter() -> logging.Formatter:
+    fmt = os.environ.get("SYNTHPANEL_LOG_FORMAT", "").strip().lower()
+    if fmt == "json":
+        return _JSONFormatter()
+    return logging.Formatter(_LOG_FORMAT)
 
 
 def setup_logging(verbosity: str | None = None) -> None:
@@ -37,8 +67,10 @@ def setup_logging(verbosity: str | None = None) -> None:
         env = os.environ.get("SYNTHPANEL_LOG_LEVEL", "").strip().lower()
         level = _VERBOSITY_MAP.get(env, logging.INFO)
 
+    formatter = _make_formatter()
+
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+    handler.setFormatter(formatter)
 
     logger = logging.getLogger("synth_panel")
     logger.setLevel(level)
@@ -46,5 +78,5 @@ def setup_logging(verbosity: str | None = None) -> None:
     if not logger.handlers:
         logger.addHandler(handler)
     else:
-        logger.handlers[0].setFormatter(logging.Formatter(_LOG_FORMAT))
+        logger.handlers[0].setFormatter(formatter)
         logger.setLevel(level)

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,88 @@
+"""Tests for structured logging configuration."""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from synth_panel.logging_config import setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_logger():
+    """Remove handlers added by setup_logging between tests."""
+    logger = logging.getLogger("synth_panel")
+    logger.handlers.clear()
+    logger.setLevel(logging.WARNING)
+    yield
+    logger.handlers.clear()
+    logger.setLevel(logging.WARNING)
+
+
+def test_default_plaintext(monkeypatch, capsys):
+    monkeypatch.delenv("SYNTHPANEL_LOG_FORMAT", raising=False)
+    setup_logging("debug")
+    logger = logging.getLogger("synth_panel")
+    logger.info("hello world")
+    captured = capsys.readouterr()
+    assert "hello world" in captured.err
+    # Should NOT be valid JSON
+    for line in captured.err.strip().splitlines():
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(line)
+
+
+def test_json_format(monkeypatch, capsys):
+    monkeypatch.setenv("SYNTHPANEL_LOG_FORMAT", "json")
+    setup_logging("debug")
+    logger = logging.getLogger("synth_panel")
+    logger.info("test message")
+    captured = capsys.readouterr()
+    line = captured.err.strip()
+    obj = json.loads(line)
+    assert obj["level"] == "INFO"
+    assert obj["logger"] == "synth_panel"
+    assert obj["message"] == "test message"
+    assert "timestamp" in obj
+
+
+def test_json_format_case_insensitive(monkeypatch, capsys):
+    monkeypatch.setenv("SYNTHPANEL_LOG_FORMAT", "JSON")
+    setup_logging("debug")
+    logger = logging.getLogger("synth_panel")
+    logger.warning("warn msg")
+    captured = capsys.readouterr()
+    obj = json.loads(captured.err.strip())
+    assert obj["level"] == "WARNING"
+    assert obj["message"] == "warn msg"
+
+
+def test_json_timestamp_is_iso(monkeypatch, capsys):
+    monkeypatch.setenv("SYNTHPANEL_LOG_FORMAT", "json")
+    setup_logging("debug")
+    logger = logging.getLogger("synth_panel")
+    logger.info("ts check")
+    captured = capsys.readouterr()
+    obj = json.loads(captured.err.strip())
+    # ISO 8601 with timezone offset
+    assert obj["timestamp"].endswith("+00:00")
+
+
+def test_reconfigure_switches_format(monkeypatch, capsys):
+    """Calling setup_logging again with a different format updates the handler."""
+    monkeypatch.setenv("SYNTHPANEL_LOG_FORMAT", "json")
+    setup_logging("debug")
+    logger = logging.getLogger("synth_panel")
+    logger.info("json line")
+    captured = capsys.readouterr()
+    json.loads(captured.err.strip())  # should parse
+
+    monkeypatch.delenv("SYNTHPANEL_LOG_FORMAT")
+    setup_logging("debug")
+    logger.info("text line")
+    captured = capsys.readouterr()
+    assert "text line" in captured.err
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(captured.err.strip())


### PR DESCRIPTION
## Summary

- Adds opt-in structured JSON logging for observability stacks
- Issue: sp-jsonlog
- Polecat: dementus-sp
- Branch: polecat/dementus-sp-jsonlog
- Tests: 804 passed, 3 pre-existing failures (sp-bqs), lint clean, mypy clean

---
*Created by Gas Town Refinery*