### PR TITLE
feat: add MCP variants param and multi-model ensemble runner (sp-5on.17, sp-5on.11)

### DIFF
--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -1,0 +1,156 @@
+"""Multi-model ensemble runner.
+
+Runs the same panel N times (once per model) using existing
+run_panel_parallel(), then aggregates per-model costs via
+CostEstimate/TokenUsage.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from synth_panel.cost import (
+    ZERO_USAGE,
+    CostEstimate,
+    TokenUsage,
+    estimate_cost,
+    lookup_pricing,
+)
+from synth_panel.llm.client import LLMClient
+from synth_panel.orchestrator import PanelistResult, run_panel_parallel
+from synth_panel.persistence import Session
+from synth_panel.prompts import build_question_prompt, persona_system_prompt
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelRunResult:
+    """Result from a single model's panel run."""
+
+    model: str
+    panelist_results: list[PanelistResult]
+    usage: TokenUsage
+    cost: CostEstimate
+    sessions: dict[str, Session]
+
+
+@dataclass
+class EnsembleResult:
+    """Aggregated result from running the panel across multiple models."""
+
+    model_results: list[ModelRunResult]
+    models: list[str]
+    total_usage: TokenUsage
+    total_cost: CostEstimate
+    per_model_cost: dict[str, str]  # model -> formatted USD
+    per_model_usage: dict[str, dict[str, int]]  # model -> usage dict
+    persona_count: int
+    question_count: int
+
+
+def ensemble_run(
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    models: list[str],
+    client: LLMClient,
+    *,
+    system_prompt_fn: Callable[[dict[str, Any]], str] | None = None,
+    question_prompt_fn: Callable[[dict[str, Any]], str] | None = None,
+    response_schema: dict[str, Any] | None = None,
+    extract_schema: dict[str, Any] | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> EnsembleResult:
+    """Run a panel once per model and aggregate results.
+
+    Args:
+        personas: List of persona dicts.
+        questions: List of question dicts (each with a "text" key).
+        models: List of model aliases to run. Panel is run once per model.
+        client: Shared LLM client.
+        system_prompt_fn: Builds system prompt from persona. Default:
+            built-in persona_system_prompt.
+        question_prompt_fn: Builds question text from question dict.
+            Default: built-in build_question_prompt.
+        response_schema: Optional JSON Schema for structured output.
+        extract_schema: Optional JSON Schema for post-hoc extraction.
+        temperature: Sampling temperature for panelist responses.
+        top_p: Nucleus sampling threshold.
+
+    Returns:
+        EnsembleResult with per-model and aggregated data.
+
+    Raises:
+        ValueError: If models is empty.
+    """
+    if not models:
+        raise ValueError("models list must not be empty")
+
+    sys_fn = system_prompt_fn or persona_system_prompt
+    q_fn = question_prompt_fn or build_question_prompt
+
+    model_results: list[ModelRunResult] = []
+    total_usage = ZERO_USAGE
+    total_cost = CostEstimate()
+    per_model_cost: dict[str, str] = {}
+    per_model_usage: dict[str, dict[str, int]] = {}
+
+    for model in models:
+        logger.info(
+            "Ensemble: running panel with model=%s (%d personas, %d questions)", model, len(personas), len(questions)
+        )
+
+        panelist_results, _registry, sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model=model,
+            system_prompt_fn=sys_fn,
+            question_prompt_fn=q_fn,
+            response_schema=response_schema,
+            extract_schema=extract_schema,
+            temperature=temperature,
+            top_p=top_p,
+        )
+
+        # Aggregate usage for this model
+        model_usage = ZERO_USAGE
+        for pr in panelist_results:
+            model_usage = model_usage + pr.usage
+
+        pricing, _ = lookup_pricing(model)
+        model_cost = estimate_cost(model_usage, pricing)
+
+        # Tag each result with its model
+        for pr in panelist_results:
+            pr.model = model
+
+        model_results.append(
+            ModelRunResult(
+                model=model,
+                panelist_results=panelist_results,
+                usage=model_usage,
+                cost=model_cost,
+                sessions=sessions,
+            )
+        )
+
+        total_usage = total_usage + model_usage
+        total_cost = total_cost + model_cost
+        per_model_cost[model] = model_cost.format_usd()
+        per_model_usage[model] = model_usage.to_dict()
+
+    return EnsembleResult(
+        model_results=model_results,
+        models=models,
+        total_usage=total_usage,
+        total_cost=total_cost,
+        per_model_cost=per_model_cost,
+        per_model_usage=per_model_usage,
+        persona_count=len(personas),
+        question_count=len(questions),
+    )

--- a/src/synth_panel/mcp/data.py
+++ b/src/synth_panel/mcp/data.py
@@ -430,15 +430,17 @@ def list_panel_results() -> list[dict[str, Any]]:
             continue
         try:
             data = json.loads(p.read_text(encoding="utf-8"))
-            results.append(
-                {
-                    "id": p.stem,
-                    "created_at": data.get("created_at", ""),
-                    "model": data.get("model", ""),
-                    "persona_count": data.get("persona_count", 0),
-                    "question_count": data.get("question_count", 0),
-                }
-            )
+            entry: dict[str, Any] = {
+                "id": p.stem,
+                "created_at": data.get("created_at", ""),
+                "model": data.get("model", ""),
+                "persona_count": data.get("persona_count", 0),
+                "question_count": data.get("question_count", 0),
+            }
+            vc = data.get("variant_count", 0)
+            if vc:
+                entry["variant_count"] = vc
+            results.append(entry)
         except Exception:
             continue
     return results
@@ -462,11 +464,12 @@ def save_panel_result(
     total_cost: str,
     persona_count: int,
     question_count: int,
+    variant_count: int = 0,
 ) -> str:
     """Save panel results and return the result ID."""
     rid = f"result-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{uuid.uuid4().hex[:6]}"
     p = _results_dir() / f"{rid}.json"
-    data = {
+    data: dict[str, Any] = {
         "created_at": datetime.now(timezone.utc).isoformat(),
         "model": model,
         "persona_count": persona_count,
@@ -475,5 +478,7 @@ def save_panel_result(
         "total_cost": total_cost,
         "results": results,
     }
+    if variant_count > 0:
+        data["variant_count"] = variant_count
     p.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
     return rid

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -79,7 +79,9 @@ from synth_panel.orchestrator import (
     run_multi_round_panel,
     run_panel_parallel,
 )
+from synth_panel.perturbation import generate_panel_variants
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
+from synth_panel.stats import robustness_score
 from synth_panel.synthesis import synthesize_panel
 
 logger = logging.getLogger(__name__)
@@ -122,12 +124,37 @@ def _run_panel_sync(
     persona_models: dict[str, str] | None = None,
     extract_schema: dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
-) -> tuple[list[PanelistResult], list[dict[str, Any]], CostTokenUsage, Any, dict[str, Any] | None]:
-    """Run panel synchronously. Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict)."""
+    variants: int = 0,
+) -> tuple[
+    list[PanelistResult], list[dict[str, Any]], CostTokenUsage, Any, dict[str, Any] | None, dict[str, Any] | None
+]:
+    """Run panel synchronously.
+
+    Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data).
+    variant_data is None when variants == 0.
+    """
     client = LLMClient()
+
+    # Generate persona variants if requested
+    all_personas = list(personas)
+    variant_names: set[str] = set()
+    variant_mapping: dict[str, str] = {}  # variant_name -> source_name
+    variant_count = 0
+
+    if variants > 0:
+        logger.info("Generating %d variants per persona", variants)
+        variant_sets = generate_panel_variants(personas, client, k=variants, model=model)
+        for vs in variant_sets:
+            for v in vs.variants:
+                all_personas.append(v.persona)
+                variant_names.add(v.variant_name)
+                variant_mapping[v.variant_name] = v.source_persona_name
+                variant_count += 1
+        logger.info("Running panel with %d base + %d variant personas", len(personas), variant_count)
+
     panelist_results, _registry, _sessions = run_panel_parallel(
         client=client,
-        personas=personas,
+        personas=all_personas,
         questions=questions,
         model=model,
         system_prompt_fn=persona_system_prompt,
@@ -160,13 +187,14 @@ def _run_panel_sync(
     pricing, _ = lookup_pricing(model)
     panelist_cost = estimate_cost(panelist_usage, pricing)
 
-    # Synthesis
+    # Synthesis (base personas only)
+    base_results = [pr for pr in panelist_results if pr.persona_name not in variant_names]
     synthesis_dict: dict[str, Any] | None = None
     if synthesis:
         try:
             synthesis_result = synthesize_panel(
                 client,
-                panelist_results,
+                base_results,
                 questions,
                 model=synthesis_model,
                 panelist_model=model,
@@ -179,7 +207,109 @@ def _run_panel_sync(
             logger.error("Synthesis failed (non-fatal)", exc_info=True)
             synthesis_dict = {"synthesis_error": "Synthesis failed — see server logs for details."}
 
-    return panelist_results, result_dicts, panelist_usage, panelist_cost, synthesis_dict
+    # Compute robustness scores when variants were used
+    variant_data: dict[str, Any] | None = None
+    if variants > 0 and variant_mapping:
+        variant_data = _compute_variant_data(
+            result_dicts,
+            variant_names,
+            variant_mapping,
+            variant_count,
+            questions,
+        )
+
+    return panelist_results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data
+
+
+def _compute_variant_data(
+    result_dicts: list[dict[str, Any]],
+    variant_names: set[str],
+    variant_mapping: dict[str, str],
+    variant_count: int,
+    questions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Compute robustness scores from base + variant panel results."""
+    # Separate base and variant results
+    base_results = [r for r in result_dicts if r["persona"] not in variant_names]
+    variant_results = [r for r in result_dicts if r["persona"] in variant_names]
+
+    # Build per-question robustness scores
+    robustness_scores: list[dict[str, Any]] = []
+    per_persona_robustness: list[dict[str, Any]] = []
+    n_questions = len(questions)
+
+    for qi in range(n_questions):
+        # Group variant responses by source persona
+        variant_resps: dict[str, list[str]] = {}
+        for vr in variant_results:
+            source = variant_mapping.get(vr["persona"], "")
+            if not source:
+                continue
+            resps = vr.get("responses", [])
+            if qi < len(resps) and not resps[qi].get("error"):
+                variant_resps.setdefault(source, []).append(resps[qi].get("response", ""))
+
+        # Get base persona responses for this question
+        for br in base_results:
+            resps = br.get("responses", [])
+            if qi >= len(resps) or resps[qi].get("error"):
+                continue
+
+            base_response = resps[qi].get("response", "")
+            persona_name = br["persona"]
+            v_resps = variant_resps.get(persona_name, [])
+
+            if v_resps:
+                try:
+                    rs = robustness_score({persona_name: v_resps}, base_response)
+                    per_persona_robustness.append(
+                        {
+                            "persona": persona_name,
+                            "question_index": qi,
+                            "robustness": round(rs.per_persona.get(persona_name, 0.0), 4),
+                            "k_variants": len(v_resps),
+                            "finding_value": base_response,
+                            "interpretation": rs.interpretation,
+                        }
+                    )
+                except (ValueError, ZeroDivisionError):
+                    pass
+
+        # Overall robustness for this question across all base personas
+        if variant_resps:
+            # Find most common base response as the "finding"
+            base_responses_q = [
+                br["responses"][qi].get("response", "")
+                for br in base_results
+                if qi < len(br.get("responses", [])) and not br["responses"][qi].get("error")
+            ]
+            if base_responses_q:
+                from collections import Counter
+
+                most_common = Counter(base_responses_q).most_common(1)[0][0]
+                # Merge all variant responses for aggregate score
+                all_v = {}
+                for name, resps_list in variant_resps.items():
+                    all_v[name] = resps_list
+                try:
+                    agg = robustness_score(all_v, most_common)
+                    robustness_scores.append(
+                        {
+                            "question_index": qi,
+                            "question_text": questions[qi].get("text", ""),
+                            "finding_value": most_common,
+                            "overall_robustness": round(agg.overall_robustness, 4),
+                            "interpretation": agg.interpretation,
+                        }
+                    )
+                except (ValueError, ZeroDivisionError):
+                    pass
+
+    return {
+        "variant_count": variant_count,
+        "robustness_scores": robustness_scores,
+        "per_persona_robustness": per_persona_robustness,
+    }
 
 
 def _run_multi_round_sync(
@@ -395,6 +525,7 @@ async def _run_panel_async(
     persona_models: dict[str, str] | None = None,
     extract_schema: dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
+    variants: int = 0,
 ) -> dict[str, Any]:
     """Run panel via asyncio.to_thread with progress notifications."""
     total = len(personas)
@@ -402,7 +533,14 @@ async def _run_panel_async(
     await ctx.report_progress(0, total)
 
     # Run the blocking panel execution in a thread
-    _panelist_results, result_dicts, panelist_usage, panelist_cost, synthesis_dict = await asyncio.wait_for(
+    (
+        _panelist_results,
+        result_dicts,
+        panelist_usage,
+        panelist_cost,
+        synthesis_dict,
+        variant_data,
+    ) = await asyncio.wait_for(
         asyncio.to_thread(
             _run_panel_sync,
             personas,
@@ -417,8 +555,9 @@ async def _run_panel_async(
             persona_models=persona_models,
             extract_schema=extract_schema,
             synthesis_temperature=synthesis_temperature,
+            variants=variants,
         ),
-        timeout=PANELIST_TIMEOUT * total,
+        timeout=PANELIST_TIMEOUT * total * (1 + variants),
     )
 
     await ctx.report_progress(total, total)
@@ -452,6 +591,7 @@ async def _run_panel_async(
     )
 
     # Save result
+    variant_count = variant_data["variant_count"] if variant_data else 0
     result_id = save_panel_result(
         results=result_dicts,
         model=model,
@@ -459,9 +599,10 @@ async def _run_panel_async(
         total_cost=total_cost.format_usd(),
         persona_count=len(personas),
         question_count=len(questions),
+        variant_count=variant_count,
     )
 
-    return {
+    result: dict[str, Any] = {
         "result_id": result_id,
         "model": model,
         "persona_count": len(personas),
@@ -481,6 +622,13 @@ async def _run_panel_async(
         "warnings": [],
         "metadata": metadata,
     }
+
+    if variant_data:
+        result["robustness_scores"] = variant_data["robustness_scores"]
+        result["per_persona_robustness"] = variant_data["per_persona_robustness"]
+        result["variant_count"] = variant_data["variant_count"]
+
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -553,6 +701,7 @@ async def run_panel(
     persona_models: dict[str, str] | None = None,
     extract_schema: dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
+    variants: int | None = None,
     ctx: Context = None,
 ) -> str:
     """Run a full synthetic focus group panel.
@@ -609,9 +758,16 @@ async def run_panel(
         extract_schema: JSON Schema for structured extraction from responses.
         synthesis_temperature: Sampling temperature for the synthesis step.
             Independent of the panelist temperature.
+        variants: Number of persona variants to generate per persona for
+            robustness analysis. When > 0, each persona is perturbed K times
+            and all variants run through the same questions. Results include
+            robustness_scores and per_persona_robustness. Default: no variants.
     """
     model = model or MCP_DEFAULT_MODEL
-    logger.info("run_panel: model=%s synthesis=%s", model, synthesis)
+    variants_k = variants or 0
+    if variants_k < 0 or variants_k > 20:
+        return json.dumps({"error": "variants must be between 0 and 20."})
+    logger.info("run_panel: model=%s synthesis=%s variants=%d", model, synthesis, variants_k)
     merged = list(personas) if personas else []
     if pack_id is not None:
         pack = _data_get_persona_pack(pack_id)
@@ -684,6 +840,7 @@ async def run_panel(
         persona_models=persona_models,
         extract_schema=extract_schema,
         synthesis_temperature=synthesis_temperature,
+        variants=variants_k,
     )
     return json.dumps(result, indent=2)
 

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -277,3 +277,166 @@ class TestPanelistResultModel:
     def test_model_field_set(self):
         pr = PanelistResult(persona_name="Test", responses=[], usage=ZERO_USAGE, model="haiku")
         assert pr.model == "haiku"
+
+
+# ---------------------------------------------------------------------------
+# Tests: ensemble_run (multi-model runner loop)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsembleRun:
+    """Test ensemble_run: sequential N panel runs with per-model cost aggregation."""
+
+    def _mock_run_parallel(self, **kwargs):
+        """Side effect for mocked run_panel_parallel."""
+        from synth_panel.cost import TokenUsage as CostTokenUsage
+
+        model = kwargs["model"]
+        personas = kwargs["personas"]
+        results = [
+            PanelistResult(
+                persona_name=p["name"],
+                responses=[{"question": "Q1", "response": f"answer from {model}", "error": False}],
+                usage=CostTokenUsage(input_tokens=100, output_tokens=50),
+                model=model,
+            )
+            for p in personas
+        ]
+        sessions = {p["name"]: MagicMock() for p in personas}
+        return results, MagicMock(), sessions
+
+    def test_runs_once_per_model(self):
+        """ensemble_run should call run_panel_parallel once per model."""
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            _ensemble_run(personas, questions, models, client)
+
+        assert mock_rpp.call_count == 2
+        assert mock_rpp.call_args_list[0][1]["model"] == "haiku"
+        assert mock_rpp.call_args_list[1][1]["model"] == "sonnet"
+
+    def test_per_model_results_stored_separately(self):
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import EnsembleResult as _ER
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        assert isinstance(result, _ER)
+        assert len(result.model_results) == 2
+        assert result.model_results[0].model == "haiku"
+        assert result.model_results[1].model == "sonnet"
+
+    def test_per_model_cost_breakdown(self):
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        assert "haiku" in result.per_model_cost
+        assert "sonnet" in result.per_model_cost
+        assert result.per_model_cost["haiku"].startswith("$")
+        assert result.per_model_cost["sonnet"].startswith("$")
+
+    def test_total_cost_aggregated(self):
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        assert result.total_cost.total_cost > 0
+        model_costs_sum = sum(mr.cost.total_cost for mr in result.model_results)
+        assert abs(result.total_cost.total_cost - model_costs_sum) < 1e-10
+
+    def test_total_usage_aggregated(self):
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        # Each model: 100 input + 50 output per persona, 1 persona, 2 models
+        assert result.total_usage.input_tokens == 200
+        assert result.total_usage.output_tokens == 100
+
+    def test_empty_models_raises(self):
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        with pytest.raises(ValueError, match="models list must not be empty"):
+            _ensemble_run([], [], [], MagicMock())
+
+    def test_panelist_results_tagged_with_model(self):
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        for mr in result.model_results:
+            for pr in mr.panelist_results:
+                assert pr.model == mr.model
+
+    def test_metadata_counts(self):
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}, {"name": "Bob"}, {"name": "Carol"}]
+        questions = [{"text": "Q1"}, {"text": "Q2"}]
+        models = ["haiku"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        assert result.persona_count == 3
+        assert result.question_count == 2
+        assert result.models == ["haiku"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -458,3 +458,188 @@ class TestExtendPanelContract:
         # Both halves of the contract must be present.
         assert "ad-hoc" in doc
         assert "not" in doc and "DAG" in doc
+
+
+# ---------------------------------------------------------------------------
+# run_panel variants parameter
+# ---------------------------------------------------------------------------
+
+
+class TestRunPanelVariants:
+    """Test run_panel's variants parameter for robustness analysis."""
+
+    @pytest.mark.asyncio
+    async def test_variants_param_accepted(self):
+        """run_panel should accept variants param and forward to _run_panel_async."""
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": []}
+            await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                    "variants": 3,
+                },
+            )
+            # variants should be forwarded as keyword argument
+            kwargs = mock_run.call_args[1]
+            assert kwargs.get("variants") == 3
+
+    @pytest.mark.asyncio
+    async def test_variants_zero_no_robustness(self):
+        """variants=0 (default) should not include robustness data."""
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": [], "rounds": []}
+            await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                },
+            )
+            kwargs = mock_run.call_args[1]
+            assert kwargs.get("variants", 0) == 0
+
+    @pytest.mark.asyncio
+    async def test_variants_invalid_returns_error(self):
+        """variants > 20 should return an error."""
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "variants": 25,
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "variants" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_variants_negative_returns_error(self):
+        """variants < 0 should return an error."""
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "variants": -1,
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# list_panel_results variant_count
+# ---------------------------------------------------------------------------
+
+
+class TestListPanelResultsVariantCount:
+    """list_panel_results should include variant_count when present."""
+
+    @pytest.mark.asyncio
+    async def test_variant_count_in_listing(self):
+        """Results saved with variant_count should include it in listing."""
+        from synth_panel.mcp.data import save_panel_result
+
+        save_panel_result(
+            results=[{"persona": "A", "responses": [], "usage": {}, "cost": "$0", "error": None}],
+            model="haiku",
+            total_usage={"input_tokens": 0, "output_tokens": 0},
+            total_cost="$0.00",
+            persona_count=1,
+            question_count=1,
+            variant_count=5,
+        )
+        result = await mcp.call_tool("list_panel_results", {})
+        data = json.loads(result[0][0].text)
+        assert len(data) == 1
+        assert data[0]["variant_count"] == 5
+
+    @pytest.mark.asyncio
+    async def test_no_variant_count_when_zero(self):
+        """Results without variants should not include variant_count."""
+        from synth_panel.mcp.data import save_panel_result
+
+        save_panel_result(
+            results=[{"persona": "A", "responses": [], "usage": {}, "cost": "$0", "error": None}],
+            model="haiku",
+            total_usage={"input_tokens": 0, "output_tokens": 0},
+            total_cost="$0.00",
+            persona_count=1,
+            question_count=1,
+        )
+        result = await mcp.call_tool("list_panel_results", {})
+        data = json.loads(result[0][0].text)
+        assert len(data) == 1
+        assert "variant_count" not in data[0]
+
+
+# ---------------------------------------------------------------------------
+# _compute_variant_data
+# ---------------------------------------------------------------------------
+
+
+class TestComputeVariantData:
+    """Test the robustness computation from variant results."""
+
+    def test_compute_variant_data_basic(self):
+        from synth_panel.mcp.server import _compute_variant_data
+
+        result_dicts = [
+            # Base persona
+            {
+                "persona": "Alice",
+                "responses": [{"question": "Q1", "response": "agree", "error": False}],
+                "usage": {},
+                "cost": "$0",
+                "error": None,
+            },
+            # Variant
+            {
+                "persona": "Alice (v0)",
+                "responses": [{"question": "Q1", "response": "agree", "error": False}],
+                "usage": {},
+                "cost": "$0",
+                "error": None,
+            },
+            {
+                "persona": "Alice (v1)",
+                "responses": [{"question": "Q1", "response": "disagree", "error": False}],
+                "usage": {},
+                "cost": "$0",
+                "error": None,
+            },
+        ]
+        variant_names = {"Alice (v0)", "Alice (v1)"}
+        variant_mapping = {"Alice (v0)": "Alice", "Alice (v1)": "Alice"}
+        questions = [{"text": "Do you agree?"}]
+
+        data = _compute_variant_data(result_dicts, variant_names, variant_mapping, 2, questions)
+
+        assert data["variant_count"] == 2
+        assert len(data["robustness_scores"]) == 1
+        assert len(data["per_persona_robustness"]) == 1
+        assert data["per_persona_robustness"][0]["persona"] == "Alice"
+        assert data["per_persona_robustness"][0]["k_variants"] == 2
+        # One variant agreed, one disagreed -> 0.5 robustness
+        assert data["per_persona_robustness"][0]["robustness"] == 0.5
+
+    def test_compute_variant_data_no_variants(self):
+        from synth_panel.mcp.server import _compute_variant_data
+
+        result_dicts = [
+            {
+                "persona": "Alice",
+                "responses": [{"question": "Q1", "response": "agree", "error": False}],
+                "usage": {},
+                "cost": "$0",
+                "error": None,
+            },
+        ]
+        data = _compute_variant_data(result_dicts, set(), {}, 0, [{"text": "Q1"}])
+
+        assert data["variant_count"] == 0
+        assert data["robustness_scores"] == []
+        assert data["per_persona_robustness"] == []


### PR DESCRIPTION
## Summary

- Adds variants param to MCP run_panel for robustness analysis (sp-5on.17)
- Adds multi-model ensemble runner with per-model cost aggregation (sp-5on.11)
- Issue: sp-5on.17, sp-5on.11
- Polecat: toast
- Branch: polecat/toast-mnu6vhd5
- Tests: 818 passed, lint clean, mypy clean

---
*Created by Gas Town Refinery*