### PR TITLE
feat: add pack generate subcommand for LLM-based persona generation (sp-5on.18)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1039,6 +1039,109 @@ def handle_pack_show(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return handle_pack_export(args, fmt)
 
 
+def handle_pack_generate(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Generate a persona pack using an LLM."""
+    from synth_panel.llm.models import InputMessage, TextBlock
+    from synth_panel.mcp.data import PackValidationError, save_persona_pack
+    from synth_panel.structured.output import StructuredOutputConfig, StructuredOutputEngine
+
+    count = args.count
+    if count < 1 or count > 50:
+        print("Error: --count must be between 1 and 50.", file=sys.stderr)
+        return 1
+
+    model = _resolve_model(args)
+
+    schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "personas": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Full name."},
+                        "age": {"type": "integer", "description": "Age in years."},
+                        "occupation": {"type": "string", "description": "Job title or role."},
+                        "background": {
+                            "type": "string",
+                            "description": "One-paragraph professional and personal background.",
+                        },
+                        "personality_traits": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "3-5 personality traits relevant to their product usage.",
+                        },
+                    },
+                    "required": ["name", "age", "occupation", "background", "personality_traits"],
+                },
+            },
+        },
+        "required": ["personas"],
+    }
+
+    prompt = (
+        f"Generate exactly {count} diverse, realistic personas for a synthetic focus group.\n\n"
+        f"Product/service: {args.product}\n"
+        f"Target audience: {args.audience}\n\n"
+        "Requirements:\n"
+        f"- Generate exactly {count} personas\n"
+        "- Each persona needs: name, age, occupation, background (one paragraph), "
+        "and 3-5 personality_traits\n"
+        "- Personas should be diverse in age, occupation, background, and perspective\n"
+        "- Backgrounds should be specific and relevant to the product/audience context\n"
+        "- Personality traits should reflect how they'd engage with the product\n"
+        "- Names should reflect diverse cultural backgrounds"
+    )
+
+    client = LLMClient()
+    engine = StructuredOutputEngine(client)
+    config = StructuredOutputConfig(
+        schema=schema,
+        tool_name="generate_personas",
+        tool_description="Generate a list of diverse personas for a synthetic focus group.",
+    )
+
+    try:
+        result = engine.extract(
+            model=model,
+            max_tokens=4096,
+            messages=[InputMessage(role="user", content=[TextBlock(text=prompt)])],
+            config=config,
+            temperature=1.0,
+        )
+    except Exception as exc:
+        print(f"Error calling LLM: {exc}", file=sys.stderr)
+        return 1
+
+    if result.is_fallback:
+        print(f"Error: LLM did not produce valid structured output: {result.error}", file=sys.stderr)
+        return 1
+
+    personas = result.data.get("personas", [])
+    if not personas:
+        print("Error: LLM returned no personas.", file=sys.stderr)
+        return 1
+
+    pack_name = args.name or f"{args.product[:60]} personas"
+
+    try:
+        saved = save_persona_pack(pack_name, personas, pack_id=args.pack_id)
+    except PackValidationError as exc:
+        print(f"Validation error: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.TEXT:
+        print(
+            f"Generated pack '{saved['name']}' ({saved['persona_count']} personas) as {saved['id']}"
+        )
+        print(f"Saved to: {saved['path']}")
+    else:
+        emit(fmt, message="Pack generated", extra=saved)
+
+    return 0
+
+
 def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Start the MCP server on stdio transport."""
     from synth_panel.mcp.server import serve

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1132,9 +1132,7 @@ def handle_pack_generate(args: argparse.Namespace, fmt: OutputFormat) -> int:
         return 1
 
     if fmt is OutputFormat.TEXT:
-        print(
-            f"Generated pack '{saved['name']}' ({saved['persona_count']} personas) as {saved['id']}"
-        )
+        print(f"Generated pack '{saved['name']}' ({saved['persona_count']} personas) as {saved['id']}")
         print(f"Saved to: {saved['path']}")
     else:
         emit(fmt, message="Pack generated", extra=saved)

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -333,6 +333,44 @@ def build_parser() -> argparse.ArgumentParser:
         help="ID of the persona pack to show.",
     )
 
+    # pack generate (sp-5on.18: LLM-based persona generation)
+    pack_generate_parser = pack_subparsers.add_parser(
+        "generate",
+        help="Generate a persona pack using an LLM.",
+    )
+    pack_generate_parser.add_argument(
+        "--product",
+        required=True,
+        help="Description of the product or service being researched.",
+    )
+    pack_generate_parser.add_argument(
+        "--audience",
+        required=True,
+        help="Target audience for the personas.",
+    )
+    pack_generate_parser.add_argument(
+        "--count",
+        type=int,
+        default=5,
+        help="Number of personas to generate (default: 5).",
+    )
+    pack_generate_parser.add_argument(
+        "--model",
+        default=None,
+        help="LLM model to use (default: auto-detect from available API keys).",
+    )
+    pack_generate_parser.add_argument(
+        "--name",
+        default=None,
+        help="Name for the generated pack (default: derived from product).",
+    )
+    pack_generate_parser.add_argument(
+        "--id",
+        default=None,
+        dest="pack_id",
+        help="Custom pack ID (default: auto-generated).",
+    )
+
     # instruments
     instruments_parser = subparsers.add_parser(
         "instruments",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -16,6 +16,7 @@ from synth_panel.cli.commands import (
     handle_instruments_show,
     handle_mcp_serve,
     handle_pack_export,
+    handle_pack_generate,
     handle_pack_import,
     handle_pack_list,
     handle_pack_show,
@@ -61,6 +62,8 @@ def main(argv: list[str] | None = None) -> int:
             return handle_pack_export(args, output_format)
         elif sub == "show":
             return handle_pack_show(args, output_format)
+        elif sub == "generate":
+            return handle_pack_generate(args, output_format)
         else:
             parser.parse_args(["pack", "--help"])
             return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1221,12 +1221,18 @@ class TestPackCommands:
         mock_client.send.return_value = mock_response
         monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
 
-        code = main([
-            "pack", "generate",
-            "--product", "project management tool",
-            "--audience", "engineering teams",
-            "--count", "2",
-        ])
+        code = main(
+            [
+                "pack",
+                "generate",
+                "--product",
+                "project management tool",
+                "--audience",
+                "engineering teams",
+                "--count",
+                "2",
+            ]
+        )
         assert code == 0
         out = capsys.readouterr().out
         assert "2 personas" in out
@@ -1245,8 +1251,17 @@ class TestPackCommands:
                 ToolInvocationBlock(
                     id="tc1",
                     name="generate_personas",
-                    input={"personas": [{"name": "Eve", "age": 40, "occupation": "CTO",
-                                         "background": "Led teams.", "personality_traits": ["bold"]}]},
+                    input={
+                        "personas": [
+                            {
+                                "name": "Eve",
+                                "age": 40,
+                                "occupation": "CTO",
+                                "background": "Led teams.",
+                                "personality_traits": ["bold"],
+                            }
+                        ]
+                    },
                 ),
             ],
             usage=TokenUsage(input_tokens=10, output_tokens=20),
@@ -1256,14 +1271,22 @@ class TestPackCommands:
         mock_client.send.return_value = mock_response
         monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
 
-        code = main([
-            "pack", "generate",
-            "--product", "CRM",
-            "--audience", "sales teams",
-            "--count", "1",
-            "--name", "Sales Personas",
-            "--id", "sales-gen",
-        ])
+        code = main(
+            [
+                "pack",
+                "generate",
+                "--product",
+                "CRM",
+                "--audience",
+                "sales teams",
+                "--count",
+                "1",
+                "--name",
+                "Sales Personas",
+                "--id",
+                "sales-gen",
+            ]
+        )
         assert code == 0
         out = capsys.readouterr().out
         assert "Sales Personas" in out
@@ -1286,23 +1309,34 @@ class TestPackCommands:
         mock_client.send.return_value = mock_response
         monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
 
-        code = main([
-            "pack", "generate",
-            "--product", "widget",
-            "--audience", "everyone",
-        ])
+        code = main(
+            [
+                "pack",
+                "generate",
+                "--product",
+                "widget",
+                "--audience",
+                "everyone",
+            ]
+        )
         assert code == 1
         err = capsys.readouterr().err
         assert "structured output" in err.lower() or "tool call" in err.lower()
 
     def test_pack_generate_invalid_count(self, capsys):
         """pack generate rejects count outside 1-50."""
-        code = main([
-            "pack", "generate",
-            "--product", "x",
-            "--audience", "y",
-            "--count", "0",
-        ])
+        code = main(
+            [
+                "pack",
+                "generate",
+                "--product",
+                "x",
+                "--audience",
+                "y",
+                "--count",
+                "0",
+            ]
+        )
         assert code == 1
         assert "count" in capsys.readouterr().err.lower()
 
@@ -1319,8 +1353,17 @@ class TestPackCommands:
                 ToolInvocationBlock(
                     id="tc1",
                     name="generate_personas",
-                    input={"personas": [{"name": "Zara", "age": 25, "occupation": "Designer",
-                                         "background": "UX designer.", "personality_traits": ["creative"]}]},
+                    input={
+                        "personas": [
+                            {
+                                "name": "Zara",
+                                "age": 25,
+                                "occupation": "Designer",
+                                "background": "UX designer.",
+                                "personality_traits": ["creative"],
+                            }
+                        ]
+                    },
                 ),
             ],
             usage=TokenUsage(input_tokens=10, output_tokens=20),
@@ -1330,13 +1373,20 @@ class TestPackCommands:
         mock_client.send.return_value = mock_response
         monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
 
-        code = main([
-            "--output-format", "json",
-            "pack", "generate",
-            "--product", "design tool",
-            "--audience", "designers",
-            "--count", "1",
-        ])
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "pack",
+                "generate",
+                "--product",
+                "design tool",
+                "--audience",
+                "designers",
+                "--count",
+                "1",
+            ]
+        )
         assert code == 0
         data = json.loads(capsys.readouterr().out)
         assert data["persona_count"] == 1
@@ -1355,12 +1405,18 @@ class TestPackCommands:
         assert args.pack_command == "export"
         assert args.pack_id == "my-pack"
 
-        args = parser.parse_args([
-            "pack", "generate",
-            "--product", "test product",
-            "--audience", "test audience",
-            "--count", "3",
-        ])
+        args = parser.parse_args(
+            [
+                "pack",
+                "generate",
+                "--product",
+                "test product",
+                "--audience",
+                "test audience",
+                "--count",
+                "3",
+            ]
+        )
         assert args.pack_command == "generate"
         assert args.product == "test product"
         assert args.audience == "test audience"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1181,6 +1181,166 @@ class TestPackCommands:
         out = capsys.readouterr().out
         assert "my-team" in out
 
+    def test_pack_generate_success(self, capsys, monkeypatch):
+        """pack generate calls LLM and saves a valid persona pack."""
+        from unittest.mock import MagicMock
+
+        from synth_panel.llm.models import CompletionResponse, TokenUsage, ToolInvocationBlock
+
+        mock_personas = [
+            {
+                "name": "Alice Chen",
+                "age": 34,
+                "occupation": "Product Manager",
+                "background": "Ten years in SaaS product management.",
+                "personality_traits": ["analytical", "pragmatic"],
+            },
+            {
+                "name": "Bob Rivera",
+                "age": 28,
+                "occupation": "Software Engineer",
+                "background": "Full-stack developer at a startup.",
+                "personality_traits": ["curious", "detail-oriented"],
+            },
+        ]
+
+        mock_response = CompletionResponse(
+            id="r1",
+            model="test",
+            content=[
+                ToolInvocationBlock(
+                    id="tc1",
+                    name="generate_personas",
+                    input={"personas": mock_personas},
+                ),
+            ],
+            usage=TokenUsage(input_tokens=100, output_tokens=200),
+        )
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = mock_response
+        monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
+
+        code = main([
+            "pack", "generate",
+            "--product", "project management tool",
+            "--audience", "engineering teams",
+            "--count", "2",
+        ])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "2 personas" in out
+        assert "project management tool personas" in out
+
+    def test_pack_generate_custom_name_and_id(self, capsys, monkeypatch):
+        """pack generate respects --name and --id flags."""
+        from unittest.mock import MagicMock
+
+        from synth_panel.llm.models import CompletionResponse, TokenUsage, ToolInvocationBlock
+
+        mock_response = CompletionResponse(
+            id="r1",
+            model="test",
+            content=[
+                ToolInvocationBlock(
+                    id="tc1",
+                    name="generate_personas",
+                    input={"personas": [{"name": "Eve", "age": 40, "occupation": "CTO",
+                                         "background": "Led teams.", "personality_traits": ["bold"]}]},
+                ),
+            ],
+            usage=TokenUsage(input_tokens=10, output_tokens=20),
+        )
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = mock_response
+        monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
+
+        code = main([
+            "pack", "generate",
+            "--product", "CRM",
+            "--audience", "sales teams",
+            "--count", "1",
+            "--name", "Sales Personas",
+            "--id", "sales-gen",
+        ])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Sales Personas" in out
+        assert "sales-gen" in out
+
+    def test_pack_generate_llm_fallback_error(self, capsys, monkeypatch):
+        """pack generate returns 1 when LLM fails to produce structured output."""
+        from unittest.mock import MagicMock
+
+        from synth_panel.llm.models import CompletionResponse, TextBlock, TokenUsage
+
+        mock_response = CompletionResponse(
+            id="r1",
+            model="test",
+            content=[TextBlock(text="Sorry, I cannot do that.")],
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = mock_response
+        monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
+
+        code = main([
+            "pack", "generate",
+            "--product", "widget",
+            "--audience", "everyone",
+        ])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "structured output" in err.lower() or "tool call" in err.lower()
+
+    def test_pack_generate_invalid_count(self, capsys):
+        """pack generate rejects count outside 1-50."""
+        code = main([
+            "pack", "generate",
+            "--product", "x",
+            "--audience", "y",
+            "--count", "0",
+        ])
+        assert code == 1
+        assert "count" in capsys.readouterr().err.lower()
+
+    def test_pack_generate_json_output(self, capsys, monkeypatch):
+        """pack generate emits JSON when --output-format json is used."""
+        from unittest.mock import MagicMock
+
+        from synth_panel.llm.models import CompletionResponse, TokenUsage, ToolInvocationBlock
+
+        mock_response = CompletionResponse(
+            id="r1",
+            model="test",
+            content=[
+                ToolInvocationBlock(
+                    id="tc1",
+                    name="generate_personas",
+                    input={"personas": [{"name": "Zara", "age": 25, "occupation": "Designer",
+                                         "background": "UX designer.", "personality_traits": ["creative"]}]},
+                ),
+            ],
+            usage=TokenUsage(input_tokens=10, output_tokens=20),
+        )
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = mock_response
+        monkeypatch.setattr("synth_panel.cli.commands.LLMClient", lambda: mock_client)
+
+        code = main([
+            "--output-format", "json",
+            "pack", "generate",
+            "--product", "design tool",
+            "--audience", "designers",
+            "--count", "1",
+        ])
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["persona_count"] == 1
+
     def test_parser_pack_subcommands(self):
         parser = build_parser()
         args = parser.parse_args(["pack", "list"])
@@ -1194,6 +1354,17 @@ class TestPackCommands:
         args = parser.parse_args(["pack", "export", "my-pack"])
         assert args.pack_command == "export"
         assert args.pack_id == "my-pack"
+
+        args = parser.parse_args([
+            "pack", "generate",
+            "--product", "test product",
+            "--audience", "test audience",
+            "--count", "3",
+        ])
+        assert args.pack_command == "generate"
+        assert args.product == "test product"
+        assert args.audience == "test audience"
+        assert args.count == 3
 
 
 # --- Schema loading tests ---


### PR DESCRIPTION
## Summary

- Adds pack generate subcommand for LLM-based domain persona generation
- Issue: sp-5on.18
- Polecat: slit
- Branch: polecat/slit-packgen
- Tests: 807 passed, lint clean, mypy clean

---
*Created by Gas Town Refinery*