### PR TITLE
fix: reuse LLMClient across MCP tool calls (sp-clientreuse)

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -175,6 +175,10 @@ mcp = FastMCP(
     ),
 )
 
+# Shared LLM client — reused across tool calls to avoid rebuilding the
+# provider cache on every invocation.  Thread-safe by design (see LLMClient).
+_shared_client = LLMClient()
+
 
 # ---------------------------------------------------------------------------
 # Internal panel runner (bridges threads to async)
@@ -204,7 +208,7 @@ def _run_panel_sync(
     Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data).
     variant_data is None when variants == 0.
     """
-    client = LLMClient()
+    client = _shared_client
 
     # Generate persona variants if requested
     all_personas = list(personas)
@@ -399,7 +403,7 @@ def _run_multi_round_sync(
     synthesis_temperature: float | None = None,
 ) -> MultiRoundResult:
     """Drive run_multi_round_panel for v1/v2/v3 instruments."""
-    client = LLMClient()
+    client = _shared_client
 
     def _round_synth(
         c: LLMClient,
@@ -727,7 +731,7 @@ async def run_prompt(
     """
     model = model or MCP_DEFAULT_MODEL
     logger.info("run_prompt: model=%s prompt_len=%d", model, len(prompt))
-    client = LLMClient()
+    client = _shared_client
     request = CompletionRequest(
         model=model,
         max_tokens=4096,
@@ -1119,7 +1123,7 @@ async def extend_panel(
         await ctx.report_progress(0, len(personas))
 
     def _go() -> tuple[list[PanelistResult], Any]:
-        client = LLMClient()
+        client = _shared_client
         results, _registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,


### PR DESCRIPTION
## Summary

- Reuses a shared `LLMClient` instance across MCP tool calls instead of creating a new one per call
- Resolves conflict with variants support on main

- **Issue**: sp-clientreuse (conflict resolution: sp-0rq)
- **Polecat**: dementus-sp
- **Branch**: polecat/dementus-sp-clientreuse
- **Tests**: 819 passed (verified by refinery)

---
*Created by Gas Town Refinery*