### PR TITLE
feat: add --models ensemble mode and MCP models parameter (sp-5on.13)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -81,31 +81,48 @@ def _resolve_model(args: argparse.Namespace) -> str:
 def parse_models_spec(spec: str) -> list[tuple[str, float]]:
     """Parse a --models spec string into [(model, weight)] pairs.
 
-    Format: "haiku:0.5,gemini-2.5-flash:0.5"
-    Weights must be positive and are normalized to sum to 1.0.
+    Accepted formats:
+
+    * **Weighted** (per-persona assignment): ``"haiku:0.5,gemini:0.5"``
+    * **Ensemble** (no weights): ``"haiku,sonnet"`` — each model gets weight 1.0
+
+    When no entry contains ``:``, the spec is treated as an ensemble list.
+    Weights must be positive and are normalized to sum to 1.0 by the caller.
     """
-    pairs: list[tuple[str, float]] = []
-    for entry in spec.split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        if ":" not in entry:
-            raise ValueError(f"Invalid model spec entry '{entry}': expected 'model:weight' (e.g. 'haiku:0.5')")
-        model_part, weight_str = entry.rsplit(":", 1)
-        model_part = model_part.strip()
-        weight_str = weight_str.strip()
-        if not model_part:
-            raise ValueError(f"Empty model name in spec entry '{entry}'")
-        try:
-            weight = float(weight_str)
-        except ValueError as exc:
-            raise ValueError(f"Invalid weight '{weight_str}' in spec entry '{entry}': must be a number") from exc
-        if weight <= 0:
-            raise ValueError(f"Weight must be positive, got {weight} for model '{model_part}'")
-        pairs.append((model_part, weight))
-    if not pairs:
+    entries = [e.strip() for e in spec.split(",") if e.strip()]
+    if not entries:
         raise ValueError("Empty --models spec")
+
+    # Detect ensemble vs weighted: ensemble if *no* entry contains ':'
+    is_ensemble = all(":" not in e for e in entries)
+
+    pairs: list[tuple[str, float]] = []
+    for entry in entries:
+        if is_ensemble:
+            if not entry:
+                raise ValueError("Empty model name in spec")
+            pairs.append((entry, 1.0))
+        else:
+            if ":" not in entry:
+                raise ValueError(f"Invalid model spec entry '{entry}': expected 'model:weight' (e.g. 'haiku:0.5')")
+            model_part, weight_str = entry.rsplit(":", 1)
+            model_part = model_part.strip()
+            weight_str = weight_str.strip()
+            if not model_part:
+                raise ValueError(f"Empty model name in spec entry '{entry}'")
+            try:
+                weight = float(weight_str)
+            except ValueError as exc:
+                raise ValueError(f"Invalid weight '{weight_str}' in spec entry '{entry}': must be a number") from exc
+            if weight <= 0:
+                raise ValueError(f"Weight must be positive, got {weight} for model '{model_part}'")
+            pairs.append((model_part, weight))
     return pairs
+
+
+def is_ensemble_spec(spec: str) -> bool:
+    """Return True when *spec* is a weight-free ensemble list (e.g. ``"haiku,sonnet"``)."""
+    return all(":" not in e for e in spec.split(",") if e.strip())
 
 
 def assign_models_to_personas(
@@ -505,18 +522,21 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     # ── sp-blend: multi-model ensemble ───────────────────────────────────
     # Parse --models spec and build per-persona model assignments.
-    # Resolution order: persona YAML 'model' > --models weighted > --model.
+    # Two modes: ensemble (no weights) vs weighted (per-persona assignment).
     persona_models: dict[str, str] | None = None
+    ensemble_mode = has_models and is_ensemble_spec(has_models)
+
     if has_models:
         try:
             model_spec = parse_models_spec(has_models)
         except ValueError as exc:
             print(f"Error parsing --models: {exc}", file=sys.stderr)
             return 1
-        persona_models = assign_models_to_personas(personas, model_spec, model)
-        # Use the first model in the spec as the "primary" for cost fallback
-        if not has_model:
-            model = model_spec[0][0]
+        if not ensemble_mode:
+            persona_models = assign_models_to_personas(personas, model_spec, model)
+            # Use the first model in the spec as the "primary" for cost fallback
+            if not has_model:
+                model = model_spec[0][0]
     elif not has_models:
         # Even without --models, respect per-persona YAML model overrides
         yaml_overrides = {p.get("name", "Anonymous"): p["model"] for p in personas if p.get("model")}
@@ -554,6 +574,36 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             f"Variant expansion complete: {len(personas)} variant personas ready.",
             file=sys.stderr,
         )
+
+    # ── Ensemble mode: run with each model, compare across models ────────
+    if ensemble_mode:
+        from synth_panel.ensemble import ensemble_run
+
+        ensemble_models = [m for m, _w in model_spec]
+        ens_result = ensemble_run(
+            personas,
+            questions,
+            ensemble_models,
+            client,
+            system_prompt_fn=system_prompt_fn,
+            question_prompt_fn=build_question_prompt,
+            response_schema=response_schema,
+            extract_schema=extract_schema,
+            temperature=temperature,
+            top_p=top_p,
+        )
+        timer.stop()
+        output = {
+            "per_model_results": {
+                mr.model: [{"persona": pr.persona_name, "responses": pr.responses} for pr in mr.panelist_results]
+                for mr in ens_result.model_results
+            },
+            "cost_breakdown": ens_result.per_model_cost,
+            "models": ens_result.models,
+            "total_usage": ens_result.total_usage.to_dict(),
+        }
+        emit(fmt, message="Ensemble complete", extra=output)
+        return 0
 
     # Run all panelists in parallel via the orchestrator
     panelist_results, _registry, _sessions = run_panel_parallel(

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -452,6 +452,42 @@ def _format_panelist_result(pr: PanelistResult, model: str) -> dict[str, Any]:
     return rd
 
 
+def _run_ensemble_sync(
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    models: list[str],
+    response_schema: dict[str, Any] | None = None,
+    extract_schema: dict[str, Any] | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> dict[str, Any]:
+    """Run the same panel with each model and return comparative results."""
+    from synth_panel.ensemble import ensemble_run
+
+    client = LLMClient()
+    ens = ensemble_run(
+        personas,
+        questions,
+        models,
+        client,
+        system_prompt_fn=persona_system_prompt,
+        question_prompt_fn=build_question_prompt,
+        response_schema=response_schema,
+        extract_schema=extract_schema,
+        temperature=temperature,
+        top_p=top_p,
+    )
+    return {
+        "per_model_results": {
+            mr.model: [_format_panelist_result(pr, mr.model) for pr in mr.panelist_results]
+            for mr in ens.model_results
+        },
+        "cost_breakdown": ens.per_model_cost,
+        "models": ens.models,
+        "total_usage": ens.total_usage.to_dict(),
+    }
+
+
 async def _run_panel_async_instrument(
     personas: list[dict[str, Any]],
     instrument: Instrument,
@@ -771,6 +807,7 @@ async def run_panel(
     top_p: float | None = None,
     persona_models: dict[str, str] | None = None,
     extract_schema: str | dict[str, Any] | None = None,
+    models: list[str] | None = None,
     synthesis_temperature: float | None = None,
     variants: int | None = None,
     ctx: Context = None,
@@ -829,6 +866,10 @@ async def run_panel(
         extract_schema: Schema for post-hoc structured extraction from
             free-text responses. Pass a built-in name ("sentiment",
             "themes", "rating") or an inline JSON Schema dict.
+        models: List of model names for multi-model ensemble. When
+            provided, the panel is run once per model and results are
+            compared. Returns per_model_results and cost_breakdown.
+            Mutually exclusive with ``model``.
         synthesis_temperature: Sampling temperature for the synthesis step.
             Independent of the panelist temperature.
         variants: Number of persona variants to generate per persona for
@@ -873,6 +914,34 @@ async def run_panel(
                 return json.dumps({"error": f"Question at index {i} is missing required field 'text'."})
         if len(questions) > MAX_QUESTIONS:
             return json.dumps({"error": f"Too many questions ({len(questions)}). Maximum is {MAX_QUESTIONS}."})
+
+    # ── Ensemble mode: run with each model, compare across models ────────
+    if models and len(models) >= 2:
+        if not questions and instrument is None and instrument_pack is None:
+            return json.dumps({"error": "Ensemble mode requires questions or instrument."})
+        ens_questions = questions or []
+        if not ens_questions:
+            # Instruments: extract flat questions for ensemble (v1/v2 only)
+            if instrument is not None:
+                raw = instrument.get("instrument", instrument)
+                inst = parse_instrument(raw)
+                ens_questions = [{"text": q.text} for q in inst.questions]
+            elif instrument_pack is not None:
+                pack_body = _data_load_instrument_pack(instrument_pack)
+                raw = pack_body.get("instrument", pack_body)
+                inst = parse_instrument(raw)
+                ens_questions = [{"text": q.text} for q in inst.questions]
+        ens_result = await asyncio.to_thread(
+            _run_ensemble_sync,
+            merged,
+            ens_questions,
+            models,
+            response_schema,
+            extract_schema,
+            temperature,
+            top_p,
+        )
+        return json.dumps(ens_result, indent=2)
 
     # Resolve instrument source (pack > inline instrument > questions).
     instrument_obj: Instrument | None = None

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -924,12 +924,12 @@ async def run_panel(
             if instrument is not None:
                 raw = instrument.get("instrument", instrument)
                 inst = parse_instrument(raw)
-                ens_questions = [{"text": q.text} for q in inst.questions]
+                ens_questions = [{"text": q["text"]} for q in inst.questions]
             elif instrument_pack is not None:
                 pack_body = _data_load_instrument_pack(instrument_pack)
                 raw = pack_body.get("instrument", pack_body)
                 inst = parse_instrument(raw)
-                ens_questions = [{"text": q.text} for q in inst.questions]
+                ens_questions = [{"text": q["text"]} for q in inst.questions]
         ens_result = await asyncio.to_thread(
             _run_ensemble_sync,
             merged,

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -479,8 +479,7 @@ def _run_ensemble_sync(
     )
     return {
         "per_model_results": {
-            mr.model: [_format_panelist_result(pr, mr.model) for pr in mr.panelist_results]
-            for mr in ens.model_results
+            mr.model: [_format_panelist_result(pr, mr.model) for pr in mr.panelist_results] for mr in ens.model_results
         },
         "cost_breakdown": ens.per_model_cost,
         "models": ens.models,

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -825,3 +825,132 @@ def _merge_panelist_results(
                 if pr.error and not merged.error:
                     merged.error = pr.error
     return [by_name[n] for n in order]
+
+
+# ---------------------------------------------------------------------------
+# Multi-model ensemble
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EnsembleResult:
+    """Result of running the same panel across multiple models."""
+
+    per_model_results: dict[str, list[PanelistResult]]
+    convergent_findings: list[dict[str, Any]]
+    divergent_findings: list[dict[str, Any]]
+    cost_breakdown: dict[str, dict[str, Any]]
+    models: list[str]
+    usage: TokenUsage = field(default_factory=lambda: ZERO_USAGE)
+
+
+def ensemble_run(
+    *,
+    client: LLMClient,
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    models: list[str],
+    system_prompt_fn: Callable[[dict[str, Any]], str],
+    question_prompt_fn: Callable[[dict[str, Any]], str],
+    response_schema: dict[str, Any] | None = None,
+    extract_schema: dict[str, Any] | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> EnsembleResult:
+    """Run the same panel with each model and compare results.
+
+    Runs ``run_panel_parallel`` once per model, then computes cross-model
+    convergence for questions that produced categorical responses.
+
+    Returns an :class:`EnsembleResult` with per-model results and
+    convergent/divergent findings.
+    """
+    per_model: dict[str, list[PanelistResult]] = {}
+    cost_breakdown: dict[str, dict[str, Any]] = {}
+    total_usage = ZERO_USAGE
+
+    for model_name in models:
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model=model_name,
+            system_prompt_fn=system_prompt_fn,
+            question_prompt_fn=question_prompt_fn,
+            response_schema=response_schema,
+            extract_schema=extract_schema,
+            temperature=temperature,
+            top_p=top_p,
+        )
+        per_model[model_name] = results
+        model_usage = ZERO_USAGE
+        for pr in results:
+            model_usage = model_usage + pr.usage
+        total_usage = total_usage + model_usage
+        cost_breakdown[model_name] = {"usage": model_usage.to_dict()}
+
+    # Attempt convergence analysis when there are ≥2 models and structured responses
+    convergent: list[dict[str, Any]] = []
+    divergent: list[dict[str, Any]] = []
+
+    if len(models) >= 2 and questions:
+        question_texts = [q.get("text", str(q)) for q in questions]
+        try:
+            multi_model_responses = _extract_categorical_responses(per_model, len(questions))
+            if multi_model_responses:
+                from synth_panel.stats import convergence_report
+
+                report = convergence_report(multi_model_responses, question_texts)
+                for f in report.findings:
+                    entry = {
+                        "question_index": f.question_index,
+                        "question": f.question_text,
+                        "alpha": round(f.alpha, 3),
+                        "level": f.level.value,
+                        "interpretation": f.interpretation,
+                    }
+                    if f.alpha >= 0.60:
+                        convergent.append(entry)
+                    elif f.alpha < 0.40:
+                        divergent.append(entry)
+        except (ValueError, KeyError):
+            pass  # Convergence analysis not applicable (e.g. free-text responses)
+
+    return EnsembleResult(
+        per_model_results=per_model,
+        convergent_findings=convergent,
+        divergent_findings=divergent,
+        cost_breakdown=cost_breakdown,
+        models=models,
+        usage=total_usage,
+    )
+
+
+def _extract_categorical_responses(
+    per_model: dict[str, list[PanelistResult]],
+    n_questions: int,
+) -> dict[str, list[list[str]]] | None:
+    """Extract categorical response strings for convergence analysis.
+
+    Returns model_name -> [[response_per_question] per persona], or None
+    if responses aren't categorical (e.g. free-text with no structured data).
+    """
+    result: dict[str, list[list[str]]] = {}
+    for model_name, panelist_results in per_model.items():
+        personas_data: list[list[str]] = []
+        for pr in panelist_results:
+            q_responses: list[str] = []
+            for resp in pr.responses[:n_questions]:
+                # Prefer structured data for categorical comparison
+                if isinstance(resp.get("response"), dict):
+                    q_responses.append(str(sorted(resp["response"].items())))
+                elif isinstance(resp.get("response"), str):
+                    # Free-text: truncate to first 200 chars for rough comparison
+                    q_responses.append(resp["response"][:200])
+                else:
+                    return None
+            if len(q_responses) != n_questions:
+                return None
+            personas_data.append(q_responses)
+        result[model_name] = personas_data
+    return result

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -89,9 +89,23 @@ class TestParseModelsSpec:
         result = parse_models_spec(" haiku : 0.5 , gemini : 0.5 ")
         assert result == [("haiku", 0.5), ("gemini", 0.5)]
 
-    def test_missing_weight_raises(self):
+    def test_ensemble_no_weights(self):
+        """Model names without weights are treated as ensemble spec."""
+        result = parse_models_spec("haiku,sonnet")
+        assert result == [("haiku", 1.0), ("sonnet", 1.0)]
+
+    def test_ensemble_single_model(self):
+        result = parse_models_spec("haiku")
+        assert result == [("haiku", 1.0)]
+
+    def test_ensemble_three_models(self):
+        result = parse_models_spec("haiku,sonnet,gemini")
+        assert result == [("haiku", 1.0), ("sonnet", 1.0), ("gemini", 1.0)]
+
+    def test_mixed_raises(self):
+        """Mixing weighted and unweighted entries raises."""
         with pytest.raises(ValueError, match="expected 'model:weight'"):
-            parse_models_spec("haiku")
+            parse_models_spec("haiku,sonnet:0.5")
 
     def test_invalid_weight_raises(self):
         with pytest.raises(ValueError, match="must be a number"):
@@ -280,6 +294,29 @@ class TestPanelistResultModel:
 
 
 # ---------------------------------------------------------------------------
+# Tests: is_ensemble_spec
+# ---------------------------------------------------------------------------
+
+
+class TestIsEnsembleSpec:
+    def test_ensemble_spec(self):
+        from synth_panel.cli.commands import is_ensemble_spec
+
+        assert is_ensemble_spec("haiku,sonnet") is True
+        assert is_ensemble_spec("haiku") is True
+
+    def test_weighted_spec(self):
+        from synth_panel.cli.commands import is_ensemble_spec
+
+        assert is_ensemble_spec("haiku:0.5,sonnet:0.5") is False
+
+    def test_mixed_spec(self):
+        from synth_panel.cli.commands import is_ensemble_spec
+
+        assert is_ensemble_spec("haiku,sonnet:0.5") is False
+
+
+# ---------------------------------------------------------------------------
 # Tests: ensemble_run (multi-model runner loop)
 # ---------------------------------------------------------------------------
 
@@ -440,3 +477,17 @@ class TestEnsembleRun:
         assert result.persona_count == 3
         assert result.question_count == 2
         assert result.models == ["haiku"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI parser --models ensemble format
+# ---------------------------------------------------------------------------
+
+
+class TestParserEnsembleModels:
+    def test_models_ensemble_flag_parsed(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml", "--models", "haiku,sonnet"]
+        )
+        assert args.models == "haiku,sonnet"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -352,6 +352,53 @@ class TestRunPanelExtractSchema:
 
 
 # ---------------------------------------------------------------------------
+# run_panel models (ensemble) parameter
+# ---------------------------------------------------------------------------
+
+
+class TestRunPanelModels:
+    """Test run_panel's models parameter for multi-model ensemble."""
+
+    @pytest.mark.asyncio
+    async def test_models_triggers_ensemble(self):
+        """Providing models list triggers ensemble path via _run_ensemble_sync."""
+        with patch("synth_panel.mcp.server._run_ensemble_sync") as mock_ens:
+            mock_ens.return_value = {
+                "per_model_results": {},
+                "cost_breakdown": {},
+                "models": ["haiku", "sonnet"],
+                "total_usage": {},
+            }
+            result = await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                    "models": ["haiku", "sonnet"],
+                },
+            )
+            mock_ens.assert_called_once()
+            data = json.loads(result[0][0].text)
+            assert "per_model_results" in data
+            assert data["models"] == ["haiku", "sonnet"]
+
+    @pytest.mark.asyncio
+    async def test_single_model_list_uses_normal_path(self):
+        """A models list with <2 entries falls through to the normal path."""
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": []}
+            await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                    "models": ["haiku"],
+                },
+            )
+            mock_run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
 # Prompt templates
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `--models` ensemble mode for multi-model panel runs via CLI and MCP
- Rebased on current main (includes sp-templates merge)
- Lint fix applied

- **Issue**: sp-5on.13 (conflict resolution: sp-ayj)
- **Polecat**: capable
- **Branch**: polecat/capable-ensemble
- **Tests**: 819 passed (verified by refinery)

---
*Created by Gas Town Refinery*