### PR TITLE
fix: reuse LLMClient across MCP tool calls

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -175,6 +175,10 @@ mcp = FastMCP(
     ),
 )
 
+# Shared LLM client — reused across tool calls to avoid rebuilding the
+# provider cache on every invocation.  Thread-safe by design (see LLMClient).
+_shared_client = LLMClient()
+
 
 # ---------------------------------------------------------------------------
 # Internal panel runner (bridges threads to async)
@@ -204,7 +208,7 @@ def _run_panel_sync(
     Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data).
     variant_data is None when variants == 0.
     """
-    client = LLMClient()
+    client = _shared_client
 
     # Generate persona variants if requested
     all_personas = list(personas)
@@ -399,7 +403,7 @@ def _run_multi_round_sync(
     synthesis_temperature: float | None = None,
 ) -> MultiRoundResult:
     """Drive run_multi_round_panel for v1/v2/v3 instruments."""
-    client = LLMClient()
+    client = _shared_client
 
     def _round_synth(
         c: LLMClient,
@@ -762,7 +766,7 @@ async def run_prompt(
     """
     model = model or MCP_DEFAULT_MODEL
     logger.info("run_prompt: model=%s prompt_len=%d", model, len(prompt))
-    client = LLMClient()
+    client = _shared_client
     request = CompletionRequest(
         model=model,
         max_tokens=4096,
@@ -1187,7 +1191,7 @@ async def extend_panel(
         await ctx.report_progress(0, len(personas))
 
     def _go() -> tuple[list[PanelistResult], Any]:
-        client = LLMClient()
+        client = _shared_client
         results, _registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -177,7 +177,16 @@ mcp = FastMCP(
 
 # Shared LLM client — reused across tool calls to avoid rebuilding the
 # provider cache on every invocation.  Thread-safe by design (see LLMClient).
-_shared_client = LLMClient()
+# Lazy-initialised so that module import in test/CI contexts doesn't trigger
+# provider resolution before patches or env vars are set up.
+_shared_client: LLMClient | None = None
+
+
+def _get_shared_client() -> LLMClient:
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = LLMClient()
+    return _shared_client
 
 
 # ---------------------------------------------------------------------------
@@ -208,7 +217,7 @@ def _run_panel_sync(
     Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data).
     variant_data is None when variants == 0.
     """
-    client = _shared_client
+    client = _get_shared_client()
 
     # Generate persona variants if requested
     all_personas = list(personas)
@@ -403,7 +412,7 @@ def _run_multi_round_sync(
     synthesis_temperature: float | None = None,
 ) -> MultiRoundResult:
     """Drive run_multi_round_panel for v1/v2/v3 instruments."""
-    client = _shared_client
+    client = _get_shared_client()
 
     def _round_synth(
         c: LLMClient,
@@ -766,7 +775,7 @@ async def run_prompt(
     """
     model = model or MCP_DEFAULT_MODEL
     logger.info("run_prompt: model=%s prompt_len=%d", model, len(prompt))
-    client = _shared_client
+    client = _get_shared_client()
     request = CompletionRequest(
         model=model,
         max_tokens=4096,
@@ -1191,7 +1200,7 @@ async def extend_panel(
         await ctx.report_progress(0, len(personas))
 
     def _go() -> tuple[list[PanelistResult], Any]:
-        client = _shared_client
+        client = _get_shared_client()
         results, _registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -82,7 +82,7 @@ class TestRunPrompt:
             content=[TextBlock(text="Hello back!")],
             usage=TokenUsage(input_tokens=10, output_tokens=5),
         )
-        with patch("synth_panel.mcp.server.LLMClient") as MockClient:
+        with patch("synth_panel.mcp.server._shared_client", None), patch("synth_panel.mcp.server.LLMClient") as MockClient:
             MockClient.return_value.send.return_value = mock_response
             result = await mcp.call_tool("run_prompt", {"prompt": "Say hello"})
 
@@ -103,7 +103,7 @@ class TestRunPrompt:
             content=[TextBlock(text="Hi")],
             usage=TokenUsage(input_tokens=5, output_tokens=2),
         )
-        with patch("synth_panel.mcp.server.LLMClient") as MockClient:
+        with patch("synth_panel.mcp.server._shared_client", None), patch("synth_panel.mcp.server.LLMClient") as MockClient:
             MockClient.return_value.send.return_value = mock_response
             await mcp.call_tool("run_prompt", {"prompt": "Hi"})
             # Verify the request used 'haiku' model (MCP default)
@@ -120,7 +120,7 @@ class TestRunPrompt:
             content=[TextBlock(text="Hi")],
             usage=TokenUsage(input_tokens=5, output_tokens=2),
         )
-        with patch("synth_panel.mcp.server.LLMClient") as MockClient:
+        with patch("synth_panel.mcp.server._shared_client", None), patch("synth_panel.mcp.server.LLMClient") as MockClient:
             MockClient.return_value.send.return_value = mock_response
             await mcp.call_tool(
                 "run_prompt",

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -82,7 +82,10 @@ class TestRunPrompt:
             content=[TextBlock(text="Hello back!")],
             usage=TokenUsage(input_tokens=10, output_tokens=5),
         )
-        with patch("synth_panel.mcp.server._shared_client", None), patch("synth_panel.mcp.server.LLMClient") as MockClient:
+        with (
+            patch("synth_panel.mcp.server._shared_client", None),
+            patch("synth_panel.mcp.server.LLMClient") as MockClient,
+        ):
             MockClient.return_value.send.return_value = mock_response
             result = await mcp.call_tool("run_prompt", {"prompt": "Say hello"})
 
@@ -103,7 +106,10 @@ class TestRunPrompt:
             content=[TextBlock(text="Hi")],
             usage=TokenUsage(input_tokens=5, output_tokens=2),
         )
-        with patch("synth_panel.mcp.server._shared_client", None), patch("synth_panel.mcp.server.LLMClient") as MockClient:
+        with (
+            patch("synth_panel.mcp.server._shared_client", None),
+            patch("synth_panel.mcp.server.LLMClient") as MockClient,
+        ):
             MockClient.return_value.send.return_value = mock_response
             await mcp.call_tool("run_prompt", {"prompt": "Hi"})
             # Verify the request used 'haiku' model (MCP default)
@@ -120,7 +126,10 @@ class TestRunPrompt:
             content=[TextBlock(text="Hi")],
             usage=TokenUsage(input_tokens=5, output_tokens=2),
         )
-        with patch("synth_panel.mcp.server._shared_client", None), patch("synth_panel.mcp.server.LLMClient") as MockClient:
+        with (
+            patch("synth_panel.mcp.server._shared_client", None),
+            patch("synth_panel.mcp.server.LLMClient") as MockClient,
+        ):
             MockClient.return_value.send.return_value = mock_response
             await mcp.call_tool(
                 "run_prompt",


### PR DESCRIPTION
## Summary
- Replace per-call `LLMClient()` instantiation with a module-level singleton to avoid rebuilding the provider cache on every MCP tool invocation
- Simplifies `parse_models_spec` by removing unused ensemble (unweighted) mode
- Removes unused template files and orchestrator module

## Context
Refinery MR `sp-wisp-sx1` for issue `sp-0rq`. Branch was pushed by polecat `dementus` but got stuck in the merge queue for 6h. PR created manually by Mayor to unblock.

## Test plan
- [ ] CI passes (mypy, pytest, coverage gate)
- [ ] Verify MCP tool calls reuse the singleton client

🤖 Generated with [Claude Code](https://claude.com/claude-code)