### PR TITLE
feat: add distribution blending to ensemble mode (--blend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Traditional focus groups cost $5,000-$15,000 and take weeks. Synthetic panels co
 ## Quick Start
 
 ```bash
-# Install from PyPI (v0.4.0+)
+# Install from PyPI
 pip install synthpanel
 
 # For MCP server support (agent integration)
@@ -234,6 +234,7 @@ synthpanel works with any LLM provider. Set the appropriate environment variable
 | Anthropic (Claude) | `ANTHROPIC_API_KEY` | `--model sonnet` |
 | Google (Gemini) | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | `--model gemini` |
 | OpenAI | `OPENAI_API_KEY` | `--model gpt-4o` |
+| OpenRouter | `OPENROUTER_API_KEY` | `--model openrouter/anthropic/claude-haiku-4-5` |
 | xAI (Grok) | `XAI_API_KEY` | `--model grok` |
 | Any OpenAI-compatible | `OPENAI_API_KEY` + `OPENAI_BASE_URL` | `--model <model-id>` |
 
@@ -401,10 +402,31 @@ Known limitations:
 
 Use synthpanel to pre-screen and iterate, then validate with real participants.
 
+## Multi-Model Ensemble (0.7.0)
+
+Run the same panel through multiple models and blend their response distributions for higher-fidelity results. [SynthBench experiments](https://github.com/DataViking-Tech/synthbench/blob/main/FINDINGS.md) show 3-model ensembles improve human-parity scores by +5-7 points over any single model.
+
+```bash
+# Run 3 models with equal weights and blend distributions
+synthpanel panel run \
+  --models haiku:0.33,gemini:0.33,gpt-4o-mini:0.34 \
+  --blend \
+  --personas personas.yaml \
+  --instrument survey.yaml
+
+# Each persona is interviewed by all 3 models independently.
+# The --blend flag averages response distributions across models,
+# producing more representative synthetic survey data.
+```
+
+The blended output includes per-model distributions and the weighted ensemble distribution, letting you inspect both individual model perspectives and the consensus view.
+
 ## Versions
 
 | Version | Highlights |
 |---------|-----------|
+| 0.7.0 | Multi-model ensemble blending (`--blend`), OpenRouter provider support, temperature/top_p controls, prompt template customization |
+| 0.6.0 | `--models` weighted model spec, `--temperature`/`--top_p` flags, persona prompt templates, pack generation, domain templates, MCP improvements |
 | 0.5.0 | v3 branching instruments, router predicates, 5 bundled instrument packs, `instruments` subcommand (list/show/install/graph), MCP `*_instrument_pack` tools, rounds-shaped panel output, `extend_panel` ad-hoc round tool |
 | 0.4.0 | `--var KEY=VALUE` and `--vars-file` for instrument templates, fail-loud on all-provider errors, default `--model` respects available credentials, `pack show <id>` alias, publish workflow fix |
 | 0.3.0 | Structured output via tool-use forcing, cost tracking, MCP server (stdio), persona-pack persistence |

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -636,9 +636,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         blend_result = blend_distributions(ensemble, weights=blend_weights)
 
         # Flatten all panelist results across models for output + synthesis
-        panelist_results = [
-            pr for mr in ensemble.model_results for pr in mr.panelist_results
-        ]
+        panelist_results = [pr for mr in ensemble.model_results for pr in mr.panelist_results]
     else:
         panelist_results, _registry, _sessions = run_panel_parallel(
             client=client,

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -522,8 +522,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     # ── sp-blend: multi-model ensemble ───────────────────────────────────
     # Parse --models spec and build per-persona model assignments.
-    # Two modes: ensemble (no weights) vs weighted (per-persona assignment).
+    # Resolution order: persona YAML 'model' > --models weighted > --model.
+    blend_mode = getattr(args, "blend", False)
     persona_models: dict[str, str] | None = None
+    model_spec: list[tuple[str, float]] | None = None
     ensemble_mode = has_models and is_ensemble_spec(has_models)
 
     if has_models:
@@ -532,16 +534,21 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         except ValueError as exc:
             print(f"Error parsing --models: {exc}", file=sys.stderr)
             return 1
-        if not ensemble_mode:
+        if not ensemble_mode and not blend_mode:
             persona_models = assign_models_to_personas(personas, model_spec, model)
-            # Use the first model in the spec as the "primary" for cost fallback
-            if not has_model:
-                model = model_spec[0][0]
+        # Use the first model in the spec as the "primary" for cost fallback
+        if not has_model:
+            model = model_spec[0][0]
     elif not has_models:
         # Even without --models, respect per-persona YAML model overrides
         yaml_overrides = {p.get("name", "Anonymous"): p["model"] for p in personas if p.get("model")}
         if yaml_overrides:
             persona_models = yaml_overrides
+
+    # Validate --blend requires --models
+    if blend_mode and not has_models:
+        print("Error: --blend requires --models.", file=sys.stderr)
+        return 1
 
     import uuid as _uuid
 
@@ -606,19 +613,46 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         return 0
 
     # Run all panelists in parallel via the orchestrator
-    panelist_results, _registry, _sessions = run_panel_parallel(
-        client=client,
-        personas=personas,
-        questions=questions,
-        model=model,
-        system_prompt_fn=system_prompt_fn,
-        question_prompt_fn=build_question_prompt,
-        response_schema=response_schema,
-        extract_schema=extract_schema,
-        temperature=temperature,
-        top_p=top_p,
-        persona_models=persona_models,
-    )
+    blend_result = None  # populated only when --blend is active
+    if blend_mode and model_spec:
+        # ── Blend mode: run full panel once per model, then blend ────
+        from synth_panel.ensemble import blend_distributions, ensemble_run
+
+        ensemble_models = [m for m, _w in model_spec]
+        ensemble = ensemble_run(
+            personas,
+            questions,
+            ensemble_models,
+            client,
+            system_prompt_fn=system_prompt_fn,
+            question_prompt_fn=build_question_prompt,
+            response_schema=response_schema,
+            extract_schema=extract_schema,
+            temperature=temperature,
+            top_p=top_p,
+        )
+        # Build weights dict from the model spec
+        blend_weights = {m: w for m, w in model_spec}
+        blend_result = blend_distributions(ensemble, weights=blend_weights)
+
+        # Flatten all panelist results across models for output + synthesis
+        panelist_results = [
+            pr for mr in ensemble.model_results for pr in mr.panelist_results
+        ]
+    else:
+        panelist_results, _registry, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model=model,
+            system_prompt_fn=system_prompt_fn,
+            question_prompt_fn=build_question_prompt,
+            response_schema=response_schema,
+            extract_schema=extract_schema,
+            temperature=temperature,
+            top_p=top_p,
+            persona_models=persona_models,
+        )
 
     # Build output results and aggregate panelist usage
     results: list[dict[str, Any]] = []
@@ -762,6 +796,21 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             print(f"\n  Recommendation: {synthesis_dict['recommendation']}")
             print(f"  Synthesis cost: {synthesis_dict['cost']}")
 
+        # Blend output
+        if blend_result:
+            print(f"\n{'=' * 60}")
+            print("BLENDED DISTRIBUTIONS")
+            print(f"{'=' * 60}")
+            print(f"  Models: {', '.join(blend_result.models)}")
+            print(f"  Weights: {', '.join(f'{m}={w:.2f}' for m, w in blend_result.weights.items())}")
+            for bq in blend_result.questions:
+                print(f"\n  Q{bq.question_index + 1}: {bq.question_text}")
+                print(f"  Responses: {bq.response_count}")
+                if bq.distribution:
+                    sorted_dist = sorted(bq.distribution.items(), key=lambda x: x[1], reverse=True)
+                    for option, prob in sorted_dist:
+                        print(f"    {option}: {prob:.1%}")
+
         # Cost summaries
         print(f"\n{'=' * 60}")
         print(
@@ -827,6 +876,22 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # downstream consumers (MCP, CI) can gate on it without parsing text.
         extra["failure_stats"] = failure_stats
         extra["run_invalid"] = bool(run_invalid or strict_violation)
+        # Include blend distributions when --blend is active
+        if blend_result:
+            extra["blend"] = {
+                "models": blend_result.models,
+                "weights": blend_result.weights,
+                "questions": [
+                    {
+                        "index": bq.question_index,
+                        "question": bq.question_text,
+                        "distribution": bq.distribution,
+                        "per_model": bq.per_model,
+                        "response_count": bq.response_count,
+                    }
+                    for bq in blend_result.questions
+                ],
+            }
         if run_invalid or strict_violation:
             extra["message"] = banner.replace("\n", " ").strip() if banner else "PANEL RUN INVALID"
         emit(fmt, message=extra.get("message", "Panel complete"), extra=extra)

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -268,6 +268,18 @@ def build_parser() -> argparse.ArgumentParser:
             "rephrase). Requires an LLM call per variant."
         ),
     )
+    panel_run_parser.add_argument(
+        "--blend",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable distribution blending when running with multiple models "
+            "via --models. Runs each model on the full panel, then computes "
+            "weighted-average response distributions across models for each "
+            "question. Weights are taken from the --models spec (e.g. "
+            "'haiku:0.5,gemini:0.5'). Requires --models."
+        ),
+    )
 
     # pack
     pack_parser = subparsers.add_parser(

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -2,14 +2,16 @@
 
 Runs the same panel N times (once per model) using existing
 run_panel_parallel(), then aggregates per-model costs via
-CostEstimate/TokenUsage.
+CostEstimate/TokenUsage.  Optionally blends response distributions
+across models for multiple-choice / structured-option questions.
 """
 
 from __future__ import annotations
 
 import logging
+from collections import Counter
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from synth_panel.cost import (
@@ -153,4 +155,161 @@ def ensemble_run(
         per_model_usage=per_model_usage,
         persona_count=len(personas),
         question_count=len(questions),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Distribution blending
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BlendedQuestion:
+    """Blended distribution for a single question across models."""
+
+    question_index: int
+    question_text: str
+    distribution: dict[str, float]  # option -> blended probability
+    per_model: dict[str, dict[str, float]]  # model -> {option -> probability}
+    response_count: int  # total panelist responses that contributed
+
+
+@dataclass
+class BlendedResult:
+    """Complete blended distribution set from an ensemble run."""
+
+    questions: list[BlendedQuestion]
+    models: list[str]
+    weights: dict[str, float]  # model -> normalized weight
+
+
+def _extract_response_value(response: dict[str, Any]) -> str:
+    """Extract a comparable response value from a panelist response dict.
+
+    Handles both free-text and structured responses. For structured
+    responses, extracts the primary value (first string field or the
+    ``response`` key). For free-text, returns the raw response string.
+    """
+    val = response.get("response", "")
+    if isinstance(val, dict):
+        # Structured response — try common keys, then first string value
+        for key in ("answer", "choice", "selection", "value", "response"):
+            if key in val and isinstance(val[key], str):
+                return val[key].strip()
+        # Fallback: first string value in the dict
+        for v in val.values():
+            if isinstance(v, str):
+                return v.strip()
+        return str(val)
+    return str(val).strip()
+
+
+def _build_distribution(responses: list[str]) -> dict[str, float]:
+    """Build a probability distribution from a list of response strings.
+
+    Each unique response gets a probability equal to its frequency.
+    Returns a dict mapping response -> probability (sums to 1.0).
+    """
+    if not responses:
+        return {}
+    counts = Counter(responses)
+    total = len(responses)
+    return {option: count / total for option, count in counts.items()}
+
+
+def blend_distributions(
+    ensemble_result: EnsembleResult,
+    *,
+    weights: dict[str, float] | None = None,
+) -> BlendedResult:
+    """Blend response distributions across models in an ensemble result.
+
+    For each question, collects all panelist responses from each model,
+    computes per-model response distributions (option frequencies), and
+    produces a weighted average across models.
+
+    Args:
+        ensemble_result: Result from :func:`ensemble_run` containing
+            per-model panelist results.
+        weights: Optional model -> weight mapping. When provided, weights
+            are normalized to sum to 1.0. When ``None``, all models get
+            equal weight.
+
+    Returns:
+        :class:`BlendedResult` with per-question blended distributions.
+
+    Raises:
+        ValueError: If ensemble_result has no model results.
+    """
+    if not ensemble_result.model_results:
+        raise ValueError("ensemble_result has no model results")
+
+    models = ensemble_result.models
+
+    # Resolve and normalize weights
+    if weights:
+        raw_weights = {m: weights.get(m, 0.0) for m in models}
+    else:
+        raw_weights = {m: 1.0 for m in models}
+
+    weight_sum = sum(raw_weights.values())
+    if weight_sum <= 0:
+        raise ValueError("model weights must sum to a positive value")
+    norm_weights = {m: w / weight_sum for m, w in raw_weights.items()}
+
+    # Determine the number of questions from the first model's results.
+    # All models ran the same questions, so we use the max response count
+    # across panelists as the question count.
+    n_questions = 0
+    for mr in ensemble_result.model_results:
+        for pr in mr.panelist_results:
+            n_questions = max(n_questions, len(pr.responses))
+
+    blended_questions: list[BlendedQuestion] = []
+
+    for qi in range(n_questions):
+        per_model_dist: dict[str, dict[str, float]] = {}
+        question_text = ""
+        total_responses = 0
+
+        for mr in ensemble_result.model_results:
+            model_responses: list[str] = []
+            for pr in mr.panelist_results:
+                if qi < len(pr.responses):
+                    resp = pr.responses[qi]
+                    if not question_text:
+                        question_text = resp.get("question", f"Q{qi + 1}")
+                    if not resp.get("error"):
+                        model_responses.append(_extract_response_value(resp))
+
+            total_responses += len(model_responses)
+            per_model_dist[mr.model] = _build_distribution(model_responses)
+
+        # Weighted average across models: collect all options, then for
+        # each option compute sum(weight_m * prob_m(option)).
+        all_options: set[str] = set()
+        for dist in per_model_dist.values():
+            all_options.update(dist.keys())
+
+        blended: dict[str, float] = {}
+        for option in all_options:
+            blended[option] = sum(
+                norm_weights.get(m, 0.0) * per_model_dist.get(m, {}).get(option, 0.0)
+                for m in models
+            )
+
+        blended_questions.append(
+            BlendedQuestion(
+                question_index=qi,
+                question_text=question_text,
+                distribution=blended,
+                per_model=per_model_dist,
+                response_count=total_responses,
+            )
+        )
+
+    return BlendedResult(
+        questions=blended_questions,
+        models=models,
+        weights=norm_weights,
     )

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from collections import Counter
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from synth_panel.cost import (

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -293,10 +293,7 @@ def blend_distributions(
 
         blended: dict[str, float] = {}
         for option in all_options:
-            blended[option] = sum(
-                norm_weights.get(m, 0.0) * per_model_dist.get(m, {}).get(option, 0.0)
-                for m in models
-            )
+            blended[option] = sum(norm_weights.get(m, 0.0) * per_model_dist.get(m, {}).get(option, 0.0) for m in models)
 
         blended_questions.append(
             BlendedQuestion(

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -736,7 +736,7 @@ class TestBlendDistributions:
 
     def test_empty_ensemble_raises(self):
         """Empty model_results raises ValueError."""
-        from synth_panel.ensemble import BlendedResult, EnsembleResult, blend_distributions
+        from synth_panel.ensemble import EnsembleResult, blend_distributions
 
         empty = EnsembleResult(
             model_results=[],

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -785,10 +785,14 @@ class TestParserBlendFlag:
         parser = build_parser()
         args = parser.parse_args(
             [
-                "panel", "run",
-                "--personas", "p.yaml",
-                "--instrument", "i.yaml",
-                "--models", "haiku:0.5,gemini:0.5",
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--instrument",
+                "i.yaml",
+                "--models",
+                "haiku:0.5,gemini:0.5",
                 "--blend",
             ]
         )
@@ -796,7 +800,5 @@ class TestParserBlendFlag:
 
     def test_blend_default_false(self):
         parser = build_parser()
-        args = parser.parse_args(
-            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"]
-        )
+        args = parser.parse_args(["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"])
         assert args.blend is False

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -491,3 +491,312 @@ class TestParserEnsembleModels:
             ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml", "--models", "haiku,sonnet"]
         )
         assert args.models == "haiku,sonnet"
+
+
+# ---------------------------------------------------------------------------
+# Tests: blend_distributions
+# ---------------------------------------------------------------------------
+
+
+class TestBlendDistributions:
+    """Tests for the blend_distributions function."""
+
+    def _make_ensemble_result(
+        self,
+        models: list[str],
+        model_responses: dict[str, list[list[dict]]],
+    ):
+        """Build an EnsembleResult from per-model response dicts.
+
+        model_responses maps model -> list of panelist response lists.
+        Each panelist response list is a list of response dicts.
+        """
+        from synth_panel.cost import CostEstimate, TokenUsage
+        from synth_panel.ensemble import EnsembleResult, ModelRunResult
+
+        model_results = []
+        total_usage = ZERO_USAGE
+        for m in models:
+            panelist_results = []
+            for i, responses in enumerate(model_responses[m]):
+                pr = PanelistResult(
+                    persona_name=f"P{i}",
+                    responses=responses,
+                    usage=TokenUsage(input_tokens=10, output_tokens=5),
+                    model=m,
+                )
+                panelist_results.append(pr)
+
+            mr = ModelRunResult(
+                model=m,
+                panelist_results=panelist_results,
+                usage=TokenUsage(input_tokens=20, output_tokens=10),
+                cost=CostEstimate(input_cost=0.001, output_cost=0.001),
+                sessions={},
+            )
+            model_results.append(mr)
+            total_usage = total_usage + mr.usage
+
+        return EnsembleResult(
+            model_results=model_results,
+            models=models,
+            total_usage=total_usage,
+            total_cost=CostEstimate(input_cost=0.002, output_cost=0.002),
+            per_model_cost={m: "$0.00" for m in models},
+            per_model_usage={m: {"input_tokens": 20, "output_tokens": 10} for m in models},
+            persona_count=len(model_responses[models[0]]),
+            question_count=len(model_responses[models[0]][0]) if model_responses[models[0]] else 0,
+        )
+
+    def test_equal_weights_two_models_unanimous(self):
+        """When both models agree, blended distribution has 100% for one option."""
+        from synth_panel.ensemble import blend_distributions
+
+        # Both models, both panelists say "A"
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Pick one", "response": "A"}],
+                    [{"question": "Pick one", "response": "A"}],
+                ],
+                "gemini": [
+                    [{"question": "Pick one", "response": "A"}],
+                    [{"question": "Pick one", "response": "A"}],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        assert len(result.questions) == 1
+        assert result.questions[0].distribution["A"] == pytest.approx(1.0)
+        assert result.weights["haiku"] == pytest.approx(0.5)
+        assert result.weights["gemini"] == pytest.approx(0.5)
+
+    def test_equal_weights_models_disagree(self):
+        """When models fully disagree, each option gets 50%."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Pick one", "response": "A"}],
+                ],
+                "gemini": [
+                    [{"question": "Pick one", "response": "B"}],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        dist = result.questions[0].distribution
+        assert dist["A"] == pytest.approx(0.5)
+        assert dist["B"] == pytest.approx(0.5)
+
+    def test_custom_weights(self):
+        """Custom weights bias toward the heavier model."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Pick one", "response": "A"}],
+                ],
+                "gemini": [
+                    [{"question": "Pick one", "response": "B"}],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble, weights={"haiku": 0.8, "gemini": 0.2})
+        dist = result.questions[0].distribution
+        assert dist["A"] == pytest.approx(0.8)
+        assert dist["B"] == pytest.approx(0.2)
+        assert result.weights["haiku"] == pytest.approx(0.8)
+        assert result.weights["gemini"] == pytest.approx(0.2)
+
+    def test_multiple_questions(self):
+        """Blending works across multiple questions."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [
+                        {"question": "Q1", "response": "A"},
+                        {"question": "Q2", "response": "X"},
+                    ],
+                ],
+                "gemini": [
+                    [
+                        {"question": "Q1", "response": "B"},
+                        {"question": "Q2", "response": "X"},
+                    ],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        assert len(result.questions) == 2
+        # Q1: split between A and B
+        assert result.questions[0].distribution["A"] == pytest.approx(0.5)
+        assert result.questions[0].distribution["B"] == pytest.approx(0.5)
+        # Q2: unanimous X
+        assert result.questions[1].distribution["X"] == pytest.approx(1.0)
+
+    def test_intra_model_distribution(self):
+        """Multiple panelists within a model create a proper distribution."""
+        from synth_panel.ensemble import blend_distributions
+
+        # haiku: 2 say A, 1 says B -> haiku dist: A=2/3, B=1/3
+        # gemini: all say B -> gemini dist: B=1.0
+        # equal weights: A = 0.5*2/3 + 0.5*0 = 1/3, B = 0.5*1/3 + 0.5*1 = 2/3
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Q1", "response": "A"}],
+                    [{"question": "Q1", "response": "A"}],
+                    [{"question": "Q1", "response": "B"}],
+                ],
+                "gemini": [
+                    [{"question": "Q1", "response": "B"}],
+                    [{"question": "Q1", "response": "B"}],
+                    [{"question": "Q1", "response": "B"}],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        dist = result.questions[0].distribution
+        assert dist["A"] == pytest.approx(1 / 3, abs=1e-9)
+        assert dist["B"] == pytest.approx(2 / 3, abs=1e-9)
+
+    def test_three_models(self):
+        """Blending works with three models."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini", "gpt"],
+            model_responses={
+                "haiku": [[{"question": "Q1", "response": "A"}]],
+                "gemini": [[{"question": "Q1", "response": "B"}]],
+                "gpt": [[{"question": "Q1", "response": "C"}]],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        dist = result.questions[0].distribution
+        assert dist["A"] == pytest.approx(1 / 3, abs=1e-9)
+        assert dist["B"] == pytest.approx(1 / 3, abs=1e-9)
+        assert dist["C"] == pytest.approx(1 / 3, abs=1e-9)
+
+    def test_per_model_distributions_preserved(self):
+        """per_model field on BlendedQuestion shows each model's raw distribution."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [[{"question": "Q1", "response": "A"}]],
+                "gemini": [[{"question": "Q1", "response": "B"}]],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        bq = result.questions[0]
+        assert bq.per_model["haiku"] == {"A": 1.0}
+        assert bq.per_model["gemini"] == {"B": 1.0}
+
+    def test_error_responses_excluded(self):
+        """Responses flagged as errors are excluded from distributions."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Q1", "response": "A"}],
+                    [{"question": "Q1", "response": "[error: timeout]", "error": True}],
+                ],
+                "gemini": [
+                    [{"question": "Q1", "response": "B"}],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        dist = result.questions[0].distribution
+        # haiku: only 1 valid response (A=1.0), gemini: B=1.0
+        assert dist["A"] == pytest.approx(0.5)
+        assert dist["B"] == pytest.approx(0.5)
+
+    def test_empty_ensemble_raises(self):
+        """Empty model_results raises ValueError."""
+        from synth_panel.ensemble import BlendedResult, EnsembleResult, blend_distributions
+
+        empty = EnsembleResult(
+            model_results=[],
+            models=[],
+            total_usage=ZERO_USAGE,
+            total_cost=__import__("synth_panel.cost", fromlist=["CostEstimate"]).CostEstimate(),
+            per_model_cost={},
+            per_model_usage={},
+            persona_count=0,
+            question_count=0,
+        )
+        with pytest.raises(ValueError, match="no model results"):
+            blend_distributions(empty)
+
+    def test_structured_response_extraction(self):
+        """Structured (dict) responses are handled correctly."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Q1", "response": {"answer": "Strongly Agree"}}],
+                ],
+                "gemini": [
+                    [{"question": "Q1", "response": {"answer": "Disagree"}}],
+                ],
+            },
+        )
+
+        result = blend_distributions(ensemble)
+        dist = result.questions[0].distribution
+        assert "Strongly Agree" in dist
+        assert "Disagree" in dist
+        assert dist["Strongly Agree"] == pytest.approx(0.5)
+        assert dist["Disagree"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI parser --blend flag
+# ---------------------------------------------------------------------------
+
+
+class TestParserBlendFlag:
+    def test_blend_flag_parsed(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel", "run",
+                "--personas", "p.yaml",
+                "--instrument", "i.yaml",
+                "--models", "haiku:0.5,gemini:0.5",
+                "--blend",
+            ]
+        )
+        assert args.blend is True
+
+    def test_blend_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"]
+        )
+        assert args.blend is False


### PR DESCRIPTION
## Summary
- `blend_distributions()` averages per-model response distributions with configurable weights
- `--blend` CLI flag on `panel run` enables blending when using multi-model specs
- Custom weights from model spec (`haiku:0.5,gemini:0.5`) or equal by default
- JSON output includes `"blend"` key with per-question distributions and per-model breakdowns
- 12 new tests covering unanimous, disagreement, custom weights, 3-model, error exclusion

## Usage
```bash
synthpanel panel run --models haiku:0.33,gemini:0.33,gpt-4o-mini:0.34 --blend \
  --personas panel.yaml --instrument survey.yaml
```

## Benchmark context
SynthBench experiments show 3-model ensemble blending improves SPS by +5-7 points over any single model (SPS 0.877 vs 0.766 best single). This feature makes ensemble blending a first-class synthpanel capability.

## Test plan
- [x] 12 new unit tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)