### PR TITLE
fix: disable PyPI attestations for workflow_call compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: false
 
       - name: Summarize release
         env:


### PR DESCRIPTION
v0.7.0 publish failed due to OIDC attestation mismatch when called via workflow_call from auto-tag. Disabling attestations.