### PR TITLE
fix(cli): YAML parse errors, --version flag, OpenRouter key warning

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -44,6 +44,7 @@ _DEFAULT_MODEL_PREFERENCE: list[tuple[str, str]] = [
     ("GEMINI_API_KEY", "gemini-2.5-flash"),
     ("GOOGLE_API_KEY", "gemini-2.5-flash"),
     ("XAI_API_KEY", "grok-3"),
+    ("OPENROUTER_API_KEY", "openrouter/auto"),
 ]
 
 
@@ -294,7 +295,10 @@ def _load_yaml(path: str) -> Any:
     if not p.exists():
         raise FileNotFoundError(f"File not found: {path}")
     with open(p, encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        try:
+            return yaml.safe_load(f)
+        except yaml.YAMLError as exc:
+            raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
 
 
 def _load_personas(path: str) -> list[dict[str, Any]]:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 import argparse
 
+from synth_panel import __version__
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser with global args and subcommands."""
@@ -14,6 +16,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="synthpanel",
         description="Synthetic focus group CLI — orchestrate LLM-powered personas for structured qualitative feedback.",
     )
+    parser.add_argument("--version", action="version", version=f"synthpanel {__version__}")
 
     # Global arguments (apply to all commands)
     parser.add_argument(


### PR DESCRIPTION
## Summary
- Wrap `yaml.safe_load` in `_load_yaml()` with `try/except yaml.YAMLError` so malformed persona/instrument YAML files produce a clean one-line error (`Invalid YAML in {path}: {message}`) instead of a raw Python traceback
- Add `--version` flag to the top-level argparse parser (prints `synthpanel {__version__}`)
- Add `OPENROUTER_API_KEY` to `_DEFAULT_MODEL_PREFERENCE` so it appears in the "no provider API keys detected" warning message

Note: The hardcoded version string issue (item 2) was already resolved -- `metadata.py` uses `_get_synthpanel_version()` which dynamically reads from `importlib.metadata` with `__init__.__version__` as fallback.

## Test plan
- [ ] `synthpanel --version` prints version and exits
- [ ] Feed a malformed YAML file to `--personas` or `--instrument` and confirm clean error output
- [ ] Unset all API keys and run `synthpanel panel run ...` to confirm OPENROUTER_API_KEY appears in the warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)