### PR TITLE
fix: dynamic __version__ from importlib.metadata

### DIFF
--- a/src/synth_panel/__init__.py
+++ b/src/synth_panel/__init__.py
@@ -1,3 +1,8 @@
 from __future__ import annotations
 
-__version__ = "0.6.0"
+try:
+    from importlib.metadata import version as _pkg_version
+
+    __version__ = _pkg_version("synthpanel")
+except Exception:
+    __version__ = "0.0.0-dev"


### PR DESCRIPTION
Replaces hardcoded 0.6.0 with importlib.metadata.version('synthpanel'). Fixes --version and JSON metadata.