### PR TITLE
feat: extract MC option selections in --blend output (sp-dm7)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -637,7 +637,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         )
         # Build weights dict from the model spec
         blend_weights = {m: w for m, w in model_spec}
-        blend_result = blend_distributions(ensemble, weights=blend_weights)
+        blend_result = blend_distributions(ensemble, weights=blend_weights, questions=questions)
 
         # Flatten all panelist results across models for output + synthesis
         panelist_results = [pr for mr in ensemble.model_results for pr in mr.panelist_results]

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -204,6 +204,45 @@ def _extract_response_value(response: dict[str, Any]) -> str:
     return str(val).strip()
 
 
+def _match_to_option(value: str, options: list[str]) -> str:
+    """Match a response value to the closest option from a defined list.
+
+    Matching strategy (first match wins):
+    1. Exact match (case-insensitive)
+    2. Option is a substring of the response (case-insensitive),
+       preferring the longest matching option
+    3. Response is a substring of an option (case-insensitive),
+       preferring the longest matching option
+
+    Returns the original option string (preserving case) on match,
+    or the original value if no match is found.
+    """
+    val_lower = value.lower()
+
+    # 1. Exact match
+    for opt in options:
+        if val_lower == opt.lower():
+            return opt
+
+    # 2. Option contained in response (longest wins)
+    contained: list[str] = []
+    for opt in options:
+        if opt.lower() in val_lower:
+            contained.append(opt)
+    if contained:
+        return max(contained, key=len)
+
+    # 3. Response contained in option (longest matching option wins)
+    reverse_contained: list[str] = []
+    for opt in options:
+        if val_lower in opt.lower():
+            reverse_contained.append(opt)
+    if reverse_contained:
+        return max(reverse_contained, key=len)
+
+    return value
+
+
 def _build_distribution(responses: list[str]) -> dict[str, float]:
     """Build a probability distribution from a list of response strings.
 
@@ -221,6 +260,7 @@ def blend_distributions(
     ensemble_result: EnsembleResult,
     *,
     weights: dict[str, float] | None = None,
+    questions: list[dict[str, Any]] | None = None,
 ) -> BlendedResult:
     """Blend response distributions across models in an ensemble result.
 
@@ -228,12 +268,21 @@ def blend_distributions(
     computes per-model response distributions (option frequencies), and
     produces a weighted average across models.
 
+    When *questions* is provided and a question defines an ``options``
+    list, each response value is matched to the closest option before
+    aggregation.  This collapses free-text variations into canonical
+    option names (e.g. "I'd go with hybrid" → "Hybrid 3 days").
+
     Args:
         ensemble_result: Result from :func:`ensemble_run` containing
             per-model panelist results.
         weights: Optional model -> weight mapping. When provided, weights
             are normalized to sum to 1.0. When ``None``, all models get
             equal weight.
+        questions: Optional list of question dicts from the instrument.
+            When a question dict contains an ``options`` key (a list of
+            strings), responses are matched to those options before
+            distribution calculation.
 
     Returns:
         :class:`BlendedResult` with per-question blended distributions.
@@ -272,6 +321,13 @@ def blend_distributions(
         question_text = ""
         total_responses = 0
 
+        # Resolve options list for this question index (if provided)
+        q_options: list[str] | None = None
+        if questions and qi < len(questions):
+            opts = questions[qi].get("options")
+            if isinstance(opts, list) and opts:
+                q_options = [str(o) for o in opts]
+
         for mr in ensemble_result.model_results:
             model_responses: list[str] = []
             for pr in mr.panelist_results:
@@ -280,7 +336,10 @@ def blend_distributions(
                     if not question_text:
                         question_text = resp.get("question", f"Q{qi + 1}")
                     if not resp.get("error"):
-                        model_responses.append(_extract_response_value(resp))
+                        val = _extract_response_value(resp)
+                        if q_options:
+                            val = _match_to_option(val, q_options)
+                        model_responses.append(val)
 
             total_responses += len(model_responses)
             per_model_dist[mr.model] = _build_distribution(model_responses)

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -823,20 +823,14 @@ class TestMatchToOption:
         from synth_panel.ensemble import _match_to_option
 
         options = ["Fully remote", "Hybrid 3 days", "In office"]
-        assert _match_to_option(
-            "I'd definitely prefer fully remote work", options
-        ) == "Fully remote"
-        assert _match_to_option(
-            "I think hybrid 3 days is best for me", options
-        ) == "Hybrid 3 days"
+        assert _match_to_option("I'd definitely prefer fully remote work", options) == "Fully remote"
+        assert _match_to_option("I think hybrid 3 days is best for me", options) == "Hybrid 3 days"
 
     def test_longest_match_wins(self):
         from synth_panel.ensemble import _match_to_option
 
         options = ["remote", "Fully remote"]
-        assert _match_to_option(
-            "I want fully remote work", options
-        ) == "Fully remote"
+        assert _match_to_option("I want fully remote work", options) == "Fully remote"
 
     def test_response_contained_in_option(self):
         from synth_panel.ensemble import _match_to_option

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -802,3 +802,204 @@ class TestParserBlendFlag:
         parser = build_parser()
         args = parser.parse_args(["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"])
         assert args.blend is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: _match_to_option
+# ---------------------------------------------------------------------------
+
+
+class TestMatchToOption:
+    """Tests for the _match_to_option helper."""
+
+    def test_exact_match_case_insensitive(self):
+        from synth_panel.ensemble import _match_to_option
+
+        assert _match_to_option("Fully remote", ["Fully remote", "Hybrid 3 days"]) == "Fully remote"
+        assert _match_to_option("fully remote", ["Fully remote", "Hybrid 3 days"]) == "Fully remote"
+        assert _match_to_option("FULLY REMOTE", ["Fully remote", "Hybrid 3 days"]) == "Fully remote"
+
+    def test_option_contained_in_response(self):
+        from synth_panel.ensemble import _match_to_option
+
+        options = ["Fully remote", "Hybrid 3 days", "In office"]
+        assert _match_to_option(
+            "I'd definitely prefer fully remote work", options
+        ) == "Fully remote"
+        assert _match_to_option(
+            "I think hybrid 3 days is best for me", options
+        ) == "Hybrid 3 days"
+
+    def test_longest_match_wins(self):
+        from synth_panel.ensemble import _match_to_option
+
+        options = ["remote", "Fully remote"]
+        assert _match_to_option(
+            "I want fully remote work", options
+        ) == "Fully remote"
+
+    def test_response_contained_in_option(self):
+        from synth_panel.ensemble import _match_to_option
+
+        options = ["Fully remote work schedule", "Hybrid 3 days per week"]
+        assert _match_to_option("hybrid 3 days", options) == "Hybrid 3 days per week"
+
+    def test_no_match_returns_original(self):
+        from synth_panel.ensemble import _match_to_option
+
+        options = ["Fully remote", "Hybrid 3 days"]
+        assert _match_to_option("Something else entirely", options) == "Something else entirely"
+
+    def test_empty_options_returns_original(self):
+        from synth_panel.ensemble import _match_to_option
+
+        assert _match_to_option("anything", []) == "anything"
+
+
+# ---------------------------------------------------------------------------
+# Tests: blend_distributions with options
+# ---------------------------------------------------------------------------
+
+
+class TestBlendDistributionsWithOptions(TestBlendDistributions):
+    """Tests for blend_distributions when questions define options."""
+
+    def test_options_normalize_responses(self):
+        """Responses are matched to defined options before aggregation."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Work preference?", "response": "I prefer fully remote work"}],
+                    [{"question": "Work preference?", "response": "Hybrid 3 days sounds good"}],
+                ],
+                "gemini": [
+                    [{"question": "Work preference?", "response": "fully remote for me"}],
+                    [{"question": "Work preference?", "response": "I'd choose in office"}],
+                ],
+            },
+        )
+        questions = [
+            {"text": "Work preference?", "options": ["Fully remote", "Hybrid 3 days", "In office"]},
+        ]
+
+        result = blend_distributions(ensemble, questions=questions)
+        dist = result.questions[0].distribution
+        # haiku: Fully remote=0.5, Hybrid 3 days=0.5
+        # gemini: Fully remote=0.5, In office=0.5
+        # blended (equal weight): Fully remote=0.5, Hybrid 3 days=0.25, In office=0.25
+        assert "Fully remote" in dist
+        assert "Hybrid 3 days" in dist
+        assert "In office" in dist
+        assert dist["Fully remote"] == pytest.approx(0.5)
+        assert dist["Hybrid 3 days"] == pytest.approx(0.25)
+        assert dist["In office"] == pytest.approx(0.25)
+
+    def test_structured_response_with_options(self):
+        """Structured responses (pick_one) are matched to defined options."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Q1", "response": {"choice": "fully remote", "reasoning": "I like it"}}],
+                ],
+                "gemini": [
+                    [{"question": "Q1", "response": {"choice": "Hybrid 3 days", "reasoning": "balance"}}],
+                ],
+            },
+        )
+        questions = [
+            {"text": "Q1", "options": ["Fully remote", "Hybrid 3 days", "In office"]},
+        ]
+
+        result = blend_distributions(ensemble, questions=questions)
+        dist = result.questions[0].distribution
+        assert "Fully remote" in dist
+        assert "Hybrid 3 days" in dist
+        assert dist["Fully remote"] == pytest.approx(0.5)
+        assert dist["Hybrid 3 days"] == pytest.approx(0.5)
+
+    def test_no_options_preserves_behavior(self):
+        """Questions without options keep raw response values."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [[{"question": "Q1", "response": "A long answer"}]],
+                "gemini": [[{"question": "Q1", "response": "B long answer"}]],
+            },
+        )
+        questions = [{"text": "Q1"}]  # no options
+
+        result = blend_distributions(ensemble, questions=questions)
+        dist = result.questions[0].distribution
+        assert "A long answer" in dist
+        assert "B long answer" in dist
+
+    def test_questions_none_preserves_behavior(self):
+        """When questions is None, behavior is unchanged."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku", "gemini"],
+            model_responses={
+                "haiku": [[{"question": "Q1", "response": "A"}]],
+                "gemini": [[{"question": "Q1", "response": "B"}]],
+            },
+        )
+
+        result = blend_distributions(ensemble, questions=None)
+        dist = result.questions[0].distribution
+        assert dist["A"] == pytest.approx(0.5)
+        assert dist["B"] == pytest.approx(0.5)
+
+    def test_mixed_questions_some_with_options(self):
+        """Only questions with options get matching; others pass through."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku"],
+            model_responses={
+                "haiku": [
+                    [
+                        {"question": "Q1", "response": "I like fully remote"},
+                        {"question": "Q2", "response": "Free-form answer here"},
+                    ],
+                ],
+            },
+        )
+        questions = [
+            {"text": "Q1", "options": ["Fully remote", "Hybrid", "In office"]},
+            {"text": "Q2"},  # no options
+        ]
+
+        result = blend_distributions(ensemble, questions=questions)
+        assert result.questions[0].distribution == {"Fully remote": pytest.approx(1.0)}
+        assert result.questions[1].distribution == {"Free-form answer here": pytest.approx(1.0)}
+
+    def test_unmatched_response_passes_through(self):
+        """Responses that don't match any option are kept as-is."""
+        from synth_panel.ensemble import blend_distributions
+
+        ensemble = self._make_ensemble_result(
+            models=["haiku"],
+            model_responses={
+                "haiku": [
+                    [{"question": "Q1", "response": "Something completely different"}],
+                    [{"question": "Q1", "response": "Fully remote"}],
+                ],
+            },
+        )
+        questions = [
+            {"text": "Q1", "options": ["Fully remote", "Hybrid"]},
+        ]
+
+        result = blend_distributions(ensemble, questions=questions)
+        dist = result.questions[0].distribution
+        assert "Fully remote" in dist
+        assert "Something completely different" in dist


### PR DESCRIPTION
## Summary

- Extract multiple-choice option selections from panelist responses in `--blend` mode
- Match each response to the closest option from the instrument YAML and aggregate into distributions
- Issue: sp-dm7
- Polecat: capable
- Branch: polecat/capable-mnvhuq9b
- Tests: 860 passed (verified by refinery)

---
*Created by Gas Town Refinery*