### PR TITLE
feat: add auto-save + result IDs for synthpanel analyze (sp-7vp)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -898,6 +898,38 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             extra["message"] = banner.replace("\n", " ").strip() if banner else "PANEL RUN INVALID"
         emit(fmt, message=extra.get("message", "Panel complete"), extra=extra)
 
+    # ── sp-7vp: auto-save results with --save ─────────────────────────
+    if getattr(args, "save", False):
+        from synth_panel.mcp.data import save_panel_result
+
+        # Determine instrument name (pack name or filename stem)
+        inst_name: str | None = None
+        inst_arg = getattr(args, "instrument", None)
+        if inst_arg:
+            inst_path = Path(inst_arg)
+            if inst_path.exists():
+                inst_name = inst_path.stem
+            else:
+                inst_name = inst_arg  # pack name
+
+        all_models: list[str] | None = None
+        if persona_models:
+            all_models = sorted(set(persona_models.values()))
+        elif model_spec:
+            all_models = [m for m, _w in model_spec]
+
+        result_id = save_panel_result(
+            results=results,
+            model=model,
+            total_usage=total_usage.to_dict(),
+            total_cost=total_cost_est.format_usd(),
+            persona_count=len(personas),
+            question_count=len(questions),
+            instrument_name=inst_name,
+            models=all_models,
+        )
+        print(f"Result saved: {result_id}", file=sys.stderr)
+
     # sp-2hg: exit non-zero when the run is invalid so automation (CI,
     # refinery, wrapper scripts) can detect silent-failure scenarios.
     if strict_violation:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -283,6 +283,16 @@ def build_parser() -> argparse.ArgumentParser:
             "'haiku:0.5,gemini:0.5'). Requires --models."
         ),
     )
+    panel_run_parser.add_argument(
+        "--save",
+        action="store_true",
+        default=False,
+        help=(
+            "Save panel results to ~/.synthpanel/results/ with a generated "
+            "result ID. The result ID is printed to stderr on completion and "
+            "can be passed to 'synthpanel analyze <RESULT_ID>'."
+        ),
+    )
 
     # pack
     pack_parser = subparsers.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -766,6 +766,129 @@ class TestPanelRun:
         mock_synth.assert_not_called()
 
 
+# --- sp-7vp: --save flag --------------------------------------------------
+
+
+class TestPanelRunSave:
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_save_flag_writes_result_and_prints_id(
+        self, mock_client_cls, mock_runtime_cls, mock_synth, capsys, tmp_path, monkeypatch
+    ):
+        """--save stores results to disk and prints the result ID to stderr."""
+        mock_runtime = MagicMock()
+        mock_runtime.run_turn.return_value = _mock_turn_summary("answer")
+        mock_runtime_cls.return_value = mock_runtime
+        mock_synth.return_value = _mock_synthesis_result()
+
+        # Redirect results to tmp_path so we don't pollute ~/.synthpanel
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n    age: 30\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: What do you think?\n")
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--save",
+            ]
+        )
+        assert code == 0
+        captured = capsys.readouterr()
+        assert "Result saved: result-" in captured.err
+
+        # Extract the result ID from stderr
+        for line in captured.err.splitlines():
+            if line.startswith("Result saved: "):
+                result_id = line.split("Result saved: ")[1].strip()
+                break
+        else:
+            pytest.fail("Result ID not found in stderr")
+
+        # Verify the file was created
+        result_file = tmp_path / "data" / "results" / f"{result_id}.json"
+        assert result_file.exists()
+
+        # Verify the file content is valid JSON with expected fields
+        data = json.loads(result_file.read_text())
+        assert data["persona_count"] == 1
+        assert data["question_count"] == 1
+        assert "results" in data
+        assert "total_usage" in data
+        assert "total_cost" in data
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_save_result_works_with_analyze(
+        self, mock_client_cls, mock_runtime_cls, mock_synth, capsys, tmp_path, monkeypatch
+    ):
+        """Saved result can be loaded by 'synthpanel analyze'."""
+        mock_runtime = MagicMock()
+        mock_runtime.run_turn.return_value = _mock_turn_summary("Strongly agree")
+        mock_runtime_cls.return_value = mock_runtime
+        mock_synth.return_value = _mock_synthesis_result()
+
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text(
+            "personas:\n  - name: Alice\n    age: 30\n  - name: Bob\n    age: 25\n"
+        )
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Do you agree?\n")
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--save",
+            ]
+        )
+        assert code == 0
+
+        # Extract result ID
+        captured = capsys.readouterr()
+        result_id = None
+        for line in captured.err.splitlines():
+            if line.startswith("Result saved: "):
+                result_id = line.split("Result saved: ")[1].strip()
+                break
+        assert result_id is not None
+
+        # Now run analyze on the saved result
+        code = main(["analyze", result_id])
+        assert code == 0
+
+    def test_save_flag_parser(self):
+        """--save flag is accepted by the parser."""
+        parser = build_parser()
+        args = parser.parse_args(
+            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml", "--save"]
+        )
+        assert args.save is True
+
+    def test_save_flag_default_false(self):
+        """--save defaults to False."""
+        parser = build_parser()
+        args = parser.parse_args(
+            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"]
+        )
+        assert args.save is False
+
+
 # --- sp-f4t: default model resolution -----------------------------------
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -840,9 +840,7 @@ class TestPanelRunSave:
         monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
 
         personas_file = tmp_path / "personas.yaml"
-        personas_file.write_text(
-            "personas:\n  - name: Alice\n    age: 30\n  - name: Bob\n    age: 25\n"
-        )
+        personas_file.write_text("personas:\n  - name: Alice\n    age: 30\n  - name: Bob\n    age: 25\n")
         survey_file = tmp_path / "survey.yaml"
         survey_file.write_text("instrument:\n  questions:\n    - text: Do you agree?\n")
 
@@ -875,17 +873,13 @@ class TestPanelRunSave:
     def test_save_flag_parser(self):
         """--save flag is accepted by the parser."""
         parser = build_parser()
-        args = parser.parse_args(
-            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml", "--save"]
-        )
+        args = parser.parse_args(["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml", "--save"])
         assert args.save is True
 
     def test_save_flag_default_false(self):
         """--save defaults to False."""
         parser = build_parser()
-        args = parser.parse_args(
-            ["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"]
-        )
+        args = parser.parse_args(["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"])
         assert args.save is False
 
 


### PR DESCRIPTION
## Summary

- Add `--save` flag to panel run that stores results to `~/.synthpanel/results/` with a generated result ID
- Print the result ID on completion
- Make `synthpanel analyze` work with saved results
- Include JSON and text output formats
- Issue: sp-7vp
- Polecat: dag
- Branch: polecat/dag-mnvhvkok
- Tests: 842 passed (verified by refinery)

---
*Created by Gas Town Refinery*