### PR TITLE
docs: API stability policy + pre-commit config (sp-l6b)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,9 @@ pip install -e ".[dev]"
 
 # For MCP server development, also install MCP deps
 pip install -e ".[dev,mcp]"
+
+# Install pre-commit hooks (runs ruff auto-fixes on commit)
+pip install pre-commit && pre-commit install
 ```
 
 ## Running Tests

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -1,0 +1,35 @@
+# API Stability Policy
+
+synth-panel is currently **pre-1.0** (0.x.y). This document describes what contributors and users can expect about breaking changes.
+
+## Pre-1.0 stance
+
+- Breaking changes are possible.
+- **Minor bumps** (0.x → 0.(x+1)) may include breaking changes. The CHANGELOG documents all breakage.
+- **Patch bumps** (0.x.y → 0.x.(y+1)) are bug-fix-only. Never breaking.
+- Use the CHANGELOG as your source of truth before upgrading.
+
+## 1.0 promise
+
+1.0 will require a separate announcement and commitment to strict semver (breaking changes = major bump only). We're not there yet.
+
+## Public API surface
+
+The following are considered **public** and we try hard not to break them:
+
+- `synth_panel.llm.providers.base.LLMProvider` — the adapter base class
+- `ProviderConfig`, `CompletionRequest`, `CompletionResponse`, `StreamEvent` — adapter contract types
+- `synth-panel` CLI commands (`prompt`, `panel run`, `pack list`, `instruments list|show`, etc.)
+- MCP tool signatures (12 tools — see [MCP docs](./mcp.md))
+- Instrument YAML formats (v1 flat, v2 linear, v3 branching)
+- Persona pack YAML format
+
+## Internal / unstable
+
+These may change without notice between minor versions:
+
+- `synth_panel.runtime.*`
+- `synth_panel.orchestrator.*` internals (the orchestrator public methods are stable; internal state is not)
+- `synth_panel.plugins.*` — plugin system is evolving
+- `synth_panel.structured.*` — structured output subsystem is evolving
+- Anything not listed above as public


### PR DESCRIPTION
## Summary
- Add `docs/stability.md` declaring pre-1.0 policy and public API surface (providers base, CLI, MCP tools, YAML formats)
- Add `.pre-commit-config.yaml` with ruff + ruff-format hooks for local dev (mypy stays CI-only)
- Document `pre-commit install` in CONTRIBUTING.md

CI coverage summary via `$GITHUB_STEP_SUMMARY` was already in place (`.github/workflows/ci.yml` coverage job), so no workflow changes were needed.

Closes sp-l6b.

## Test plan
- [x] ruff check + format clean
- [x] `pytest tests/` — 864 passed, 83.25% coverage
- [ ] CI green on all required checks