### PR TITLE
docs: community governance — CoC, issue/PR templates, DCO (sp-0s6)

### DIFF
--- a/.github/ISSUE_TEMPLATE/adapter_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/adapter_proposal.yml
@@ -1,0 +1,53 @@
+name: Adapter proposal
+description: Propose a new LLM provider adapter for synth-panel
+labels: ["adapter", "enhancement"]
+body:
+  - type: input
+    id: provider
+    attributes:
+      label: Provider name
+      description: The LLM provider you'd like to add support for.
+      placeholder: e.g. Cohere, Mistral, Together
+    validations:
+      required: true
+
+  - type: input
+    id: api_docs
+    attributes:
+      label: API documentation URL
+      description: Link to the provider's public API documentation.
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: textarea
+    id: models
+    attributes:
+      label: Model list
+      description: Which models should the adapter expose? Include model IDs and any aliases.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Why this adapter?
+      description: What's the use case? Why is this provider valuable for synth-panel users?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: maintain
+    attributes:
+      label: Willingness to author and maintain
+      options:
+        - label: I'd be willing to author this adapter and help maintain it going forward.
+          required: false
+
+  - type: checkboxes
+    id: synthbench
+    attributes:
+      label: SynthBench results (recommended for adapter PRs)
+      options:
+        - label: I plan to include SynthBench results with the adapter PR.
+          required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: Report a bug in synth-panel
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: synth-panel version
+      description: Output of `synthpanel --version` or the installed package version.
+      placeholder: e.g. 0.7.4
+    validations:
+      required: true
+
+  - type: dropdown
+    id: provider
+    attributes:
+      label: LLM provider
+      description: Which provider were you using when the bug occurred?
+      options:
+        - Anthropic
+        - OpenAI
+        - xAI
+        - Gemini
+        - OpenRouter
+        - Other (please describe in reproduction steps)
+    validations:
+      required: true
+
+  - type: input
+    id: model
+    attributes:
+      label: Model name
+      description: Exact model name or alias (e.g. `claude-sonnet-4-6`, `sonnet`, `gpt-4o`).
+      placeholder: e.g. claude-sonnet-4-6
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal steps to reproduce. Include command, YAML input, or code snippet.
+      placeholder: |
+        1. Create `personas.yaml` with ...
+        2. Run `synthpanel panel run --personas personas.yaml --instrument ...`
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened? Include exit codes, error messages, or unexpected output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: Paste relevant logs, stack traces, or NDJSON output. Redact API keys.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & discussion
+    url: https://github.com/DataViking-Tech/synthpanel/discussions
+    about: Ask questions, share ideas, and discuss usage with the community.
+  - name: Security reports
+    url: https://github.com/DataViking-Tech/synthpanel/blob/main/SECURITY.md
+    about: Please do not file public issues for security vulnerabilities. See SECURITY.md for reporting instructions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature request
+description: Suggest a new feature or enhancement for synth-panel
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve? What's the use case?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to see. Interface sketches, YAML examples, and CLI flags are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they fell short.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: contribute
+    attributes:
+      label: Willingness to contribute
+      options:
+        - label: I'd be willing to open a PR implementing this.
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## What changed
+
+<!-- Brief summary of what this PR does. -->
+
+## Why
+
+<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New adapter
+- [ ] New instrument pack
+- [ ] New persona pack
+- [ ] Feature
+- [ ] Docs
+- [ ] Refactor
+
+## Test plan
+
+<!-- How did you verify this works? Commands run, cases covered, manual checks. -->
+
+## Semver impact
+
+Choose one (matches the auto-tag labels):
+
+- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
+- [ ] `semver:patch` — bug fix or small internal change
+- [ ] `semver:minor` — new feature, backwards compatible
+- [ ] `semver:major` — breaking change
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `ruff check src/ tests/` passes
+- [ ] `mypy src/synth_panel/` passes
+- [ ] CHANGELOG.md updated (if user-visible change)
+- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)
+
+## For adapter PRs
+
+<!-- Delete this section if not an adapter PR. -->
+
+Benchmarked on SynthBench? Link results here: ___

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Enforcement
+
+Report violations to **conduct@dataviking.tech**. Reports are handled confidentially; we respond within 7 days.
+
+See [SECURITY.md](SECURITY.md) for security-specific reports.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,3 +118,7 @@ Releases are published to PyPI via GitHub Actions:
 3. The `publish.yml` workflow builds and publishes to PyPI using trusted publishing.
 
 See the [Versions table in README.md](README.md#versions) for release history.
+
+## Sign-off
+
+All contributions require a DCO sign-off. Use `git commit -s` to add a `Signed-off-by:` trailer. This certifies you have the right to submit the contribution under the project's MIT license. See https://developercertificate.org/.


### PR DESCRIPTION
## Summary

Prep for public launch + external contribution intake.

- `CODE_OF_CONDUCT.md` — short form, references [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/). Contact: `conduct@dataviking.tech`.
- `.github/ISSUE_TEMPLATE/` YAML issue forms: `bug_report.yml`, `feature_request.yml`, `adapter_proposal.yml`, plus `config.yml` (blank issues disabled, Discussions + SECURITY links).
- `.github/pull_request_template.md` covering what/why, type, test plan, semver label (matches `auto-tag.yml`), checklist, and an adapter/SynthBench soft-prompt section.
- DCO sign-off section appended to `CONTRIBUTING.md`.

No code changes. Docs-only.

## MANUAL STEP REQUIRED

Maintainer must enable GitHub Discussions in repo settings (Settings → Features → check 'Discussions'). The `config.yml` Discussions link will 404 until enabled, then resolve.

## Test plan

- [x] `ruff check src/ tests/` passes
- [x] `mypy src/synth_panel/` passes
- [x] All four issue-template YAML files parse via `yaml.safe_load`
- [x] Commit signed off (DCO)

Refs sp-0s6