### PR TITLE
docs: add v3 branching instrument examples + examples index (sp-ug9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ The unified instrument resolver (used by `panel run --instrument`) accepts
 either a YAML path *or* an installed pack name, so you can iterate on a
 local file and then `install` it once it's stable.
 
+## Examples
+
+The [`examples/`](examples/) directory ships a persona pack plus one
+instrument per format (v1 flat, v2 linear, v3 branching). Start from
+[`examples/README.md`](examples/README.md) for the full index and
+annotated walkthroughs — including two v3 branching patterns
+(demographic segmentation and A/B concept testing) you can adapt to
+your own studies.
+
 ## LLM Provider Support
 
 synthpanel works with any LLM provider. Set the appropriate environment variable:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,89 @@
+# synthpanel examples
+
+Drop-in YAML files for getting started. Pair any persona pack with any
+instrument pack — the CLI takes both as separate `--personas` and
+`--instrument` arguments.
+
+## Files
+
+| File | Kind | What it shows |
+|------|------|---------------|
+| [`personas.yaml`](personas.yaml) | Persona pack | Three personas used by every instrument example below |
+| [`survey.yaml`](survey.yaml) | v1 instrument | Flat list of questions, no rounds — the simplest possible shape |
+| [`multi-round-study.yaml`](multi-round-study.yaml) | v2 instrument | Three sequential rounds (`discovery` → `deep_dive` → `validation`) with linear `depends_on` |
+| [`pricing-segmentation-study.yaml`](pricing-segmentation-study.yaml) | v3 branching | Demographic routing: splits into premium-tier vs value-tier probes based on income themes that surface in discovery |
+| [`concept-test-ab.yaml`](concept-test-ab.yaml) | v3 branching | A/B concept test with a conditional divergence probe driven by the `matches` (regex) predicate |
+
+The `instruments/` subdirectory holds three additional standalone
+instrument files (`general_survey.yaml`, `market_research.yaml`,
+`product_feedback.yaml`) kept for backward compatibility. Prefer the
+bundled packs (`synthpanel instruments list`) for new work.
+
+## Running an example
+
+```bash
+# v1: single round, flat questions
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/survey.yaml
+
+# v2: linear multi-round
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/multi-round-study.yaml
+
+# v3: branching — pricing segmentation
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/pricing-segmentation-study.yaml
+
+# v3: branching — A/B concept test
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/concept-test-ab.yaml
+```
+
+## Inspecting a branching instrument
+
+Render the round DAG to sanity-check routing before you spend tokens:
+
+```bash
+synthpanel instruments graph examples/pricing-segmentation-study.yaml --format mermaid
+synthpanel instruments graph examples/concept-test-ab.yaml --format mermaid
+```
+
+Validate a file without running it (parse-only — fails on bad DAGs,
+missing `else` clauses, unreachable rounds, etc.):
+
+```bash
+synthpanel instruments install examples/concept-test-ab.yaml --name concept-test-ab
+```
+
+`install` parses the file through the full v3 validator before writing
+anything to the pack directory, so a successful install means the
+instrument is well-formed.
+
+## Authoring v3 branching instruments
+
+Two gotchas are worth internalizing before you write your own:
+
+1. **Theme predicates match exact substrings.** `contains: price` only
+   fires if the synthesizer emitted a theme containing the literal
+   substring `price`. Add a canonical-tag comment block at the top of
+   your instrument (both branching examples above include one) so the
+   synthesizer prefers those tags. See the main
+   [README "Theme Matching" section](../README.md#theme-matching-the-r3-caveat)
+   for the full explanation.
+
+2. **`else` is mandatory.** Every `route_when` block must end with an
+   `else:` clause. The target can be another round name or the
+   reserved sentinel `__end__` (which terminates the run and triggers
+   final synthesis over the path traversed so far).
+
+Predicate operators:
+
+| Op | Meaning | Use when |
+|----|---------|----------|
+| `contains` | Substring match | You control the canonical tag vocabulary (most cases) |
+| `equals` | Exact string match | You know the synthesizer emits one of a fixed small set |
+| `matches` | Python regex | You want to catch a family of related phrasings (see `concept-test-ab.yaml`) |

--- a/examples/concept-test-ab.yaml
+++ b/examples/concept-test-ab.yaml
@@ -1,0 +1,79 @@
+# concept-test-ab: v3 branching instrument for classic A/B concept
+# testing. Panelists react to concept A, then concept B, and a
+# conditional third round probes the underlying reasoning *only* when
+# their reactions diverge significantly across the two concepts.
+#
+# This example demonstrates the `matches` predicate (Python regex).
+# `matches` is the right tool when you want to detect a family of
+# related phrasings — here, any synthesizer theme tag that signals
+# divergence, split reactions, or preference flipping.
+#
+# Canonical theme tags the synthesizer is encouraged to emit:
+#   - "divergent"       (panelists split sharply between A and B)
+#   - "diverge_strong"  (near-opposite reactions across the panel)
+#   - "prefer_a"        (clear group lean toward concept A)
+#   - "prefer_b"        (clear group lean toward concept B)
+#   - "tie"             (no meaningful difference between A and B)
+
+instrument:
+  version: 3
+  rounds:
+    - name: concept_a_reaction
+      questions:
+        - text: >
+            Here's concept A: {concept_a}. What's your immediate,
+            unfiltered reaction? Don't think too hard.
+        - text: >
+            Who do you think this is for? Would you use it yourself?
+
+    - name: concept_b_reaction
+      depends_on: concept_a_reaction
+      questions:
+        - text: >
+            Now here's concept B: {concept_b}. Same drill — gut
+            reaction first, then tell me who it's for.
+        - text: >
+            If you had to pick one of the two to actually use
+            tomorrow, which would it be, and by how wide a margin?
+      route_when:
+        - if:
+            field: themes
+            op: matches
+            value: "diverge|split|flip|opposite"
+          goto: probe_divergence
+        - if:
+            field: themes
+            op: matches
+            value: "(?i)prefer_[ab]|strong_(?:a|b)"
+          goto: probe_preference
+        - else: wrap_up
+
+    - name: probe_divergence
+      questions:
+        - text: >
+            The group split hard on these two. Walk me through what
+            concept A promises that concept B doesn't, and vice
+            versa — in your own words.
+        - text: >
+            What would concept A need to borrow from concept B (or
+            the other way around) to become the clear winner for you?
+      route_when:
+        - else: wrap_up
+
+    - name: probe_preference
+      questions:
+        - text: >
+            You leaned toward one concept pretty clearly. What tipped
+            it — the idea itself, the way it was framed, or something
+            about the alternative that turned you off?
+        - text: >
+            If we reframed the weaker concept so that its strongest
+            idea led, would your preference shift? Be honest.
+      route_when:
+        - else: wrap_up
+
+    - name: wrap_up
+      questions:
+        - text: >
+            Final word — if you had to explain to a friend in one
+            sentence which concept wins and why, what would you say?

--- a/examples/pricing-segmentation-study.yaml
+++ b/examples/pricing-segmentation-study.yaml
@@ -1,0 +1,78 @@
+# pricing-segmentation-study: v3 branching instrument that splits the
+# panel into a premium-tier probe or value-tier probe based on the
+# income bracket that surfaces in the discovery round.
+#
+# Routing note: v3 predicates match exact substrings against themes
+# emitted by the synthesizer, not numeric response values. There is no
+# `greater_than` operator — instead, we prompt the synthesizer to emit
+# canonical income-bracket tags and branch on `contains`. See the
+# README "Theme Matching" section for the full R3 caveat.
+#
+# Canonical theme tags used below:
+#   - "income_high"  (respondents anchor on >$75K household income
+#                     or premium-tier willingness to pay)
+#   - "income_low"   (respondents anchor on <=$75K or value-tier
+#                     willingness to pay)
+#   - "price_sensitive" (any strong price-anchored resistance)
+
+instrument:
+  version: 3
+  rounds:
+    - name: discovery
+      questions:
+        - text: >
+            Walk me through the last time you paid for a {category}
+            product. What did you pay, and did it feel fair?
+        - text: >
+            When you think about your household budget, where does a
+            product like this sit — comfortable purchase, stretch, or
+            splurge? A rough income bracket is fine if you're willing.
+      route_when:
+        - if:
+            field: themes
+            op: contains
+            value: income_high
+          goto: premium_tier
+        - if:
+            field: themes
+            op: contains
+            value: income_low
+          goto: value_tier
+        - if:
+            field: themes
+            op: contains
+            value: price_sensitive
+          goto: value_tier
+        - else: value_tier
+
+    - name: premium_tier
+      questions:
+        - text: >
+            For a premium version of {category} — best-in-class
+            materials, white-glove support, early access to new
+            features — what would you expect to pay per year?
+        - text: >
+            What would make the premium price feel *earned* versus
+            feel like a tax on people who can afford it?
+      route_when:
+        - else: wrap_up
+
+    - name: value_tier
+      questions:
+        - text: >
+            For a no-frills version of {category} that covers the
+            essentials reliably, what monthly price would feel fair —
+            and what price would feel like a bargain?
+        - text: >
+            What's the one feature you'd refuse to give up even in a
+            value-tier product? What would you trade away without
+            blinking?
+      route_when:
+        - else: wrap_up
+
+    - name: wrap_up
+      questions:
+        - text: >
+            Last question for everyone — if {category} raised its
+            price 20% tomorrow, what would you do? Pay it, switch,
+            cancel, or something else?


### PR DESCRIPTION
## Summary
- Adds two new v3 branching instrument examples in `examples/`:
  - `pricing-segmentation-study.yaml` — demographic routing via canonical income-bracket theme tags (`contains`)
  - `concept-test-ab.yaml` — A/B concept test with a conditional divergence probe driven by the `matches` (regex) predicate
- Adds `examples/README.md` indexing every example file (persona pack, v1, v2, v3), with run/validate/graph snippets and a short v3 authoring primer
- Links `examples/README.md` from the main `README.md`

Closes sp-ug9.

## Design notes
- There is no `greater_than` predicate op (the bead's hint was aspirational); predicates compare against synthesizer-emitted themes. Both new examples therefore lean on theme-tag routing with an explicit canonical-tag comment block, matching the bundled pack convention and the "Theme Matching" R3 caveat.
- Both files pass `parse_instrument` with zero warnings and install cleanly via `synthpanel instruments install`.
- Constraint honored: YAML + docs only, no code changes.

## Test plan
- [x] `synth_panel.instrument.parse_instrument` accepts both new YAMLs with empty `warnings`
- [x] `synthpanel instruments install` on both files succeeds
- [x] `synthpanel instruments graph <file> --format mermaid` renders cleanly
- [x] `ruff check .` → all checks passed
- [x] `mypy src/` → no issues in 54 files
- [x] `pytest tests/ -x -q` → 903 passed, coverage 86.93%