### PR TITLE
fix: print synthesis cost estimate to stderr directly (sp-bqs)

### DIFF
--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sys
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -158,7 +159,7 @@ def _print_cost_estimate(
     parts = [f"Synthesis will cost ~{est.format_usd()}"]
     if panelist_cost is not None:
         parts.append(f"(panelist cost was {panelist_cost.format_usd()})")
-    logger.info(" ".join(parts))
+    print(" ".join(parts), file=sys.stderr)
 
 
 def synthesize_panel(


### PR DESCRIPTION
## Summary
Fix pre-existing TestCostEstimate failures on main. The sp-log structured logging refactor replaced the pre-synthesis cost `stderr` print() with `logger.info()`, but `setup_logging()` is only called from CLI/MCP entry points — library consumers and tests invoking `synthesize_panel()` directly get no handler on the `synth_panel` logger, silently swallowing the cost announcement.

## Fix
Revert this specific call to `print(file=sys.stderr)`. The cost estimate is a user-facing UX message before a billable operation, not a debug log — it must appear regardless of logging configuration. Restores the contract documented in the function docstring and asserted by TestCostEstimate.

Closes sp-bqs.

## Test plan
- [x] `pytest tests/ -k cost_estimate` — TestCostEstimate green
- [ ] CI green on all required checks