### PR TITLE
feat(cli): panel synthesize subcommand for post-hoc re-synthesis (sp-5on.5)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1502,6 +1502,138 @@ def _build_params_metadata(
     return params
 
 
+def handle_panel_synthesize(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Re-synthesize a saved panel result (sp-5on.5).
+
+    Loads a saved panel result, reconstructs the panelist results and
+    question list, invokes :func:`synthesize_panel` with the requested
+    model/prompt, and writes a sidecar file
+    ``<result_id>.synthesis-<ts>.json`` next to the original result.
+    """
+    from datetime import datetime, timezone
+
+    from synth_panel.orchestrator import PanelistResult
+
+    result_ref = args.result
+    path = Path(result_ref)
+    if path.exists() and path.suffix == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data.setdefault("id", path.stem)
+    else:
+        from synth_panel.mcp.data import get_panel_result
+
+        try:
+            data = get_panel_result(result_ref)
+        except FileNotFoundError:
+            print(f"Error: panel result not found: {result_ref}", file=sys.stderr)
+            return 1
+
+    saved_results = data.get("results") or []
+    if not saved_results:
+        print(f"Error: no panelist results found in {result_ref}", file=sys.stderr)
+        return 1
+
+    panelist_results: list[PanelistResult] = []
+    for r in saved_results:
+        usage_dict = r.get("usage") or {}
+        usage = TokenUsage.from_dict(usage_dict) if usage_dict else ZERO_USAGE
+        panelist_results.append(
+            PanelistResult(
+                persona_name=r.get("persona", "Anonymous"),
+                responses=r.get("responses") or [],
+                usage=usage,
+                error=r.get("error"),
+                model=r.get("model"),
+            )
+        )
+
+    saved_questions = data.get("questions")
+    if saved_questions:
+        questions = saved_questions
+    else:
+        seen: list[dict[str, Any]] = []
+        seen_texts: set[str] = set()
+        for pr in panelist_results:
+            for resp in pr.responses:
+                if resp.get("follow_up"):
+                    continue
+                q_text = resp.get("question", "")
+                if q_text and q_text not in seen_texts:
+                    seen.append({"text": q_text})
+                    seen_texts.add(q_text)
+        questions = seen
+
+    panelist_model = data.get("model")
+    client = LLMClient()
+    try:
+        synth = synthesize_panel(
+            client,
+            panelist_results,
+            questions,
+            model=getattr(args, "synthesis_model", None),
+            panelist_model=panelist_model,
+            custom_prompt=getattr(args, "synthesis_prompt", None),
+        )
+    except Exception as exc:
+        print(f"Error: synthesis failed: {exc}", file=sys.stderr)
+        return 1
+
+    synthesis_dict = synth.to_dict()
+
+    from synth_panel.mcp.data import save_panel_synthesis
+
+    source_id = data.get("id") or path.stem
+    ts = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    sidecar_name = save_panel_synthesis(
+        source_id,
+        ts,
+        {
+            "source_result_id": source_id,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "synthesis_model": synth.model,
+            "synthesis_prompt_override": getattr(args, "synthesis_prompt", None) is not None,
+            "synthesis": synthesis_dict,
+        },
+    )
+
+    if fmt is OutputFormat.TEXT:
+        print(f"{'=' * 60}")
+        print("SYNTHESIS")
+        print(f"{'=' * 60}")
+        print(f"\n  Summary: {synthesis_dict['summary']}")
+        if synthesis_dict.get("themes"):
+            print("\n  Themes:")
+            for t in synthesis_dict["themes"]:
+                print(f"    - {t}")
+        if synthesis_dict.get("agreements"):
+            print("\n  Agreements:")
+            for a in synthesis_dict["agreements"]:
+                print(f"    - {a}")
+        if synthesis_dict.get("disagreements"):
+            print("\n  Disagreements:")
+            for d in synthesis_dict["disagreements"]:
+                print(f"    - {d}")
+        if synthesis_dict.get("surprises"):
+            print("\n  Surprises:")
+            for s in synthesis_dict["surprises"]:
+                print(f"    - {s}")
+        print(f"\n  Recommendation: {synthesis_dict['recommendation']}")
+        print(f"  Synthesis cost: {synthesis_dict['cost']}")
+        print(f"\nSaved synthesis: {sidecar_name}", file=sys.stderr)
+    else:
+        emit(
+            fmt,
+            message="Panel synthesis complete",
+            extra={
+                "source_result_id": source_id,
+                "synthesis": synthesis_dict,
+                "saved_as": sidecar_name,
+            },
+        )
+
+    return 0
+
+
 def handle_analyze(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run statistical analysis on a saved panel result."""
     import json as _json

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -284,6 +284,29 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # panel synthesize (sp-5on.5: post-hoc re-synthesis of a saved result)
+    panel_synth_parser = panel_subparsers.add_parser(
+        "synthesize",
+        help="Re-synthesize a saved panel result with a different model or prompt.",
+    )
+    panel_synth_parser.add_argument(
+        "result",
+        metavar="RESULT_ID",
+        help="Panel result ID (from 'panel run --save') or path to a result JSON file.",
+    )
+    panel_synth_parser.add_argument(
+        "--synthesis-model",
+        default=None,
+        metavar="MODEL",
+        help="Model for re-synthesis (default: original panelist model).",
+    )
+    panel_synth_parser.add_argument(
+        "--synthesis-prompt",
+        default=None,
+        metavar="PROMPT",
+        help="Custom synthesis prompt (replaces the default entirely).",
+    )
+
     # pack
     pack_parser = subparsers.add_parser(
         "pack",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -21,6 +21,7 @@ from synth_panel.cli.commands import (
     handle_pack_list,
     handle_pack_show,
     handle_panel_run,
+    handle_panel_synthesize,
     handle_prompt,
 )
 from synth_panel.cli.output import OutputFormat
@@ -49,6 +50,8 @@ def main(argv: list[str] | None = None) -> int:
     elif args.command == "panel":
         if getattr(args, "panel_command", None) == "run":
             return handle_panel_run(args, output_format)
+        elif getattr(args, "panel_command", None) == "synthesize":
+            return handle_panel_synthesize(args, output_format)
         else:
             parser.parse_args(["panel", "--help"])
             return 1

--- a/src/synth_panel/mcp/data.py
+++ b/src/synth_panel/mcp/data.py
@@ -461,6 +461,24 @@ def get_panel_result(result_id: str) -> dict[str, Any]:
     return data
 
 
+def save_panel_synthesis(
+    source_result_id: str,
+    timestamp: str,
+    payload: dict[str, Any],
+) -> str:
+    """Write a sidecar synthesis file next to a saved panel result.
+
+    Used by ``synthpanel panel synthesize`` (sp-5on.5) to persist a
+    re-synthesis without mutating the original result. Returns the
+    sidecar filename (not the full path).
+    """
+    _validate_pack_id(source_result_id)
+    name = f"{source_result_id}.synthesis-{timestamp}.json"
+    p = _results_dir() / name
+    p.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return name
+
+
 def save_panel_result(
     results: list[dict[str, Any]],
     model: str,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -882,6 +882,151 @@ class TestPanelRunSave:
         assert args.save is False
 
 
+# --- sp-5on.5: panel synthesize re-synthesis subcommand -----------------
+
+
+class TestPanelSynthesize:
+    """sp-5on.5: ``panel synthesize`` replays synthesis against a saved result."""
+
+    def test_panel_synthesize_parser(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            ["panel", "synthesize", "result-abc", "--synthesis-model", "opus", "--synthesis-prompt", "Be brief."]
+        )
+        assert args.command == "panel"
+        assert args.panel_command == "synthesize"
+        assert args.result == "result-abc"
+        assert args.synthesis_model == "opus"
+        assert args.synthesis_prompt == "Be brief."
+
+    def test_panel_synthesize_parser_defaults(self):
+        parser = build_parser()
+        args = parser.parse_args(["panel", "synthesize", "result-xyz"])
+        assert args.synthesis_model is None
+        assert args.synthesis_prompt is None
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_synthesize_reloads_result_and_saves_sidecar(
+        self, mock_client_cls, mock_synth, capsys, tmp_path, monkeypatch
+    ):
+        """Loads saved result by ID, invokes synthesize_panel, writes sidecar."""
+        mock_synth.return_value = _mock_synthesis_result()
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        # Seed a saved panel result on disk
+        results_dir = tmp_path / "data" / "results"
+        results_dir.mkdir(parents=True)
+        result_id = "result-20260101-120000-abcdef"
+        (results_dir / f"{result_id}.json").write_text(
+            json.dumps(
+                {
+                    "created_at": "2026-01-01T12:00:00+00:00",
+                    "model": "haiku",
+                    "persona_count": 1,
+                    "question_count": 1,
+                    "total_usage": {"input_tokens": 5, "output_tokens": 10},
+                    "total_cost": "$0.0001",
+                    "results": [
+                        {
+                            "persona": "Alice",
+                            "responses": [
+                                {"question": "What do you think?", "response": "I like it."},
+                            ],
+                            "usage": {"input_tokens": 5, "output_tokens": 10},
+                            "cost": "$0.0001",
+                            "error": None,
+                        }
+                    ],
+                }
+            )
+        )
+
+        code = main(["panel", "synthesize", result_id, "--synthesis-model", "opus"])
+        assert code == 0
+
+        # synthesize_panel should have been called with the rebuilt panelist_results
+        mock_synth.assert_called_once()
+        _, kwargs = mock_synth.call_args
+        assert kwargs["model"] == "opus"
+        assert kwargs["panelist_model"] == "haiku"
+        panelist_results_arg = mock_synth.call_args.args[1]
+        assert len(panelist_results_arg) == 1
+        assert panelist_results_arg[0].persona_name == "Alice"
+        # Questions reconstructed from response dicts when not saved explicitly
+        questions_arg = mock_synth.call_args.args[2]
+        assert questions_arg == [{"text": "What do you think?"}]
+
+        # Sidecar was written alongside the original result
+        sidecars = list(results_dir.glob(f"{result_id}.synthesis-*.json"))
+        assert len(sidecars) == 1
+        sidecar_data = json.loads(sidecars[0].read_text())
+        assert sidecar_data["source_result_id"] == result_id
+        assert sidecar_data["synthesis"]["summary"] == "Test synthesis summary"
+        assert sidecar_data["synthesis_prompt_override"] is False
+
+        # Original result file must remain untouched
+        original = json.loads((results_dir / f"{result_id}.json").read_text())
+        assert "synthesis" not in original
+
+        # Text output surfaces the synthesis
+        out = capsys.readouterr()
+        assert "SYNTHESIS" in out.out
+        assert "Test synthesis summary" in out.out
+        assert "Saved synthesis:" in out.err
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_synthesize_passes_custom_prompt(self, mock_client_cls, mock_synth, capsys, tmp_path, monkeypatch):
+        """``--synthesis-prompt`` flows through as custom_prompt."""
+        mock_synth.return_value = _mock_synthesis_result()
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        result_file = tmp_path / "inline-result.json"
+        result_file.write_text(
+            json.dumps(
+                {
+                    "model": "sonnet",
+                    "persona_count": 1,
+                    "question_count": 1,
+                    "results": [
+                        {
+                            "persona": "Bob",
+                            "responses": [{"question": "Q?", "response": "A."}],
+                            "usage": {"input_tokens": 1, "output_tokens": 2},
+                        }
+                    ],
+                }
+            )
+        )
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "synthesize",
+                str(result_file),
+                "--synthesis-prompt",
+                "Summarize tersely.",
+            ]
+        )
+        assert code == 0
+        _, kwargs = mock_synth.call_args
+        assert kwargs["custom_prompt"] == "Summarize tersely."
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["source_result_id"] == result_file.stem
+        assert payload["synthesis"]["summary"] == "Test synthesis summary"
+        assert payload["saved_as"].startswith(f"{result_file.stem}.synthesis-")
+
+    def test_panel_synthesize_missing_result_returns_error(self, capsys, tmp_path, monkeypatch):
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+        code = main(["panel", "synthesize", "result-does-not-exist"])
+        assert code == 1
+        assert "not found" in capsys.readouterr().err
+
+
 # --- sp-f4t: default model resolution -----------------------------------
 
 


### PR DESCRIPTION
## Summary
Adds `synthpanel panel synthesize <result-id>` to re-run synthesis on a previously-saved panel result.

- Loads saved results via `get_panel_result()` (or a file path)
- Reconstructs `PanelistResult` objects and the question list from stored response dicts
- Invokes `synthesize_panel()` with optional `--synthesis-model` / `--synthesis-prompt` overrides
- New synthesis is written to a sidecar file `<result_id>.synthesis-<ts>.json` alongside the original — the original is never mutated (mirrors the `.pre-extend.json` sidecar pattern used by `update_panel_result()`)

Enables a `--synthesis-only`-style workflow: run a panel once, then try multiple models / prompts against captured panelist responses without repaying the panelist cost.

Closes sp-5on.5.

## Test plan
- [x] Local tests pass
- [ ] CI green on all required checks