### PR TITLE
feat(cost): lookup_pricing_by_provider + multi-question CLI cost shape (sp-027)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-14
+
 ### Added
+- `lookup_pricing_by_provider(provider_string)` helper in `synth_panel.cost`: parses synthbench `config.provider` strings (`synthpanel/`, `openrouter/`, `raw-anthropic/`, `raw-openai/`, `raw-gemini/`, `ollama/` plus `t=`/`profile=`/`tpl=` decorators) and resolves to `(ModelPricing, is_estimated)`. Refuses substring fallback to SONNET so callers (notably synthbench publish) decide whether to emit null. Returns `(None, False)` for `ollama/*`, the named baselines, `ensemble/*`, and unknown inner models. (sp-027)
+- `pricing snapshot_date: 2026-04-14` comment above the pricing table to anchor downstream snapshot generation. (sp-027)
+- `panelist_usage` field on the rounds-shaped CLI JSON output, restoring symmetry with `panelist_cost`/`total_cost`/`total_usage` so multi-question runs no longer drop a usage bucket downstream consumers rely on. (sp-027)
 - v3 branching instruments with `route_when` predicates and DAG validation
 - Router predicate engine: `contains`, `equals`, `matches` operators
 - Multi-round branching orchestrator loop
@@ -23,6 +28,7 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 - GitHub Release notes + changelog config in auto-tag workflow
 
 ### Fixed
+- Multi-question CLI runs now emit the full cost shape (`total_cost`, `total_usage`, `panelist_cost`, `panelist_usage`) on the rounds-shaped output. Previously `panelist_usage` was absent, which silently zeroed the synthbench leaderboard's `$/100Q` column for new rows. (sp-027)
 - Fail loud when all provider requests error (#37)
 - Default `--model` now respects available credentials and announces pick (#38)
 - Publish workflow trigger corrected + manual PyPI setup documented (#40)
@@ -57,6 +63,7 @@ First published release on [PyPI](https://pypi.org/project/synthpanel/).
 - Persona-pack persistence (`save_persona_pack`, `get_persona_pack`, `list_persona_packs`)
 - Panel result persistence and retrieval
 
-[Unreleased]: https://github.com/DataViking-Tech/synthpanel/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/DataViking-Tech/synthpanel/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/DataViking-Tech/synthpanel/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/DataViking-Tech/synthpanel/releases/tag/v0.4.0
 [0.3.0]: https://github.com/DataViking-Tech/synthpanel/releases/tag/v0.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.4.0"
+version = "0.4.1"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -846,6 +846,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             results=results,
             synthesis_dict=synthesis_dict,
             panelist_cost=panelist_cost_est,
+            panelist_usage=panelist_usage,
             total_usage=total_usage,
             total_cost=total_cost_est,
             model=model,
@@ -1042,6 +1043,7 @@ def _build_rounds_shape(
     model: str,
     persona_count: int,
     question_count: int,
+    panelist_usage: TokenUsage | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the rounds-shaped panel output payload.
@@ -1065,6 +1067,7 @@ def _build_rounds_shape(
         "warnings": list(getattr(instrument, "warnings", []) or []),
         "synthesis": synthesis_dict,
         "panelist_cost": panelist_cost.format_usd(),
+        "panelist_usage": (panelist_usage.to_dict() if panelist_usage is not None else None),
         "total_usage": total_usage.to_dict(),
         "total_cost": total_cost.format_usd(),
         "model": model,

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -7,6 +7,7 @@ cost estimation, budget enforcement, and human-readable summaries.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -65,6 +66,7 @@ class ModelPricing:
 
 
 # Known pricing tiers from SPEC.md §7.
+# pricing snapshot_date: 2026-04-14
 HAIKU_PRICING = ModelPricing(
     input_cost_per_million=1.00,
     output_cost_per_million=5.00,
@@ -124,6 +126,70 @@ def lookup_pricing(model: str | None = None) -> tuple[ModelPricing, bool]:
             if key in lower:
                 return pricing, False
     return DEFAULT_PRICING, True
+
+
+# Bucket prefixes observed in synthbench `config.provider` strings
+# (see synthbench specs/cost-metrics/research/synthbench-runner.md Q5).
+_PROVIDER_BUCKETS = ("synthpanel", "openrouter", "raw-anthropic", "raw-openai", "raw-gemini", "ollama")
+
+# Strip a leading bucket prefix and any trailing " t=...", " profile=...", " tpl=..."
+# decorators so the remainder is a plain canonical model string suitable for
+# ``lookup_pricing``.
+_PROVIDER_SPLIT_RE = re.compile(
+    r"^(?P<bucket>" + "|".join(re.escape(b) for b in _PROVIDER_BUCKETS) + r")/(?P<inner>.+?)"
+    r"(?:\s+(?:t|profile|tpl)=\S+)*\s*$"
+)
+
+# Provider strings that intentionally have no priced equivalent: synthetic
+# baselines (zero-cost references) and ensemble blends (cost is the sum of
+# constituents, computed elsewhere). Callers decide whether to emit null or 0.
+_UNPRICED_PROVIDERS = frozenset(
+    {
+        "random-baseline",
+        "majority-baseline",
+        "population-average-baseline",
+    }
+)
+
+
+def lookup_pricing_by_provider(provider_string: str) -> tuple[ModelPricing | None, bool]:
+    """Resolve a synthbench ``config.provider`` string to pricing.
+
+    Parses the bucket prefix (``synthpanel/``, ``openrouter/``,
+    ``raw-(anthropic|openai|gemini)/``, ``ollama/``) and trailing
+    ``" t=..."``, ``" profile=..."``, ``" tpl=..."`` decorators, then
+    delegates to ``lookup_pricing`` on the inner model string.
+
+    Returns ``(pricing, is_estimated)`` matching ``lookup_pricing``'s
+    return shape, except: returns ``(None, False)`` for unresolved
+    providers — ``ollama/*`` (self-hosted), the named baselines, any
+    ``ensemble/*`` provider, and any inner string that ``lookup_pricing``
+    can only price via the substring-fallback. Refusing the fallback is
+    intentional: callers (e.g. synthbench publish) decide whether to emit
+    null or a default rather than silently billing at Sonnet rates.
+    """
+    if not provider_string:
+        return None, False
+
+    stripped = provider_string.strip()
+
+    if stripped in _UNPRICED_PROVIDERS or stripped.startswith("ensemble/"):
+        return None, False
+
+    match = _PROVIDER_SPLIT_RE.match(stripped)
+    if not match:
+        return None, False
+
+    bucket = match.group("bucket")
+    inner = match.group("inner").strip()
+
+    if bucket == "ollama":
+        return None, False
+
+    pricing, is_estimated = lookup_pricing(inner)
+    if is_estimated:
+        return None, False
+    return pricing, False
 
 
 @dataclass(frozen=True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -489,6 +489,72 @@ class TestPanelRun:
     @patch("synth_panel.cli.commands.synthesize_panel")
     @patch("synth_panel.orchestrator.AgentRuntime")
     @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_multi_question_emits_full_cost_shape(
+        self, mock_client_cls, mock_runtime_cls, mock_synth, capsys, tmp_path
+    ):
+        """Multi-question CLI runs must surface the full cost shape (sp-027).
+
+        The synthbench publish pipeline reads ``total_cost``, ``total_usage``,
+        ``panelist_cost`` and ``panelist_usage`` off the rounds-shaped JSON
+        output. A regression in any one of them silently zeroes a
+        leaderboard row's $/100Q column, so this test pins the contract.
+        """
+        mock_runtime = MagicMock()
+        mock_runtime.run_turn.return_value = _mock_turn_summary("answer")
+        mock_runtime_cls.return_value = mock_runtime
+        mock_synth.return_value = _mock_synthesis_result()
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q1?\n    - text: Q2?\n    - text: Q3?\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+
+        # All four cost fields must be present at the top level of the
+        # rounds-shaped output — no silent drops, no Nones.
+        for key in ("total_cost", "total_usage", "panelist_cost", "panelist_usage"):
+            assert key in data, f"missing {key} in multi-question output"
+            assert data[key] is not None, f"{key} unexpectedly None"
+
+        # panelist_usage is the dict shape produced by TokenUsage.to_dict()
+        # — it must include the four token buckets even when zero.
+        for bucket in (
+            "input_tokens",
+            "output_tokens",
+            "cache_creation_input_tokens",
+            "cache_read_input_tokens",
+        ):
+            assert bucket in data["panelist_usage"]
+            assert bucket in data["total_usage"]
+
+        # Cost strings are formatted USD (e.g. "$0.0001"). Reject the
+        # accidental empty / placeholder shapes that would mask a regression.
+        assert data["total_cost"].startswith("$")
+        assert data["panelist_cost"].startswith("$")
+
+        # The metadata block surfaces the same data for downstream consumers
+        # (synthbench publish reads either path); both must agree.
+        assert "metadata" in data
+        assert "cost" in data["metadata"]
+        assert "total_cost_usd" in data["metadata"]["cost"]
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
     def test_panel_run_synthesis_model(self, mock_client_cls, mock_runtime_cls, mock_synth, capsys, tmp_path):
         """--synthesis-model is passed through to synthesize_panel."""
         mock_runtime = MagicMock()

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import pytest
 
 from synth_panel.cost import (
+    GEMINI_FLASH_PRICING,
+    GEMINI_PRO_PRICING,
     HAIKU_PRICING,
     OPUS_PRICING,
     SONNET_PRICING,
@@ -17,6 +19,7 @@ from synth_panel.cost import (
     estimate_cost,
     format_summary,
     lookup_pricing,
+    lookup_pricing_by_provider,
 )
 
 # --- TokenUsage -----------------------------------------------------------
@@ -81,6 +84,57 @@ class TestPricingLookup:
     def test_none_model_defaults(self):
         _p, est = lookup_pricing(None)
         assert est is True
+
+
+# --- Provider-string pricing lookup --------------------------------------
+
+
+class TestProviderLookup:
+    """Cover the 7 R-observed `config.provider` formats plus negatives.
+
+    The provider string is the synthbench-side identifier that pairs a
+    bucket prefix (delivery channel) with an inner model string. The
+    helper must (a) parse the bucket + inner correctly, (b) refuse to
+    fall back to SONNET pricing for unrecognised inner strings, and
+    (c) treat baselines / ensembles / self-hosted as unpriced.
+    """
+
+    @pytest.mark.parametrize(
+        "provider, expected",
+        [
+            # 7 positive cases — valid bucket + recognised inner.
+            ("synthpanel/claude-sonnet-4", SONNET_PRICING),
+            ("synthpanel/claude-sonnet-4 t=0.85 tpl=current", SONNET_PRICING),
+            ("synthpanel/claude-haiku-4-5 t=0.85 profile=foo tpl=minimal", HAIKU_PRICING),
+            ("openrouter/anthropic/claude-haiku-4-5", HAIKU_PRICING),
+            ("openrouter/google/gemini-2.5-flash", GEMINI_FLASH_PRICING),
+            ("raw-anthropic/claude-opus-4-6", OPUS_PRICING),
+            ("raw-gemini/gemini-2.5-pro", GEMINI_PRO_PRICING),
+        ],
+    )
+    def test_positive_lookup(self, provider: str, expected: object) -> None:
+        pricing, is_estimated = lookup_pricing_by_provider(provider)
+        assert pricing is expected
+        assert is_estimated is False
+
+    @pytest.mark.parametrize(
+        "provider",
+        [
+            # 5 negative cases — unpriced by design.
+            "ollama/llama3",
+            "random-baseline",
+            "majority-baseline",
+            "population-average-baseline",
+            "ensemble/3-model-blend",
+            # 1 edge case — valid bucket but inner has no priced match.
+            # Refuses to silently fall back to SONNET.
+            "raw-openai/gpt-5-unreleased",
+        ],
+    )
+    def test_negative_lookup(self, provider: str) -> None:
+        pricing, is_estimated = lookup_pricing_by_provider(provider)
+        assert pricing is None
+        assert is_estimated is False
 
 
 # --- CostEstimate ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Slice 1 of the cost-metrics epic ([sb-tbm](../synthbench)). Exposes the helper synthbench publish needs to derive cost from provider strings, and patches a cost-shape asymmetry in the multi-question CLI output.

- Adds `lookup_pricing_by_provider(provider_string)` parsing the 6 bucket prefixes (`synthpanel/`, `openrouter/`, `raw-anthropic/`, `raw-openai/`, `raw-gemini/`, `ollama/`) plus `t=`/`profile=`/`tpl=` decorators. Refuses the SONNET substring fallback so callers decide null vs default.
- Adds `pricing snapshot_date: 2026-04-14` anchor comment for downstream pricing snapshot generation.
- Adds `panelist_usage` to rounds-shaped CLI JSON output, restoring symmetry with `panelist_cost` / `total_cost` / `total_usage`.
- 13 parametrized unit tests covering 7 positive provider formats + 5 unpriced-by-design + 1 unknown-inner edge.
- Integration test pinning the full cost shape on multi-question CLI runs.
- Bumps version 0.4.0 → 0.4.1, CHANGELOG entry.

## Note on spec translation

Bead [sp-027](.) referenced `_run_multi_cli` / `_run_multi_batch` in `src/synth_panel/synthpanel.py:745`/`:825` — that file and those functions do not exist in this repo. The synthpanel codebase uses a unified `handle_panel_run` in `src/synth_panel/cli/commands.py`. Translated the intent (full cost shape on multi-question output) to the rounds-shape builder, where `panelist_usage` was the missing field.

## Acceptance criteria

- [x] `pytest tests/test_cost.py::TestProviderLookup` — 13 cases pass
- [x] `pytest tests/test_acceptance.py` still green (922 tests pass overall)
- [x] Integration test for multi-question CLI cost passes
- [x] Smoke: `python -c "from synth_panel.cost import lookup_pricing_by_provider; print(lookup_pricing_by_provider('openrouter/anthropic/claude-haiku-4-5'))"` returns `(ModelPricing(...), False)`
- [x] Version bump (0.4.0 → 0.4.1; the bead-specified 0.2.0 was based on stale current-version assumptions)

## Test plan

- [ ] CI green
- [ ] Reviewer confirms version-bump choice (0.4.1 patch vs an alternative)

🤖 Generated with [Claude Code](https://claude.com/claude-code)