### PR TITLE
chore(release): bump to 0.8.0 — publish lookup_pricing_by_provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-14
+
+### Added
+- (sp-027) `lookup_pricing_by_provider(provider_string)` — parses synthbench-format provider strings (synthpanel/*, openrouter/*, raw-anthropic/*, etc.) into pricing tuples; returns `(None, False)` for ollama, baselines, ensembles, and unresolved providers.
+
+### Fixed
+- (sp-027) Multi-question CLI cost-drop: `_run_multi_cli` and `_run_multi_batch` now propagate `total_cost` / `panelist_cost` / `total_usage` / `panelist_usage` to per-response metadata, matching `_run_single`.
+
+### Notes
+- Version bumped from 0.4.1 → 0.8.0 to reconcile pyproject.toml with PyPI release line (last published was 0.7.4); minor bump reflects new public API.
+
+
 ## [0.4.1] - 2026-04-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.4.1"
+version = "0.8.0"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Bumps synthpanel to **0.8.0** and reconciles the pyproject ↔ PyPI version disconnect (pyproject was 0.4.1; last PyPI publish was 0.7.4).

Triggers Auto Semver Tag → cuts v0.8.0 → triggers Publish to PyPI workflow → makes \`lookup_pricing_by_provider\` (added by sp-027 / #130) installable in downstream synthbench.

## Why minor

New public API (\`lookup_pricing_by_provider\`) added in #130 — semver-correct minor bump. \`semver:minor\` label applied for Auto Semver Tag.

## Downstream

Unblocks synthbench Slice 3 (sb-x8t / PR #141) which pins \`synthpanel>=0.8.0\` to import the new function.

## Test plan

- [x] CI passes (no code changes — version + CHANGELOG only)
- [ ] After merge: Auto Semver Tag creates v0.8.0
- [ ] After tag: Publish to PyPI workflow ships 0.8.0 to PyPI
- [ ] synthbench Slice 3 PR #141 re-runs CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)