### PR TITLE
chore(release): bump to 0.9.0 — public-launch milestone (sp-t9e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-15
+
+### Public Launch
+- First release post-public-flip. Repo renamed from `synth-panel` to
+  `SynthPanel` (PyPI distribution name `synthpanel` unchanged).
+- Pre-launch audit verdict: READY-TO-FLIP (see `docs/release-audit-2026-04-15.md`).
+
+### Documentation
+- README badges: PyPI version, CI status, MIT license, Python versions.
+- README links updated to canonical Pascal-case repo name.
+- CHANGELOG backfilled with 0.5/0.6/0.7 entries.
+- `docs/stability.md` documents `lookup_pricing_by_provider` as part of public surface.
+
+### Internal
+- Removed Gas Town agent-internal config from public repo.
+- Reconciled conflicting CODEOWNERS file.
+
 ## [0.8.0] - 2026-04-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.8.0"
+version = "0.9.0"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` version 0.8.0 → 0.9.0
- Add CHANGELOG `## [0.9.0] - 2026-04-15` section documenting the public-launch milestone
- Apply `semver:minor` so Auto Semver Tag → Publish to PyPI fires on merge

## Why
First release after the repo went public and was renamed `synth-panel` → `SynthPanel`. Pre-launch audit was READY-TO-FLIP (PR #132). This release exercises the rename-survival of the PyPI Trusted Publisher binding.

## Test plan
- [x] `pytest tests/` — 922 passed, coverage 86.87% (≥80% threshold)
- [x] `pyproject.toml` parses; `version` field = `"0.9.0"`
- [ ] Post-merge: Auto Semver Tag cuts `v0.9.0`
- [ ] Post-merge: Publish to PyPI workflow runs (success or known trusted-publisher rebind needed)
- [ ] `pip install synthpanel==0.9.0` resolves from clean venv
- [ ] `pip show synthpanel | grep Version` returns `0.9.0`

## Risk
Trusted Publisher binding may require rebinding to point at `DataViking-Tech/SynthPanel`. If publish fails, founder rebinds at https://pypi.org/manage/project/synthpanel/settings/publishing/ and re-triggers via workflow_dispatch — tag stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)