### PR TITLE
chore(security): disable patch automerge in renovate.json (sp-cjq)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "packageRules": [
-    { "matchUpdateTypes": ["patch"], "automerge": true },
+    { "matchUpdateTypes": ["patch"], "automerge": false },
     {
       "matchUpdateTypes": ["minor"],
       "groupName": "minor deps",


### PR DESCRIPTION
## Summary
- Sets `automerge: false` for patch updates in renovate.json
- Defense-in-depth: ensures every Renovate PR receives human review regardless of branch-protection state

## Why
Per sp-273 audit follow-up #7. Combined with current branch protection (`required_approving_review_count=0`), the previous `automerge: true` for patches meant a malicious upstream patch release could land with zero human review. Even after branch-protection hardening lands, this defense-in-depth fix removes the implicit trust assumption.

## Test plan
- [x] JSON syntax valid (`python3 -c "import json; json.load(open('renovate.json'))"`)
- [x] Diff confirmed minimal (single-line change to one rule)
- [ ] CI green (lint/format/tests)

Closes sp-cjq.