### PR TITLE
ci(security): add Dependency Review + CodeQL workflows (sp-hx3)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly Monday 06:17 UTC — off-peak, off-the-hour to avoid runner contention.
+    - cron: "17 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@0e9f55954318745b37b7933c693bc093f7336125 # v4.35.1
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary

Closes audit follow-up #5 from sp-273 (external-contributor safety review). Adds two scanners that run on every PR to `main`:

- **`dependency-review.yml`** — `actions/dependency-review-action@v4.9.0`, fails the PR when a new dep introduces a known-vuln (`severity >= high`).
- **`codeql.yml`** — `github/codeql-action@v4.35.1` with `python` + `actions` language matrix, `security-extended` query suite. Runs on push, pull_request, and a weekly Monday cron (06:17 UTC, off-peak / off-the-hour).

## Why ship the workflow instead of waiting for default-setup

`gh api repos/DataViking-Tech/SynthPanel/code-scanning/default-setup` reports `state: not-configured`. Bead spec says: "If mdvi-dm0 cannot enable CodeQL default-setup, also add CodeQL workflow." Default-setup is fine if/when it's enabled later — at that point this workflow can be deleted.

All actions pinned to commit SHAs per audit recommendation #7.

## Test plan

- [ ] CI green (lint, typecheck, security, test 3.10/3.11/3.12, coverage)
- [ ] Dependency Review job appears in PR Checks tab and passes (no new deps changed in this PR)
- [ ] CodeQL Analyze (python) and Analyze (actions) jobs appear in PR Checks tab and complete
- [ ] Both workflows visible under the repo's Actions tab after merge

Bead: sp-hx3