### PR TITLE
chore(release): bump to 0.9.0 — public-launch milestone (sp-t9e)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-15
+
+### Public Launch
+- First release post-public-flip. Repo renamed from `synth-panel` to
+  `SynthPanel` (PyPI distribution name `synthpanel` unchanged).
+- Pre-launch audit verdict: READY-TO-FLIP (see `docs/release-audit-2026-04-15.md`).
+
+### Documentation
+- README badges: PyPI version, CI status, MIT license, Python versions.
+- README links updated to canonical Pascal-case repo name.
+- CHANGELOG backfilled with 0.5/0.6/0.7 entries.
+- `docs/stability.md` documents `lookup_pricing_by_provider` as part of public surface.
+
+### Internal
+- Removed Gas Town agent-internal config from public repo.
+- Reconciled conflicting CODEOWNERS file.
+
 ## [0.8.0] - 2026-04-14
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.8.0"
+version = "0.9.0"
 description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
First release post-public-flip. Repo renamed `synth-panel` → `SynthPanel`. Pre-launch audit verdict: READY-TO-FLIP.

- Bump `pyproject.toml` 0.8.x → 0.9.0
- CHANGELOG entry

Triggers Auto Semver Tag → Publish to PyPI workflow with semver:minor.

Closes sp-t9e.

## Test plan
- [x] `pyproject.toml` version string valid
- [ ] CI green on required checks
- [ ] Auto-tag + PyPI publish workflow fires post-merge