### PR TITLE
feat(site): synthpanel.dev landing page for Cloudflare Pages (sp-p3g)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python versions](https://img.shields.io/pypi/pyversions/synthpanel.svg)](https://pypi.org/project/synthpanel/)
 
+Site: <https://synthpanel.dev> · Benchmark: <https://synthbench.org>
+
 Open-source synthetic focus groups. Any LLM. Your terminal or your agent's tool call.
 
 Define personas in YAML. Define your research instrument in YAML. Run against any LLM — from your terminal, from a pipeline, or from an AI agent's MCP tool call. Get structured, reproducible output with full cost transparency.

--- a/docs/cloudflare-pages-setup.md
+++ b/docs/cloudflare-pages-setup.md
@@ -1,0 +1,70 @@
+# Cloudflare Pages — synthpanel.dev
+
+Operational runbook for the static landing site served at <https://synthpanel.dev>.
+
+## Source
+
+- Files live in [`site/`](../site/) at the repo root.
+- Pure static HTML; Tailwind is loaded from `cdn.tailwindcss.com`. **No build
+  step is required.**
+- `site/_headers` ships the security header set (CSP, HSTS, frame deny, etc.).
+  Cloudflare Pages applies these automatically for any path matched by the
+  `/*` rule.
+
+## Cloudflare Pages project (one-time setup)
+
+Done once by a maintainer with Cloudflare dashboard access. The polecat
+workflow cannot perform these steps because they require interactive auth /
+domain ownership confirmation.
+
+1. **Create the project** (Pages → Create → Connect to Git)
+   - Project name: `synthpanel`
+   - Production branch: `main`
+   - Repository: `DataViking-Tech/SynthPanel`
+2. **Build configuration**
+   - Framework preset: `None`
+   - Build command: *(leave empty — pure static)*
+   - Build output directory: `site`
+   - Root directory: *(leave empty)*
+3. **Environment variables**: none required.
+4. **Custom domain**
+   - Pages project → Custom domains → `synthpanel.dev`
+   - Cloudflare auto-creates the proxied CNAME on the synthpanel.dev zone.
+   - Confirm orange-cloud (proxied) and SSL/TLS mode = Full (strict).
+5. **Verification**
+   ```bash
+   curl -sI https://synthpanel.dev/ | head -5
+   #   HTTP/2 200
+   #   content-type: text/html; charset=utf-8
+   #   content-security-policy: default-src 'self'; ...
+   ```
+
+After the initial setup, every push to `main` redeploys automatically.
+
+## Local preview
+
+```bash
+# from repo root
+python3 -m http.server --directory site 8080
+open http://localhost:8080/
+```
+
+There is no test suite for the site — visual smoke check only.
+
+## Editing checklist
+
+When you change `site/index.html`:
+
+- Keep the install command (`pip install synthpanel`) discoverable above the
+  fold. Discoverability of the install command is the page's main job.
+- Keep the SynthBench cross-link present. The bead authoring this site
+  (sp-p3g) made the cross-link an explicit acceptance criterion.
+- If you bump Tailwind to the production build, drop the
+  `cdn.tailwindcss.com` entry from `site/_headers` CSP `script-src`.
+
+## Why a separate site (vs. README only)
+
+GitHub renders the README well for developers but isn't a domain users can
+land on after seeing the project mentioned. `synthpanel.dev` exists so
+that "synthpanel" the brand has a stable address that long-outlives any
+single repo host.

--- a/site/_headers
+++ b/site/_headers
@@ -1,0 +1,7 @@
+/*
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(), microphone=(), camera=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,272 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>synthpanel — Run synthetic focus groups with any LLM</title>
+    <meta
+      name="description"
+      content="Open-source synthetic focus groups. Define personas in YAML, run them against any LLM (Claude, GPT, Gemini, Grok, local), and get structured, reproducible output with full cost transparency."
+    />
+    <link rel="canonical" href="https://synthpanel.dev/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="synthpanel" />
+    <meta
+      property="og:description"
+      content="Run synthetic focus groups with any LLM. Pip-install, define personas in YAML, get structured output."
+    />
+    <meta property="og:url" content="https://synthpanel.dev/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="synthpanel" />
+    <meta
+      name="twitter:description"
+      content="Run synthetic focus groups with any LLM."
+    />
+
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' fill='%230f172a'/%3E%3Ctext x='50%25' y='54%25' text-anchor='middle' font-family='ui-monospace,monospace' font-size='34' font-weight='700' fill='%2334d399'%3Esp%3C/text%3E%3C/svg%3E"
+    />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              mono: [
+                "ui-monospace",
+                "SFMono-Regular",
+                "Menlo",
+                "Monaco",
+                "Consolas",
+                "monospace",
+              ],
+            },
+          },
+        },
+      };
+    </script>
+
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        background:
+          radial-gradient(
+            ellipse at top,
+            rgba(52, 211, 153, 0.08),
+            transparent 60%
+          ),
+          #0f172a;
+      }
+      .copy-btn:active {
+        transform: translateY(1px);
+      }
+    </style>
+  </head>
+
+  <body class="text-slate-200 antialiased">
+    <main class="mx-auto max-w-4xl px-6 pb-24 pt-16 sm:pt-24">
+      <!-- Hero -->
+      <section class="text-center">
+        <p
+          class="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-3 py-1 text-xs font-medium text-emerald-300"
+        >
+          <span class="h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
+          v0.9.0 — public beta
+        </p>
+        <h1
+          class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-5xl font-bold tracking-tight text-transparent sm:text-6xl"
+        >
+          synthpanel
+        </h1>
+        <p class="mx-auto mt-5 max-w-2xl text-lg text-slate-300 sm:text-xl">
+          Run synthetic focus groups with any LLM.
+        </p>
+        <p class="mx-auto mt-3 max-w-2xl text-base text-slate-400">
+          Define personas in YAML. Define your research instrument in YAML. Run
+          against Claude, GPT, Gemini, Grok, or any OpenAI-compatible model —
+          from your terminal, a pipeline, or an AI agent's MCP tool call.
+        </p>
+
+        <!-- Install command -->
+        <div class="mx-auto mt-8 max-w-xl">
+          <div
+            class="group relative flex items-center justify-between rounded-lg border border-slate-700 bg-slate-900/80 px-4 py-3 text-left font-mono text-sm shadow-lg shadow-emerald-500/5"
+          >
+            <span class="select-all">
+              <span class="text-slate-500">$</span>
+              <span class="text-emerald-400">pip install</span>
+              <span class="text-slate-200">synthpanel</span>
+            </span>
+            <button
+              type="button"
+              class="copy-btn ml-3 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-400 transition hover:border-emerald-400/50 hover:text-emerald-300"
+              data-copy="pip install synthpanel"
+              aria-label="Copy install command"
+            >
+              Copy
+            </button>
+          </div>
+          <p class="mt-2 text-xs text-slate-500">
+            Add <code class="text-slate-400">[mcp]</code> for
+            Claude&nbsp;Code&nbsp;/&nbsp;Cursor&nbsp;/&nbsp;Windsurf agent
+            integration.
+          </p>
+        </div>
+
+        <!-- Primary CTAs -->
+        <div
+          class="mt-8 flex flex-wrap items-center justify-center gap-3 text-sm"
+        >
+          <a
+            href="https://github.com/DataViking-Tech/SynthPanel"
+            class="inline-flex items-center gap-2 rounded-md bg-emerald-500 px-4 py-2 font-medium text-slate-950 transition hover:bg-emerald-400"
+            >GitHub repo →</a
+          >
+          <a
+            href="https://pypi.org/project/synthpanel/"
+            class="inline-flex items-center gap-2 rounded-md border border-slate-700 px-4 py-2 font-medium text-slate-200 transition hover:border-slate-500 hover:text-white"
+            >PyPI package</a
+          >
+        </div>
+      </section>
+
+      <!-- Quick-start snippet -->
+      <section class="mt-20">
+        <h2 class="mb-4 text-sm font-semibold uppercase tracking-wider text-slate-400">
+          Quick start
+        </h2>
+        <div
+          class="overflow-x-auto rounded-lg border border-slate-800 bg-slate-950/70 p-5 font-mono text-sm leading-relaxed shadow-xl"
+        >
+<pre class="text-slate-300"><span class="text-slate-500"># 1. install</span>
+<span class="text-emerald-400">pip install</span> synthpanel
+
+<span class="text-slate-500"># 2. set a key for any provider you have</span>
+<span class="text-emerald-400">export</span> ANTHROPIC_API_KEY=<span class="text-amber-300">"sk-..."</span>
+
+<span class="text-slate-500"># 3. one-shot prompt against the default model</span>
+synthpanel prompt <span class="text-amber-300">"What do you think of the name Traitprint?"</span>
+
+<span class="text-slate-500"># 4. run a full panel</span>
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/survey.yaml</pre>
+        </div>
+      </section>
+
+      <!-- Cards -->
+      <section class="mt-20 grid gap-4 sm:grid-cols-3">
+        <a
+          href="https://pypi.org/project/synthpanel/"
+          class="group rounded-lg border border-slate-800 bg-slate-900/40 p-5 transition hover:border-emerald-400/40 hover:bg-slate-900/70"
+        >
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold text-white">PyPI</h3>
+            <span class="text-slate-500 transition group-hover:text-emerald-300">→</span>
+          </div>
+          <p class="mt-2 text-sm text-slate-400">
+            Pip-installable package. <code class="text-slate-300">pip install synthpanel</code>.
+          </p>
+        </a>
+
+        <a
+          href="https://github.com/DataViking-Tech/SynthPanel"
+          class="group rounded-lg border border-slate-800 bg-slate-900/40 p-5 transition hover:border-emerald-400/40 hover:bg-slate-900/70"
+        >
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold text-white">GitHub</h3>
+            <span class="text-slate-500 transition group-hover:text-emerald-300">→</span>
+          </div>
+          <p class="mt-2 text-sm text-slate-400">
+            Source, issues, and roadmap. MIT-licensed.
+          </p>
+        </a>
+
+        <a
+          href="https://synthbench.org"
+          class="group rounded-lg border border-slate-800 bg-slate-900/40 p-5 transition hover:border-emerald-400/40 hover:bg-slate-900/70"
+        >
+          <div class="flex items-center justify-between">
+            <h3 class="font-semibold text-white">SynthBench</h3>
+            <span class="text-slate-500 transition group-hover:text-emerald-300">→</span>
+          </div>
+          <p class="mt-2 text-sm text-slate-400">
+            Open benchmark for synthetic survey quality. See the leaderboard at
+            <span class="text-emerald-300">synthbench.org</span>.
+          </p>
+        </a>
+      </section>
+
+      <!-- SynthBench callout -->
+      <section
+        class="mt-12 rounded-lg border border-emerald-400/20 bg-emerald-400/5 p-5 text-sm text-slate-300"
+      >
+        <p>
+          <span class="font-semibold text-emerald-300">Powered the
+            <a
+              class="underline decoration-emerald-400/60 underline-offset-2 hover:text-emerald-200"
+              href="https://synthbench.org"
+              >SynthBench</a
+            >
+            public benchmark</span
+          >
+          — independent, open evaluation of synthetic-respondent quality.
+          Ensemble blending of 3 models hits SPS 0.90 (90% human parity) on the
+          current
+          <a
+            href="https://synthbench.org"
+            class="underline decoration-emerald-400/60 underline-offset-2 hover:text-emerald-200"
+            >leaderboard</a
+          >.
+        </p>
+      </section>
+
+      <!-- Footer -->
+      <footer
+        class="mt-20 border-t border-slate-800 pt-6 text-xs text-slate-500"
+      >
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <span>
+            MIT-licensed · v0.9.0 ·
+            <a
+              href="https://github.com/DataViking-Tech/SynthPanel"
+              class="hover:text-slate-300"
+              >DataViking-Tech/SynthPanel</a
+            >
+          </span>
+          <span>
+            Built by
+            <a href="https://dataviking.tech" class="hover:text-slate-300"
+              >DataViking</a
+            >
+          </span>
+        </div>
+      </footer>
+    </main>
+
+    <script>
+      document.querySelectorAll(".copy-btn").forEach((btn) => {
+        btn.addEventListener("click", async () => {
+          const text = btn.getAttribute("data-copy") || "";
+          try {
+            await navigator.clipboard.writeText(text);
+            const original = btn.textContent;
+            btn.textContent = "Copied";
+            btn.classList.add("text-emerald-300", "border-emerald-400/50");
+            setTimeout(() => {
+              btn.textContent = original;
+              btn.classList.remove("text-emerald-300", "border-emerald-400/50");
+            }, 1500);
+          } catch (err) {
+            // Clipboard API unavailable — leave as no-op; users can still select-all.
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://synthpanel.dev/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://synthpanel.dev/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
Landing page for synthpanel.dev, deployable to Cloudflare Pages.

- `site/index.html` — single-page static landing with install command, quick-start, PyPI/GitHub/SynthBench cards, SynthBench cross-link. Pure HTML + Tailwind via CDN (no build step).
- `site/_headers` — hardened security headers (CSP, HSTS, X-Frame-Options, Permissions-Policy)
- `site/robots.txt` + `site/sitemap.xml`
- `docs/cloudflare-pages-setup.md` — one-time maintainer dashboard-wiring guide (Pages project, custom domain, DNS)
- README gains `Site: synthpanel.dev · Benchmark: synthbench.org` line under badges

Closes sp-p3g.

## Maintainer action required (post-merge)
Interactive Cloudflare dashboard step — see `docs/cloudflare-pages-setup.md`.

## Test plan
- [x] HTML renders standalone in browser
- [x] Headers file parses per Cloudflare Pages spec
- [ ] CI green on required checks