### PR TITLE
chore(metadata): update project.urls to DataViking-Tech/SynthPanel (sp-7c8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/DataViking-Tech/synth-panel"
-Repository = "https://github.com/DataViking-Tech/synth-panel"
-Issues = "https://github.com/DataViking-Tech/synth-panel/issues"
-Changelog = "https://github.com/DataViking-Tech/synth-panel/releases"
+Homepage = "https://github.com/DataViking-Tech/SynthPanel"
+Repository = "https://github.com/DataViking-Tech/SynthPanel"
+Issues = "https://github.com/DataViking-Tech/SynthPanel/issues"
+Changelog = "https://github.com/DataViking-Tech/SynthPanel/releases"
 
 [project.optional-dependencies]
 mcp = [


### PR DESCRIPTION
## Summary
PyPI metadata still advertised the pre-rename path `DataViking-Tech/synth-panel`. GitHub's redirect masked the issue functionally, but the PyPI project page visibly displayed the old name.

Updates all four `project.urls` entries in `pyproject.toml`: Homepage, Repository, Issues, Changelog — so corrected metadata flows into PyPI on the next publish.

4 lines changed.

Closes sp-7c8.

## Test plan
- [x] Local `pyproject.toml` validates
- [ ] CI green on required checks
- [ ] Post-publish: PyPI project page reflects new URLs