### PR TITLE
chore(metadata): fix PyPI metadata — URLs, keywords, classifiers, MCP badge (sp-ege.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/DataViking-Tech/SynthPanel/actions/workflows/ci.yml/badge.svg)](https://github.com/DataViking-Tech/SynthPanel/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python versions](https://img.shields.io/pypi/pyversions/synthpanel.svg)](https://pypi.org/project/synthpanel/)
+[![MCP](https://img.shields.io/badge/MCP-enabled-brightgreen.svg)](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md)
 
 Site: <https://synthpanel.dev> · Benchmark: <https://synthbench.org>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,26 @@
 [project]
 name = "synthpanel"
-version = "0.9.0"
-description = "Run synthetic focus groups and user research panels using AI personas. CLI tool, Python library, any LLM."
+version = "0.9.1"
+description = "Run synthetic focus groups using AI personas, with an MCP server for Claude Code / Cursor / Windsurf. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}
 authors = [{name = "DataViking", email = "openclaw@dataviking.tech"}]
 readme = "README.md"
-keywords = ["llm", "research", "focus-group", "synthetic", "personas", "user-research", "ai"]
+keywords = ["llm", "research", "focus-group", "synthetic", "personas", "user-research", "ai", "mcp", "model-context-protocol", "agent", "claude", "claude-code", "cursor", "windsurf", "survey-research", "synthetic-respondents", "market-research"]
 classifiers = [
     "Development Status :: 4 - Beta",
+    "Environment :: Console",
     "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
     "httpx>=0.27",
@@ -23,10 +28,12 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/DataViking-Tech/SynthPanel"
+Homepage = "https://synthpanel.dev"
+Documentation = "https://synthpanel.dev"
 Repository = "https://github.com/DataViking-Tech/SynthPanel"
 Issues = "https://github.com/DataViking-Tech/SynthPanel/issues"
 Changelog = "https://github.com/DataViking-Tech/SynthPanel/releases"
+"MCP Reference" = "https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md"
 
 [project.optional-dependencies]
 mcp = [


### PR DESCRIPTION
## Summary
PyPI metadata polish for public launch visibility.

- Fix project URLs, add keywords, update classifiers in `pyproject.toml`
- Add MCP badge to `README.md`

2 files: `pyproject.toml` (+12, -4), `README.md` (+1).

Closes sp-ege.3.

## Test plan
- [x] `pyproject.toml` validates
- [ ] CI green on required checks