### PR TITLE
docs(readme): add 'Use with <editor>' section with per-editor MCP configs (sp-ege.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,127 @@ Add to your editor's MCP config (Claude Code, Cursor, Windsurf):
 
 `run_panel` accepts an inline `instrument` dict or an `instrument_pack` name for v3 branching runs. `extend_panel` appends one ad-hoc round — it is **not** a re-entry into the v3 DAG. See [docs/mcp.md](docs/mcp.md) for full tool schemas, resources, and prompt templates.
 
+## Use with Claude Code / Cursor / Windsurf / Zed
+
+Copy the JSON snippet for your editor into the listed config file, set
+your API key, and restart the editor. `synthpanel mcp-serve` is launched
+on demand over stdio — no long-running process to manage.
+
+<details>
+<summary><b>Claude Code</b></summary>
+
+Add to `.mcp.json` at your project root (or `~/.claude.json` for all projects):
+
+```json
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Or install the bundled plugin (adds a `/focus-group` skill):
+
+```
+/plugin install synthpanel
+```
+
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
+
+Add to `.cursor/mcp.json` at your project root (or `~/.cursor/mcp.json` for all projects):
+
+```json
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Windsurf</b></summary>
+
+Add to `~/.codeium/windsurf/mcp_config.json` (or open
+**Settings → Windsurf Settings → MCP Servers → View Raw Config**):
+
+```json
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Zed</b></summary>
+
+Zed uses `context_servers` (not `mcpServers`). Add to `~/.config/zed/settings.json`:
+
+```json
+{
+  "context_servers": {
+    "synth_panel": {
+      "source": "custom",
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><b>Claude Desktop</b></summary>
+
+Open **Settings → Developer → Edit Config** (or edit the file directly):
+
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+</details>
+
+> **Using a non-Anthropic provider?** Swap `ANTHROPIC_API_KEY` for
+> `OPENAI_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`, or
+> `OPENROUTER_API_KEY` — see [LLM Provider Support](#llm-provider-support).
+> The `synthpanel` binary must be on the editor's `PATH`; if you installed
+> into a virtualenv, point `command` at its absolute path
+> (e.g. `/path/to/.venv/bin/synthpanel`).
+
 ## What You Get
 
 ```


### PR DESCRIPTION
## Summary

Adds a **Use with Claude Code / Cursor / Windsurf / Zed** section to the README with a collapsible `<details>` block per editor. Each block contains copy-pasteable `mcpServers` JSON and the exact config file path.

Editors covered:
- **Claude Code** — `.mcp.json` (project) or `~/.claude.json` (global), plus `/plugin install synthpanel`
- **Cursor** — `.cursor/mcp.json`
- **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
- **Zed** — `~/.config/zed/settings.json` using `context_servers` with `source: custom` (Zed's schema, not `mcpServers`)
- **Claude Desktop** — macOS + Windows config paths

Closing note points at **LLM Provider Support** for non-Anthropic API key swaps and warns about `PATH` / virtualenv gotchas.

Placed immediately after the **MCP Server (Agent Integration)** section so discovery flows *what is this → how do I wire it into my editor*.

Closes sp-ege.4.

Supersedes #147, which was closed due to a merge conflict after sp-ege.2 (#144) reorganized the README. This is a clean re-slinging against current main.

## Test plan

- [x] README renders cleanly — all five `<details>` blocks parse, JSON snippets are valid, and the superscript note at the end resolves to the existing `#llm-provider-support` anchor
- [x] Zed block uses `context_servers` (not `mcpServers`) per the Zed MCP spec
- [ ] CI green on required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)