### PR TITLE
feat(sdk): public Python SDK convenience layer (sp-2cw.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,53 @@ synthpanel panel run \
   --instrument examples/survey.yaml
 ```
 
+## Use as a Python Library
+
+Everything the CLI and MCP server can do is also callable from Python.
+No subprocess, no extra install — just import and go.
+
+```python
+from synth_panel import quick_poll, run_panel, run_prompt
+
+# One-shot LLM call
+reply = run_prompt("What makes a name feel trustworthy?")
+print(reply.response, reply.cost)
+
+# Ask a bundled persona pack a single question
+poll = quick_poll(
+    "Which pricing tier name feels most premium: Core, Plus, or Pro?",
+    pack_id="general-consumer",
+)
+print(poll.synthesis["recommendation"])
+
+# Run a full branching instrument against a bundled pack
+panel = run_panel(
+    pack_id="general-consumer",
+    instrument_pack="pricing-discovery",
+)
+print(panel.path)         # e.g. ["discovery", "probe_pricing", "validation"]
+print(panel.total_cost)
+```
+
+The package root exposes eight functions plus three typed return
+dataclasses — `PromptResult`, `PollResult`, `PanelResult`. Every
+result is dict-compatible (`result["model"]`) so code that used to
+consume the MCP JSON payload works unchanged.
+
+| Function | What it does |
+|----------|--------------|
+| `run_prompt(prompt, *, model=...)` | Single LLM call — no personas |
+| `quick_poll(question, pack_id=...)` | One question across a panel + synthesis |
+| `run_panel(pack_id=..., instrument_pack=...)` | Full branching panel run |
+| `extend_panel(result_id, questions)` | Append an ad-hoc follow-up round |
+| `list_personas()` / `list_instruments()` | Discover installed packs |
+| `list_panel_results()` / `get_panel_result(id)` | Reload saved results |
+
+Use this path when subprocess overhead hurts (Jupyter, serverless, CI)
+or when you want to wrap SynthPanel in a LangChain / LlamaIndex tool
+in three lines. See [`examples/sdk_usage.py`](examples/sdk_usage.py)
+for a runnable end-to-end walkthrough.
+
 ## MCP Server (Agent Integration)
 
 synthpanel ships an MCP server so AI agents can run synthetic focus groups as tool calls.

--- a/examples/sdk_usage.py
+++ b/examples/sdk_usage.py
@@ -1,0 +1,114 @@
+"""End-to-end demo of the synthpanel Python SDK.
+
+Run with::
+
+    export ANTHROPIC_API_KEY=sk-...
+    python examples/sdk_usage.py
+
+The script walks through the eight public entry points in order, using
+only the arguments the average caller needs. Each step prints a short
+summary so you can confirm the API surface without reading source.
+
+Every call here also works identically from inside a Jupyter notebook —
+``from synth_panel import quick_poll`` and you're off.
+"""
+
+from __future__ import annotations
+
+from synth_panel import (
+    extend_panel,
+    get_panel_result,
+    list_instruments,
+    list_panel_results,
+    list_personas,
+    quick_poll,
+    run_panel,
+    run_prompt,
+)
+
+
+def _divider(title: str) -> None:
+    print()
+    print("=" * 60)
+    print(title)
+    print("=" * 60)
+
+
+def main() -> None:
+    # 1) run_prompt — the simplest possible call.
+    _divider("1. run_prompt — one-shot LLM call")
+    prompt = run_prompt(
+        "In one sentence, what makes a synthetic focus group useful?",
+        model="haiku",
+    )
+    print(f"model: {prompt.model}")
+    print(f"cost:  {prompt.cost}")
+    print(f"reply: {prompt.response}")
+
+    # 2) list_personas — see the bundled persona packs.
+    _divider("2. list_personas — available persona packs")
+    packs = list_personas()
+    for pack in packs[:5]:
+        kind = "bundled" if pack.get("builtin") else "user"
+        print(f"  [{kind}] {pack['id']:<25} {pack['persona_count']} personas")
+
+    # 3) list_instruments — see the bundled branching instruments.
+    _divider("3. list_instruments — available instrument packs")
+    instruments = list_instruments()
+    for inst in instruments[:5]:
+        print(f"  [{inst['source']}] {inst['id']:<30} {inst['description'][:60]}")
+
+    # 4) quick_poll — a single question across a persona pack.
+    _divider("4. quick_poll — single question, bundled personas")
+    poll = quick_poll(
+        "What's the most confusing thing about B2B SaaS pricing pages?",
+        pack_id="general-consumer",
+        model="haiku",
+        synthesis=True,
+    )
+    print(f"result_id:   {poll.result_id}")
+    print(f"panelists:   {len(poll.responses)}")
+    print(f"total cost:  {poll.total_cost}")
+    if poll.synthesis:
+        rec = poll.synthesis.get("recommendation", "")
+        print(f"recommendation (first 120 chars): {rec[:120]}")
+
+    # 5) run_panel — full branching instrument against a bundled pack.
+    _divider("5. run_panel — v3 branching instrument")
+    panel = run_panel(
+        pack_id="general-consumer",
+        instrument_pack="pricing-discovery",
+        model="haiku",
+    )
+    print(f"result_id:       {panel.result_id}")
+    print(f"personas:        {panel.persona_count}")
+    print(f"rounds executed: {[r['name'] for r in panel.rounds]}")
+    print(f"routing path:    {[step['round'] for step in panel.path]}")
+    print(f"total cost:      {panel.total_cost}")
+
+    # 6) extend_panel — append a single ad-hoc follow-up round.
+    _divider("6. extend_panel — follow-up round")
+    extended = extend_panel(
+        result_id=panel.result_id,
+        questions="What single change would make you trust this brand more?",
+        model="haiku",
+    )
+    print(f"rounds now: {[r['name'] for r in extended.rounds]}")
+    print(f"path now:   {[step['round'] for step in extended.path]}")
+
+    # 7) list_panel_results — see what's on disk.
+    _divider("7. list_panel_results — saved results")
+    saved = list_panel_results()
+    for entry in saved[:3]:
+        print(f"  {entry['id']:<45} model={entry.get('model')} n={entry.get('persona_count')}")
+
+    # 8) get_panel_result — reload a specific result by id.
+    _divider("8. get_panel_result — reload a saved result")
+    reloaded = get_panel_result(panel.result_id)
+    print(f"reloaded {reloaded.result_id}")
+    print(f"question_count: {reloaded.question_count}")
+    print(f"terminal round: {reloaded.terminal_round}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_panel/__init__.py
+++ b/src/synth_panel/__init__.py
@@ -1,4 +1,30 @@
+"""synthpanel — synthetic focus groups for AI personas.
+
+The package root re-exports the public Python SDK so callers can write::
+
+    from synth_panel import quick_poll, run_panel, run_prompt
+
+See :mod:`synth_panel.sdk` for full API documentation. The CLI lives in
+:mod:`synth_panel.main` (entry point ``synthpanel``); the MCP server lives
+in :mod:`synth_panel.mcp.server` and requires the optional ``[mcp]``
+extra — the SDK itself works on a plain ``pip install synthpanel``.
+"""
+
 from __future__ import annotations
+
+from synth_panel.sdk import (
+    PanelResult,
+    PollResult,
+    PromptResult,
+    extend_panel,
+    get_panel_result,
+    list_instruments,
+    list_panel_results,
+    list_personas,
+    quick_poll,
+    run_panel,
+    run_prompt,
+)
 
 try:
     from importlib.metadata import version as _pkg_version
@@ -6,3 +32,19 @@ try:
     __version__ = _pkg_version("synthpanel")
 except Exception:
     __version__ = "0.0.0-dev"
+
+
+__all__ = [
+    "PanelResult",
+    "PollResult",
+    "PromptResult",
+    "__version__",
+    "extend_panel",
+    "get_panel_result",
+    "list_instruments",
+    "list_panel_results",
+    "list_personas",
+    "quick_poll",
+    "run_panel",
+    "run_prompt",
+]

--- a/src/synth_panel/_runners.py
+++ b/src/synth_panel/_runners.py
@@ -1,0 +1,369 @@
+"""Shared synchronous panel runners.
+
+Factored out of ``synth_panel.mcp.server`` so that both the MCP server
+handlers and the public Python SDK (``synth_panel.sdk``) can drive the
+same underlying logic without one depending on the other — the MCP
+server requires the optional ``mcp`` extra, whereas the SDK has to
+work in a plain ``pip install synthpanel`` environment.
+
+Nothing here imports the ``mcp`` library.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from typing import Any
+
+from synth_panel.cost import ZERO_USAGE, estimate_cost, lookup_pricing
+from synth_panel.cost import TokenUsage as CostTokenUsage
+from synth_panel.instrument import Instrument
+from synth_panel.llm.client import LLMClient
+from synth_panel.orchestrator import (
+    MultiRoundResult,
+    PanelistResult,
+    run_multi_round_panel,
+    run_panel_parallel,
+)
+from synth_panel.perturbation import generate_panel_variants
+from synth_panel.prompts import build_question_prompt, persona_system_prompt
+from synth_panel.stats import robustness_score
+from synth_panel.synthesis import synthesize_panel
+
+logger = logging.getLogger(__name__)
+
+# Caps mirrored from the MCP server — the SDK inherits the same guardrails.
+MAX_PERSONAS = 100
+MAX_QUESTIONS = 50
+
+# Per-panelist timeout budget used by async wrappers (seconds).
+PANELIST_TIMEOUT = 30
+
+
+# Built-in extraction schema registry — keyed by short name.
+EXTRACT_SCHEMA_REGISTRY: dict[str, dict[str, Any]] = {
+    "sentiment": {
+        "type": "object",
+        "properties": {
+            "sentiment": {
+                "type": "string",
+                "enum": ["positive", "negative", "neutral", "mixed"],
+                "description": "Overall sentiment of the response.",
+            },
+            "confidence": {
+                "type": "number",
+                "minimum": 0.0,
+                "maximum": 1.0,
+                "description": "Confidence score (0-1) for the sentiment classification.",
+            },
+        },
+        "required": ["sentiment", "confidence"],
+    },
+    "themes": {
+        "type": "object",
+        "properties": {
+            "themes": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Key themes or topics mentioned in the response.",
+            },
+            "primary_theme": {
+                "type": "string",
+                "description": "The single most dominant theme.",
+            },
+        },
+        "required": ["themes", "primary_theme"],
+    },
+    "rating": {
+        "type": "object",
+        "properties": {
+            "rating": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "description": "Numeric rating (1-10) implied by the response.",
+            },
+            "explanation": {
+                "type": "string",
+                "description": "Brief rationale for the assigned rating.",
+            },
+        },
+        "required": ["rating", "explanation"],
+    },
+}
+
+
+def resolve_extract_schema(
+    value: str | dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Resolve extract_schema: pass dicts through, look up strings in the registry."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        if value not in EXTRACT_SCHEMA_REGISTRY:
+            names = ", ".join(sorted(EXTRACT_SCHEMA_REGISTRY))
+            raise ValueError(
+                f"Unknown extract_schema name {value!r}. Available: {names}. Or pass an inline JSON Schema dict."
+            )
+        return EXTRACT_SCHEMA_REGISTRY[value]
+    raise TypeError(f"extract_schema must be a string or dict, got {type(value).__name__}")
+
+
+def format_panelist_result(pr: PanelistResult, model: str) -> dict[str, Any]:
+    """Render a :class:`PanelistResult` into the serialisable dict shape callers expect."""
+    pr_model = pr.model or model
+    pricing, _ = lookup_pricing(pr_model)
+    persona_cost = estimate_cost(pr.usage, pricing)
+    rd: dict[str, Any] = {
+        "persona": pr.persona_name,
+        "responses": pr.responses,
+        "usage": pr.usage.to_dict(),
+        "cost": persona_cost.format_usd(),
+        "error": pr.error,
+    }
+    if pr.model:
+        rd["model"] = pr.model
+    return rd
+
+
+def compute_variant_data(
+    result_dicts: list[dict[str, Any]],
+    variant_names: set[str],
+    variant_mapping: dict[str, str],
+    variant_count: int,
+    questions: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Compute robustness scores from base + variant panel results."""
+    # Separate base and variant results
+    base_results = [r for r in result_dicts if r["persona"] not in variant_names]
+    variant_results = [r for r in result_dicts if r["persona"] in variant_names]
+
+    # Build per-question robustness scores
+    robustness_scores: list[dict[str, Any]] = []
+    per_persona_robustness: list[dict[str, Any]] = []
+    n_questions = len(questions)
+
+    for qi in range(n_questions):
+        # Group variant responses by source persona
+        variant_resps: dict[str, list[str]] = {}
+        for vr in variant_results:
+            source = variant_mapping.get(vr["persona"], "")
+            if not source:
+                continue
+            resps = vr.get("responses", [])
+            if qi < len(resps) and not resps[qi].get("error"):
+                variant_resps.setdefault(source, []).append(resps[qi].get("response", ""))
+
+        # Get base persona responses for this question
+        for br in base_results:
+            resps = br.get("responses", [])
+            if qi >= len(resps) or resps[qi].get("error"):
+                continue
+
+            base_response = resps[qi].get("response", "")
+            persona_name = br["persona"]
+            v_resps = variant_resps.get(persona_name, [])
+
+            if v_resps:
+                try:
+                    rs = robustness_score({persona_name: v_resps}, base_response)
+                    per_persona_robustness.append(
+                        {
+                            "persona": persona_name,
+                            "question_index": qi,
+                            "robustness": round(rs.per_persona.get(persona_name, 0.0), 4),
+                            "k_variants": len(v_resps),
+                            "finding_value": base_response,
+                            "interpretation": rs.interpretation,
+                        }
+                    )
+                except (ValueError, ZeroDivisionError):
+                    pass
+
+        # Overall robustness for this question across all base personas
+        if variant_resps:
+            base_responses_q = [
+                br["responses"][qi].get("response", "")
+                for br in base_results
+                if qi < len(br.get("responses", [])) and not br["responses"][qi].get("error")
+            ]
+            if base_responses_q:
+                most_common = Counter(base_responses_q).most_common(1)[0][0]
+                all_v: dict[str, list[str]] = {}
+                for name, resps_list in variant_resps.items():
+                    all_v[name] = resps_list
+                try:
+                    agg = robustness_score(all_v, most_common)
+                    robustness_scores.append(
+                        {
+                            "question_index": qi,
+                            "question_text": questions[qi].get("text", ""),
+                            "finding_value": most_common,
+                            "overall_robustness": round(agg.overall_robustness, 4),
+                            "interpretation": agg.interpretation,
+                        }
+                    )
+                except (ValueError, ZeroDivisionError):
+                    pass
+
+    return {
+        "variant_count": variant_count,
+        "robustness_scores": robustness_scores,
+        "per_persona_robustness": per_persona_robustness,
+    }
+
+
+def run_panel_sync(
+    client: LLMClient,
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    model: str,
+    response_schema: dict[str, Any] | None = None,
+    *,
+    synthesis: bool = True,
+    synthesis_model: str | None = None,
+    synthesis_prompt: str | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    persona_models: dict[str, str] | None = None,
+    extract_schema: dict[str, Any] | None = None,
+    synthesis_temperature: float | None = None,
+    variants: int = 0,
+) -> tuple[
+    list[PanelistResult],
+    list[dict[str, Any]],
+    CostTokenUsage,
+    Any,
+    dict[str, Any] | None,
+    dict[str, Any] | None,
+]:
+    """Run a single-round panel synchronously.
+
+    Returns ``(panelist_results, result_dicts, panelist_usage,
+    panelist_cost, synthesis_dict, variant_data)``. ``variant_data`` is
+    ``None`` when ``variants == 0``.
+    """
+    all_personas = list(personas)
+    variant_names: set[str] = set()
+    variant_mapping: dict[str, str] = {}
+    variant_count = 0
+
+    if variants > 0:
+        logger.info("Generating %d variants per persona", variants)
+        variant_sets = generate_panel_variants(personas, client, k=variants, model=model)
+        for vs in variant_sets:
+            for v in vs.variants:
+                all_personas.append(v.persona)
+                variant_names.add(v.variant_name)
+                variant_mapping[v.variant_name] = v.source_persona_name
+                variant_count += 1
+        logger.info("Running panel with %d base + %d variant personas", len(personas), variant_count)
+
+    panelist_results, _registry, _sessions = run_panel_parallel(
+        client=client,
+        personas=all_personas,
+        questions=questions,
+        model=model,
+        system_prompt_fn=persona_system_prompt,
+        question_prompt_fn=build_question_prompt,
+        response_schema=response_schema,
+        temperature=temperature,
+        top_p=top_p,
+        persona_models=persona_models,
+        extract_schema=extract_schema,
+    )
+
+    panelist_usage = ZERO_USAGE
+    result_dicts: list[dict[str, Any]] = []
+    for pr in panelist_results:
+        result_dicts.append(format_panelist_result(pr, model))
+        panelist_usage = panelist_usage + pr.usage
+
+    pricing, _ = lookup_pricing(model)
+    panelist_cost = estimate_cost(panelist_usage, pricing)
+
+    base_results = [pr for pr in panelist_results if pr.persona_name not in variant_names]
+    synthesis_dict: dict[str, Any] | None = None
+    if synthesis:
+        try:
+            synthesis_result = synthesize_panel(
+                client,
+                base_results,
+                questions,
+                model=synthesis_model,
+                panelist_model=model,
+                custom_prompt=synthesis_prompt,
+                panelist_cost=panelist_cost,
+                temperature=synthesis_temperature,
+            )
+            synthesis_dict = synthesis_result.to_dict()
+        except Exception:
+            logger.error("Synthesis failed (non-fatal)", exc_info=True)
+            synthesis_dict = {"synthesis_error": "Synthesis failed — see logs for details."}
+
+    variant_data: dict[str, Any] | None = None
+    if variants > 0 and variant_mapping:
+        variant_data = compute_variant_data(
+            result_dicts,
+            variant_names,
+            variant_mapping,
+            variant_count,
+            questions,
+        )
+
+    return panelist_results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data
+
+
+def run_multi_round_sync(
+    client: LLMClient,
+    personas: list[dict[str, Any]],
+    instrument: Instrument,
+    model: str,
+    response_schema: dict[str, Any] | None,
+    *,
+    synthesis: bool,
+    synthesis_model: str | None,
+    synthesis_prompt: str | None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    persona_models: dict[str, str] | None = None,
+    extract_schema: dict[str, Any] | None = None,
+    synthesis_temperature: float | None = None,
+) -> MultiRoundResult:
+    """Drive :func:`run_multi_round_panel` for v1/v2/v3 instruments."""
+
+    def _round_synth(
+        c: LLMClient,
+        panelist_results: list[PanelistResult],
+        questions: list[dict[str, Any]],
+        *,
+        model: str,
+    ):
+        return synthesize_panel(
+            c,
+            panelist_results,
+            questions,
+            model=synthesis_model,
+            panelist_model=model,
+            custom_prompt=synthesis_prompt,
+            temperature=synthesis_temperature,
+        )
+
+    final_fn = _round_synth if synthesis else None
+    return run_multi_round_panel(
+        client=client,
+        personas=personas,
+        instrument=instrument,
+        model=model,
+        system_prompt_fn=persona_system_prompt,
+        question_prompt_fn=build_question_prompt,
+        synthesize_round_fn=_round_synth if synthesis else (lambda *a, **kw: None),
+        synthesize_final_fn=final_fn,
+        response_schema=response_schema,
+        temperature=temperature,
+        top_p=top_p,
+        persona_models=persona_models,
+        extract_schema=extract_schema,
+    )

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -38,6 +38,27 @@ from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 
+from synth_panel._runners import (
+    EXTRACT_SCHEMA_REGISTRY,
+    MAX_PERSONAS,
+    MAX_QUESTIONS,
+    PANELIST_TIMEOUT,
+)
+from synth_panel._runners import (
+    compute_variant_data as _compute_variant_data,  # re-exported for back-compat
+)
+from synth_panel._runners import (
+    format_panelist_result as _format_panelist_result,
+)
+from synth_panel._runners import (
+    resolve_extract_schema as _resolve_extract_schema,
+)
+from synth_panel._runners import (
+    run_multi_round_sync as _run_multi_round_sync,
+)
+from synth_panel._runners import (
+    run_panel_sync as _run_panel_sync,
+)
 from synth_panel.cost import ZERO_USAGE, estimate_cost, lookup_pricing
 from synth_panel.cost import TokenUsage as CostTokenUsage
 from synth_panel.instrument import Instrument, parse_instrument
@@ -76,12 +97,9 @@ from synth_panel.metadata import PanelTimer, build_metadata
 from synth_panel.orchestrator import (
     MultiRoundResult,
     PanelistResult,
-    run_multi_round_panel,
     run_panel_parallel,
 )
-from synth_panel.perturbation import generate_panel_variants
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
-from synth_panel.stats import robustness_score
 from synth_panel.synthesis import synthesize_panel
 
 logger = logging.getLogger(__name__)
@@ -89,82 +107,17 @@ logger = logging.getLogger(__name__)
 # Default model for MCP mode
 MCP_DEFAULT_MODEL = "haiku"
 
-# Per-panelist timeout (seconds)
-PANELIST_TIMEOUT = 30
-
-# Input caps to prevent runaway resource usage
-MAX_PERSONAS = 100
-MAX_QUESTIONS = 50
-
-# Built-in extraction schema registry — keyed by short name.
-EXTRACT_SCHEMA_REGISTRY: dict[str, dict[str, Any]] = {
-    "sentiment": {
-        "type": "object",
-        "properties": {
-            "sentiment": {
-                "type": "string",
-                "enum": ["positive", "negative", "neutral", "mixed"],
-                "description": "Overall sentiment of the response.",
-            },
-            "confidence": {
-                "type": "number",
-                "minimum": 0.0,
-                "maximum": 1.0,
-                "description": "Confidence score (0-1) for the sentiment classification.",
-            },
-        },
-        "required": ["sentiment", "confidence"],
-    },
-    "themes": {
-        "type": "object",
-        "properties": {
-            "themes": {
-                "type": "array",
-                "items": {"type": "string"},
-                "description": "Key themes or topics mentioned in the response.",
-            },
-            "primary_theme": {
-                "type": "string",
-                "description": "The single most dominant theme.",
-            },
-        },
-        "required": ["themes", "primary_theme"],
-    },
-    "rating": {
-        "type": "object",
-        "properties": {
-            "rating": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 10,
-                "description": "Numeric rating (1-10) implied by the response.",
-            },
-            "explanation": {
-                "type": "string",
-                "description": "Brief rationale for the assigned rating.",
-            },
-        },
-        "required": ["rating", "explanation"],
-    },
-}
-
-
-def _resolve_extract_schema(
-    value: str | dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Resolve extract_schema: pass dicts through, look up strings in the registry."""
-    if value is None:
-        return None
-    if isinstance(value, dict):
-        return value
-    if isinstance(value, str):
-        if value not in EXTRACT_SCHEMA_REGISTRY:
-            names = ", ".join(sorted(EXTRACT_SCHEMA_REGISTRY))
-            raise ValueError(
-                f"Unknown extract_schema name {value!r}. Available: {names}. Or pass an inline JSON Schema dict."
-            )
-        return EXTRACT_SCHEMA_REGISTRY[value]
-    raise TypeError(f"extract_schema must be a string or dict, got {type(value).__name__}")
+# Re-export for backward compatibility — callers patch these names.
+__all__ = [
+    "EXTRACT_SCHEMA_REGISTRY",
+    "MAX_PERSONAS",
+    "MAX_QUESTIONS",
+    "MCP_DEFAULT_MODEL",
+    "PANELIST_TIMEOUT",
+    "_compute_variant_data",
+    "mcp",
+    "serve",
+]
 
 
 mcp = FastMCP(
@@ -194,7 +147,7 @@ def _get_shared_client() -> LLMClient:
 # ---------------------------------------------------------------------------
 
 
-def _run_panel_sync(
+def _server_run_panel_sync(
     personas: list[dict[str, Any]],
     questions: list[dict[str, Any]],
     model: str,
@@ -212,191 +165,26 @@ def _run_panel_sync(
 ) -> tuple[
     list[PanelistResult], list[dict[str, Any]], CostTokenUsage, Any, dict[str, Any] | None, dict[str, Any] | None
 ]:
-    """Run panel synchronously.
-
-    Returns (results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data).
-    variant_data is None when variants == 0.
-    """
-    client = _get_shared_client()
-
-    # Generate persona variants if requested
-    all_personas = list(personas)
-    variant_names: set[str] = set()
-    variant_mapping: dict[str, str] = {}  # variant_name -> source_name
-    variant_count = 0
-
-    if variants > 0:
-        logger.info("Generating %d variants per persona", variants)
-        variant_sets = generate_panel_variants(personas, client, k=variants, model=model)
-        for vs in variant_sets:
-            for v in vs.variants:
-                all_personas.append(v.persona)
-                variant_names.add(v.variant_name)
-                variant_mapping[v.variant_name] = v.source_persona_name
-                variant_count += 1
-        logger.info("Running panel with %d base + %d variant personas", len(personas), variant_count)
-
-    panelist_results, _registry, _sessions = run_panel_parallel(
-        client=client,
-        personas=all_personas,
-        questions=questions,
-        model=model,
-        system_prompt_fn=persona_system_prompt,
-        question_prompt_fn=build_question_prompt,
-        response_schema=response_schema,
+    """Thin shim around :func:`synth_panel._runners.run_panel_sync` using the shared client."""
+    return _run_panel_sync(
+        _get_shared_client(),
+        personas,
+        questions,
+        model,
+        response_schema,
+        synthesis=synthesis,
+        synthesis_model=synthesis_model,
+        synthesis_prompt=synthesis_prompt,
         temperature=temperature,
         top_p=top_p,
         persona_models=persona_models,
         extract_schema=extract_schema,
+        synthesis_temperature=synthesis_temperature,
+        variants=variants,
     )
 
-    panelist_usage = ZERO_USAGE
-    result_dicts: list[dict[str, Any]] = []
-    for pr in panelist_results:
-        pr_model = pr.model or model
-        pricing, _ = lookup_pricing(pr_model)
-        persona_cost = estimate_cost(pr.usage, pricing)
-        rd: dict[str, Any] = {
-            "persona": pr.persona_name,
-            "responses": pr.responses,
-            "usage": pr.usage.to_dict(),
-            "cost": persona_cost.format_usd(),
-            "error": pr.error,
-        }
-        if pr.model:
-            rd["model"] = pr.model
-        result_dicts.append(rd)
-        panelist_usage = panelist_usage + pr.usage
 
-    pricing, _ = lookup_pricing(model)
-    panelist_cost = estimate_cost(panelist_usage, pricing)
-
-    # Synthesis (base personas only)
-    base_results = [pr for pr in panelist_results if pr.persona_name not in variant_names]
-    synthesis_dict: dict[str, Any] | None = None
-    if synthesis:
-        try:
-            synthesis_result = synthesize_panel(
-                client,
-                base_results,
-                questions,
-                model=synthesis_model,
-                panelist_model=model,
-                custom_prompt=synthesis_prompt,
-                panelist_cost=panelist_cost,
-                temperature=synthesis_temperature,
-            )
-            synthesis_dict = synthesis_result.to_dict()
-        except Exception:
-            logger.error("Synthesis failed (non-fatal)", exc_info=True)
-            synthesis_dict = {"synthesis_error": "Synthesis failed — see server logs for details."}
-
-    # Compute robustness scores when variants were used
-    variant_data: dict[str, Any] | None = None
-    if variants > 0 and variant_mapping:
-        variant_data = _compute_variant_data(
-            result_dicts,
-            variant_names,
-            variant_mapping,
-            variant_count,
-            questions,
-        )
-
-    return panelist_results, result_dicts, panelist_usage, panelist_cost, synthesis_dict, variant_data
-
-
-def _compute_variant_data(
-    result_dicts: list[dict[str, Any]],
-    variant_names: set[str],
-    variant_mapping: dict[str, str],
-    variant_count: int,
-    questions: list[dict[str, Any]],
-) -> dict[str, Any]:
-    """Compute robustness scores from base + variant panel results."""
-    # Separate base and variant results
-    base_results = [r for r in result_dicts if r["persona"] not in variant_names]
-    variant_results = [r for r in result_dicts if r["persona"] in variant_names]
-
-    # Build per-question robustness scores
-    robustness_scores: list[dict[str, Any]] = []
-    per_persona_robustness: list[dict[str, Any]] = []
-    n_questions = len(questions)
-
-    for qi in range(n_questions):
-        # Group variant responses by source persona
-        variant_resps: dict[str, list[str]] = {}
-        for vr in variant_results:
-            source = variant_mapping.get(vr["persona"], "")
-            if not source:
-                continue
-            resps = vr.get("responses", [])
-            if qi < len(resps) and not resps[qi].get("error"):
-                variant_resps.setdefault(source, []).append(resps[qi].get("response", ""))
-
-        # Get base persona responses for this question
-        for br in base_results:
-            resps = br.get("responses", [])
-            if qi >= len(resps) or resps[qi].get("error"):
-                continue
-
-            base_response = resps[qi].get("response", "")
-            persona_name = br["persona"]
-            v_resps = variant_resps.get(persona_name, [])
-
-            if v_resps:
-                try:
-                    rs = robustness_score({persona_name: v_resps}, base_response)
-                    per_persona_robustness.append(
-                        {
-                            "persona": persona_name,
-                            "question_index": qi,
-                            "robustness": round(rs.per_persona.get(persona_name, 0.0), 4),
-                            "k_variants": len(v_resps),
-                            "finding_value": base_response,
-                            "interpretation": rs.interpretation,
-                        }
-                    )
-                except (ValueError, ZeroDivisionError):
-                    pass
-
-        # Overall robustness for this question across all base personas
-        if variant_resps:
-            # Find most common base response as the "finding"
-            base_responses_q = [
-                br["responses"][qi].get("response", "")
-                for br in base_results
-                if qi < len(br.get("responses", [])) and not br["responses"][qi].get("error")
-            ]
-            if base_responses_q:
-                from collections import Counter
-
-                most_common = Counter(base_responses_q).most_common(1)[0][0]
-                # Merge all variant responses for aggregate score
-                all_v = {}
-                for name, resps_list in variant_resps.items():
-                    all_v[name] = resps_list
-                try:
-                    agg = robustness_score(all_v, most_common)
-                    robustness_scores.append(
-                        {
-                            "question_index": qi,
-                            "question_text": questions[qi].get("text", ""),
-                            "finding_value": most_common,
-                            "overall_robustness": round(agg.overall_robustness, 4),
-                            "interpretation": agg.interpretation,
-                        }
-                    )
-                except (ValueError, ZeroDivisionError):
-                    pass
-
-    return {
-        "variant_count": variant_count,
-        "robustness_scores": robustness_scores,
-        "per_persona_robustness": per_persona_robustness,
-    }
-
-
-def _run_multi_round_sync(
+def _server_run_multi_round_sync(
     personas: list[dict[str, Any]],
     instrument: Instrument,
     model: str,
@@ -411,58 +199,22 @@ def _run_multi_round_sync(
     extract_schema: dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
 ) -> MultiRoundResult:
-    """Drive run_multi_round_panel for v1/v2/v3 instruments."""
-    client = _get_shared_client()
-
-    def _round_synth(
-        c: LLMClient,
-        panelist_results: list[PanelistResult],
-        questions: list[dict[str, Any]],
-        *,
-        model: str,
-    ):
-        return synthesize_panel(
-            c,
-            panelist_results,
-            questions,
-            model=synthesis_model,
-            panelist_model=model,
-            custom_prompt=synthesis_prompt,
-            temperature=synthesis_temperature,
-        )
-
-    final_fn = _round_synth if synthesis else None
-    return run_multi_round_panel(
-        client=client,
-        personas=personas,
-        instrument=instrument,
-        model=model,
-        system_prompt_fn=persona_system_prompt,
-        question_prompt_fn=build_question_prompt,
-        synthesize_round_fn=_round_synth if synthesis else (lambda *a, **kw: None),
-        synthesize_final_fn=final_fn,
-        response_schema=response_schema,
+    """Thin shim around :func:`synth_panel._runners.run_multi_round_sync` using the shared client."""
+    return _run_multi_round_sync(
+        _get_shared_client(),
+        personas,
+        instrument,
+        model,
+        response_schema,
+        synthesis=synthesis,
+        synthesis_model=synthesis_model,
+        synthesis_prompt=synthesis_prompt,
         temperature=temperature,
         top_p=top_p,
         persona_models=persona_models,
         extract_schema=extract_schema,
+        synthesis_temperature=synthesis_temperature,
     )
-
-
-def _format_panelist_result(pr: PanelistResult, model: str) -> dict[str, Any]:
-    pr_model = pr.model or model
-    pricing, _ = lookup_pricing(pr_model)
-    persona_cost = estimate_cost(pr.usage, pricing)
-    rd: dict[str, Any] = {
-        "persona": pr.persona_name,
-        "responses": pr.responses,
-        "usage": pr.usage.to_dict(),
-        "cost": persona_cost.format_usd(),
-        "error": pr.error,
-    }
-    if pr.model:
-        rd["model"] = pr.model
-    return rd
 
 
 def _run_ensemble_sync(
@@ -523,7 +275,7 @@ async def _run_panel_async_instrument(
 
     mr: MultiRoundResult = await asyncio.wait_for(
         asyncio.to_thread(
-            _run_multi_round_sync,
+            _server_run_multi_round_sync,
             personas,
             instrument,
             model,
@@ -661,7 +413,7 @@ async def _run_panel_async(
         variant_data,
     ) = await asyncio.wait_for(
         asyncio.to_thread(
-            _run_panel_sync,
+            _server_run_panel_sync,
             personas,
             questions,
             model,

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -1,0 +1,1036 @@
+"""Public Python SDK for synthpanel.
+
+Import the functions below directly from ``synth_panel``::
+
+    from synth_panel import quick_poll, run_panel, run_prompt
+
+This is the convenience layer for Python callers — Jupyter notebooks,
+scripts, notebooks, CI pipelines, LangChain wrappers, etc. It has **no
+runtime dependency on the optional ``mcp`` extra**: ``pip install
+synthpanel`` (without ``[mcp]``) is enough.
+
+The eight public entry points mirror the MCP server's tools but return
+typed :mod:`dataclasses` instead of JSON strings:
+
+* :func:`run_prompt` — one-shot LLM call, no personas
+* :func:`quick_poll` — single question across a panel
+* :func:`run_panel` — full panel run (v1/v2/v3 instruments)
+* :func:`extend_panel` — append an ad-hoc follow-up round
+* :func:`list_personas` — installed persona packs (bundled + user)
+* :func:`list_instruments` — installed instrument packs (bundled + user)
+* :func:`list_panel_results` — saved panel-result summaries
+* :func:`get_panel_result` — load a full saved result
+
+The return types (:class:`PromptResult`, :class:`PollResult`,
+:class:`PanelResult`) all expose a ``.to_dict()`` method for JSON
+serialisation and dict-like ``__getitem__`` for back-compat with code
+that used to receive the raw MCP payload.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from synth_panel._runners import (
+    MAX_PERSONAS,
+    MAX_QUESTIONS,
+    resolve_extract_schema,
+    run_multi_round_sync,
+    run_panel_sync,
+)
+from synth_panel.cost import (
+    ZERO_USAGE,
+    estimate_cost,
+    lookup_pricing,
+)
+from synth_panel.cost import (
+    TokenUsage as CostTokenUsage,
+)
+from synth_panel.instrument import Instrument, parse_instrument
+from synth_panel.llm.client import LLMClient
+from synth_panel.llm.models import CompletionRequest, InputMessage, TextBlock
+from synth_panel.mcp.data import (
+    get_panel_result as _data_get_panel_result,
+)
+from synth_panel.mcp.data import (
+    get_persona_pack as _data_get_persona_pack,
+)
+from synth_panel.mcp.data import (
+    list_instrument_packs as _data_list_instrument_packs,
+)
+from synth_panel.mcp.data import (
+    list_panel_results as _data_list_panel_results,
+)
+from synth_panel.mcp.data import (
+    list_persona_packs as _data_list_persona_packs,
+)
+from synth_panel.mcp.data import (
+    load_instrument_pack as _data_load_instrument_pack,
+)
+from synth_panel.mcp.data import (
+    load_panel_sessions,
+    save_panel_result,
+    update_panel_result,
+)
+from synth_panel.metadata import PanelTimer, build_metadata
+from synth_panel.orchestrator import (
+    MultiRoundResult,
+    run_panel_parallel,
+)
+from synth_panel.prompts import build_question_prompt, persona_system_prompt
+from synth_panel.synthesis import synthesize_panel
+
+__all__ = [
+    "PanelResult",
+    "PollResult",
+    "PromptResult",
+    "extend_panel",
+    "get_panel_result",
+    "list_instruments",
+    "list_panel_results",
+    "list_personas",
+    "quick_poll",
+    "run_panel",
+    "run_prompt",
+]
+
+# ---------------------------------------------------------------------------
+# Default model resolution
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_MODEL_PREFERENCE: list[tuple[str, str]] = [
+    ("ANTHROPIC_API_KEY", "sonnet"),
+    ("OPENAI_API_KEY", "gpt-4o-mini"),
+    ("GEMINI_API_KEY", "gemini-2.5-flash"),
+    ("GOOGLE_API_KEY", "gemini-2.5-flash"),
+    ("XAI_API_KEY", "grok-3"),
+    ("OPENROUTER_API_KEY", "openrouter/auto"),
+]
+
+
+def _default_model() -> str:
+    """Pick a default alias from the first provider with credentials in the env.
+
+    Mirrors the CLI's resolution order so ``from synth_panel import quick_poll``
+    works with whichever API key the user has set, falling back to
+    ``"sonnet"`` when nothing is set (so the LLM client's missing-
+    credentials error is the one the user sees).
+    """
+    for env_var, alias in _DEFAULT_MODEL_PREFERENCE:
+        if os.environ.get(env_var, "").strip():
+            return alias
+    return "sonnet"
+
+
+# Module-level shared client — reused across calls to avoid rebuilding the
+# provider cache on every invocation. Thread-safe (see LLMClient).
+_shared_client: LLMClient | None = None
+
+
+def _get_client() -> LLMClient:
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = LLMClient()
+    return _shared_client
+
+
+# ---------------------------------------------------------------------------
+# Public result dataclasses
+# ---------------------------------------------------------------------------
+
+
+class _DictLikeMixin:
+    """Support ``result["key"]`` and ``"key" in result`` for dict-compat."""
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+    def __contains__(self, key: str) -> bool:
+        return hasattr(self, key)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return getattr(self, key, default)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain-dict representation of the result."""
+        return asdict(self)  # type: ignore[call-overload]
+
+
+@dataclass
+class PromptResult(_DictLikeMixin):
+    """One LLM response to a single prompt, with cost + usage metadata.
+
+    Returned by :func:`run_prompt`.
+
+    Attributes:
+        response: The text content of the model's reply.
+        model: The canonical model id the provider reported (e.g.
+            ``"claude-sonnet-4-6"``).
+        usage: Per-turn token usage — input, output, cache read/write.
+        cost: Estimated USD cost formatted as ``"$0.0012"``.
+    """
+
+    response: str
+    model: str
+    usage: dict[str, Any]
+    cost: str
+
+
+@dataclass
+class PollResult(_DictLikeMixin):
+    """Panel responses to a single question with optional synthesis.
+
+    Returned by :func:`quick_poll`.
+
+    Attributes:
+        result_id: Opaque id persisted under
+            ``$SYNTH_PANEL_DATA_DIR/results/`` — pass to
+            :func:`get_panel_result` or :func:`extend_panel`.
+        question: The question that was asked.
+        responses: One dict per panelist — ``persona``, ``responses``,
+            ``usage``, ``cost``, ``error``.
+        synthesis: Synthesis payload (themes, agreements, recommendation,
+            etc.) or ``None`` when ``synthesis=False`` was passed.
+        model: The panelist model alias that was used.
+        total_usage: Aggregate token usage across panel + synthesis.
+        total_cost: Formatted USD total.
+        metadata: Full run metadata (per-tier cost breakdown, timings).
+    """
+
+    result_id: str
+    question: str
+    responses: list[dict[str, Any]]
+    synthesis: dict[str, Any] | None
+    model: str
+    total_usage: dict[str, Any]
+    total_cost: str
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass
+class PanelResult(_DictLikeMixin):
+    """Result of a full panel run (v1/v2/v3 instruments).
+
+    Returned by :func:`run_panel`, :func:`extend_panel`, and
+    :func:`get_panel_result`.
+
+    The shape mirrors the MCP server's ``run_panel`` payload so code
+    that previously consumed the JSON can swap in the SDK without a
+    rewrite.
+
+    Attributes:
+        result_id: Persistent id under
+            ``$SYNTH_PANEL_DATA_DIR/results/``.
+        model: Panelist model alias.
+        persona_count: Number of panelists that participated.
+        question_count: Total questions asked across all rounds.
+        rounds: Per-round dicts with ``name``, ``results``,
+            ``synthesis``, ``usage``.
+        path: Routing decisions actually taken —
+            ``[{round, branch, next}, ...]``.
+        synthesis: Final synthesis payload (or the single round's
+            synthesis for v1/v2 and ``questions`` input).
+        total_cost: Formatted USD total across panel + synthesis.
+        total_usage: Aggregate token usage.
+        warnings: Parser + runtime warnings (empty in the happy path).
+        terminal_round: The last round whose synthesis fed final
+            synthesis. ``None`` for v1 runs and when synthesis is off.
+        results: Flat panelist results for the terminal round
+            (back-compat mirror — equivalent to ``rounds[-1]["results"]``).
+        metadata: Full run metadata bundle (timings, per-tier cost
+            breakdown). Present for fresh runs; may be ``None`` on
+            results loaded from disk that predate metadata capture.
+    """
+
+    result_id: str
+    model: str
+    persona_count: int
+    question_count: int
+    rounds: list[dict[str, Any]]
+    path: list[dict[str, Any]]
+    synthesis: dict[str, Any] | None
+    total_cost: str
+    total_usage: dict[str, Any]
+    warnings: list[str] = field(default_factory=list)
+    terminal_round: str | None = None
+    results: list[dict[str, Any]] = field(default_factory=list)
+    metadata: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_personas(personas: list[dict[str, Any]]) -> None:
+    for i, p in enumerate(personas):
+        if not isinstance(p, dict):
+            raise TypeError(f"Persona at index {i} must be a dict, got {type(p).__name__}.")
+        if "name" not in p or not str(p["name"]).strip():
+            raise ValueError(f"Persona at index {i} is missing required field 'name'.")
+    if len(personas) > MAX_PERSONAS:
+        raise ValueError(f"Too many personas ({len(personas)}). Maximum is {MAX_PERSONAS}.")
+
+
+def _validate_questions(questions: list[dict[str, Any]]) -> None:
+    for i, q in enumerate(questions):
+        if not isinstance(q, dict):
+            raise TypeError(f"Question at index {i} must be a dict, got {type(q).__name__}.")
+        if "text" not in q or not str(q["text"]).strip():
+            raise ValueError(f"Question at index {i} is missing required field 'text'.")
+    if len(questions) > MAX_QUESTIONS:
+        raise ValueError(f"Too many questions ({len(questions)}). Maximum is {MAX_QUESTIONS}.")
+
+
+def _resolve_personas(
+    personas: list[dict[str, Any]] | None,
+    pack_id: str | None,
+) -> list[dict[str, Any]]:
+    merged: list[dict[str, Any]] = list(personas) if personas else []
+    if pack_id is not None:
+        pack = _data_get_persona_pack(pack_id)
+        merged.extend(pack.get("personas", []))
+    if not merged:
+        raise ValueError("No personas provided. Pass personas=... and/or pack_id=...")
+    _validate_personas(merged)
+    return merged
+
+
+def _coerce_questions(questions: list[str] | list[dict[str, Any]] | str) -> list[dict[str, Any]]:
+    """Accept a string, list of strings, or list of dicts; normalise to dicts."""
+    if isinstance(questions, str):
+        return [{"text": questions}]
+    out: list[dict[str, Any]] = []
+    for q in questions:
+        if isinstance(q, str):
+            out.append({"text": q})
+        else:
+            out.append(dict(q))
+    return out
+
+
+def _build_panel_result_from_single_round(
+    result_id: str,
+    model: str,
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    result_dicts: list[dict[str, Any]],
+    panelist_usage: CostTokenUsage,
+    panelist_cost: Any,
+    synthesis_dict: dict[str, Any] | None,
+    metadata: dict[str, Any] | None,
+    total_usage: CostTokenUsage,
+    total_cost: Any,
+) -> PanelResult:
+    return PanelResult(
+        result_id=result_id,
+        model=model,
+        persona_count=len(personas),
+        question_count=len(questions),
+        rounds=[
+            {
+                "name": "default",
+                "results": result_dicts,
+                "synthesis": synthesis_dict,
+            }
+        ],
+        path=[],
+        synthesis=synthesis_dict,
+        total_cost=total_cost.format_usd(),
+        total_usage=total_usage.to_dict(),
+        warnings=[],
+        terminal_round=None,
+        results=result_dicts,
+        metadata=metadata,
+    )
+
+
+def _build_panel_result_from_multi_round(
+    result_id: str,
+    model: str,
+    personas: list[dict[str, Any]],
+    instrument: Instrument,
+    mr: MultiRoundResult,
+    metadata: dict[str, Any] | None,
+) -> PanelResult:
+    from synth_panel._runners import format_panelist_result
+
+    rounds_payload: list[dict[str, Any]] = []
+    flat_results: list[dict[str, Any]] = []
+    total_question_count = 0
+    for rr in mr.rounds:
+        round_dict_results = [format_panelist_result(pr, model) for pr in rr.panelist_results]
+        questions_for_round = next((r.questions for r in instrument.rounds if r.name == rr.name), [])
+        total_question_count += len(questions_for_round)
+        rounds_payload.append(
+            {
+                "name": rr.name,
+                "results": round_dict_results,
+                "synthesis": rr.synthesis.to_dict() if hasattr(rr.synthesis, "to_dict") else None,
+                "usage": rr.usage.to_dict(),
+            }
+        )
+        flat_results = round_dict_results
+
+    pricing, _ = lookup_pricing(model)
+    total_cost = estimate_cost(mr.usage, pricing)
+    final_synth_dict = (
+        mr.final_synthesis.to_dict()
+        if mr.final_synthesis is not None and hasattr(mr.final_synthesis, "to_dict")
+        else None
+    )
+    return PanelResult(
+        result_id=result_id,
+        model=model,
+        persona_count=len(personas),
+        question_count=total_question_count,
+        rounds=rounds_payload,
+        path=mr.path,
+        synthesis=final_synth_dict,
+        total_cost=total_cost.format_usd(),
+        total_usage=mr.usage.to_dict(),
+        warnings=mr.warnings,
+        terminal_round=mr.terminal_round,
+        results=flat_results,
+        metadata=metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def run_prompt(
+    prompt: str,
+    *,
+    model: str | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> PromptResult:
+    """Send a single prompt to an LLM and return its response.
+
+    The simplest entry point — ask a quick one-shot question without
+    constructing personas or running a panel.
+
+    Args:
+        prompt: The text to send.
+        model: Model alias or canonical id. Defaults to the first
+            provider whose API key is in the environment (Anthropic →
+            ``sonnet``, OpenAI → ``gpt-4o-mini``, etc.).
+        temperature: Sampling temperature (0.0-1.0). ``None`` leaves the
+            provider default.
+        top_p: Nucleus sampling threshold (0.0-1.0). Alternative to
+            ``temperature``.
+
+    Returns:
+        :class:`PromptResult` with the response text, canonical model
+        id, token usage, and USD cost.
+
+    Example:
+        >>> from synth_panel import run_prompt
+        >>> result = run_prompt("Summarise the MECE principle in one line.")
+        >>> print(result.response)
+    """
+    if not prompt or not prompt.strip():
+        raise ValueError("prompt must be a non-empty string.")
+    model = model or _default_model()
+
+    client = _get_client()
+    request = CompletionRequest(
+        model=model,
+        max_tokens=4096,
+        messages=[InputMessage(role="user", content=[TextBlock(text=prompt)])],
+        temperature=temperature,
+        top_p=top_p,
+    )
+    response = client.send(request)
+    usage = CostTokenUsage(
+        input_tokens=response.usage.input_tokens,
+        output_tokens=response.usage.output_tokens,
+        cache_creation_input_tokens=response.usage.cache_write_tokens,
+        cache_read_input_tokens=response.usage.cache_read_tokens,
+    )
+    pricing, _ = lookup_pricing(model)
+    cost = estimate_cost(usage, pricing)
+    return PromptResult(
+        response=response.text,
+        model=response.model,
+        usage=usage.to_dict(),
+        cost=cost.format_usd(),
+    )
+
+
+def quick_poll(
+    question: str,
+    personas: list[dict[str, Any]] | None = None,
+    *,
+    pack_id: str | None = None,
+    model: str | None = None,
+    synthesis: bool = True,
+    synthesis_model: str | None = None,
+    synthesis_prompt: str | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+) -> PollResult:
+    """Ask one question of a panel and get synthesized findings back.
+
+    A streamlined version of :func:`run_panel` for the common single-
+    question case. Each persona answers independently in parallel; by
+    default a synthesis step then aggregates themes, agreements, and
+    disagreements.
+
+    Args:
+        question: The question to put to every persona.
+        personas: List of persona dicts (each needs at least ``name``).
+            Provide ``personas`` and/or ``pack_id``; at least one is
+            required.
+        pack_id: Name of an installed persona pack — see
+            :func:`list_personas`. Merged after ``personas``.
+        model: Model alias for panelist responses. Defaults per
+            environment.
+        synthesis: Run the synthesis step after collecting responses.
+            Default ``True``.
+        synthesis_model: Model for the synthesis step. Defaults to the
+            panelist model.
+        synthesis_prompt: Custom synthesis prompt. Replaces the default
+            template.
+        temperature: Panelist sampling temperature.
+        top_p: Panelist nucleus sampling threshold.
+
+    Returns:
+        :class:`PollResult` — per-panelist responses, synthesis, and
+        cost. Result is persisted; use ``result.result_id`` with
+        :func:`extend_panel` to probe deeper.
+
+    Example:
+        >>> from synth_panel import quick_poll
+        >>> out = quick_poll(
+        ...     "What's confusing about our pricing page?",
+        ...     pack_id="general-consumer",
+        ... )
+        >>> print(out.synthesis["recommendation"])
+    """
+    if not question or not question.strip():
+        raise ValueError("question must be a non-empty string.")
+    merged = _resolve_personas(personas, pack_id)
+    model = model or _default_model()
+    questions = [{"text": question}]
+
+    client = _get_client()
+    timer = PanelTimer()
+    (
+        _panelist_results,
+        result_dicts,
+        panelist_usage,
+        panelist_cost,
+        synthesis_dict,
+        _variant_data,
+    ) = run_panel_sync(
+        client=client,
+        personas=merged,
+        questions=questions,
+        model=model,
+        synthesis=synthesis,
+        synthesis_model=synthesis_model,
+        synthesis_prompt=synthesis_prompt,
+        temperature=temperature,
+        top_p=top_p,
+    )
+
+    synthesis_usage_obj: CostTokenUsage | None = None
+    synthesis_cost_obj = None
+    if synthesis_dict and "usage" in synthesis_dict:
+        synthesis_usage_obj = CostTokenUsage.from_dict(synthesis_dict["usage"])
+        synthesis_pricing, _ = lookup_pricing(synthesis_dict.get("model"))
+        synthesis_cost_obj = estimate_cost(synthesis_usage_obj, synthesis_pricing)
+        total_usage = panelist_usage + synthesis_usage_obj
+        total_cost = panelist_cost + synthesis_cost_obj
+    else:
+        total_usage = panelist_usage
+        total_cost = panelist_cost
+
+    timer.stop()
+    metadata = build_metadata(
+        panelist_model=model,
+        synthesis_model=synthesis_dict.get("model") if synthesis_dict else None,
+        panelist_usage=panelist_usage,
+        panelist_cost=panelist_cost,
+        synthesis_usage=synthesis_usage_obj,
+        synthesis_cost=synthesis_cost_obj,
+        total_usage=total_usage,
+        total_cost=total_cost,
+        persona_count=len(merged),
+        question_count=1,
+        timer=timer,
+    )
+
+    result_id = save_panel_result(
+        results=result_dicts,
+        model=model,
+        total_usage=total_usage.to_dict(),
+        total_cost=total_cost.format_usd(),
+        persona_count=len(merged),
+        question_count=1,
+    )
+
+    return PollResult(
+        result_id=result_id,
+        question=question,
+        responses=result_dicts,
+        synthesis=synthesis_dict,
+        model=model,
+        total_usage=total_usage.to_dict(),
+        total_cost=total_cost.format_usd(),
+        metadata=metadata,
+    )
+
+
+def run_panel(
+    personas: list[dict[str, Any]] | None = None,
+    instrument: dict[str, Any] | None = None,
+    *,
+    questions: list[dict[str, Any]] | list[str] | None = None,
+    instrument_pack: str | None = None,
+    pack_id: str | None = None,
+    model: str | None = None,
+    response_schema: dict[str, Any] | None = None,
+    synthesis: bool = True,
+    synthesis_model: str | None = None,
+    synthesis_prompt: str | None = None,
+    temperature: float | None = None,
+    top_p: float | None = None,
+    persona_models: dict[str, str] | None = None,
+    extract_schema: str | dict[str, Any] | None = None,
+    synthesis_temperature: float | None = None,
+    variants: int = 0,
+) -> PanelResult:
+    """Run a full synthetic focus group panel.
+
+    Accepts personas inline or via a saved pack, plus **one** of three
+    question sources:
+
+    1. ``questions=[...]`` — flat list (or list of strings), v1 shape.
+    2. ``instrument={...}`` — a v1/v2/v3 instrument body. v3 instruments
+       with ``route_when`` clauses run as a branching multi-round panel.
+    3. ``instrument_pack="pricing-discovery"`` — load an installed
+       instrument pack. See :func:`list_instruments`.
+
+    Args:
+        personas: List of persona dicts. Each needs ``name``. Provide
+            this, ``pack_id``, or both.
+        instrument: Inline instrument body (the value under the top-
+            level ``instrument:`` key in YAML). Takes precedence over
+            ``questions``.
+        questions: Flat question list for the simplest case. Strings are
+            auto-wrapped as ``{"text": ...}``.
+        instrument_pack: Installed instrument pack name. Takes
+            precedence over both ``instrument`` and ``questions``.
+        pack_id: Persona pack name. Merged after inline ``personas``.
+        model: Model alias for panelist responses. Defaults per
+            environment.
+        response_schema: JSON Schema for structured per-persona output.
+        synthesis: Run the synthesis step. Default ``True``.
+        synthesis_model: Override the synthesis-step model.
+        synthesis_prompt: Custom synthesis prompt.
+        temperature: Panelist sampling temperature.
+        top_p: Panelist nucleus sampling threshold.
+        persona_models: Per-persona model overrides, e.g.
+            ``{"Sarah Chen": "sonnet", "Marcus": "haiku"}``.
+        extract_schema: Post-hoc extraction schema — either a built-in
+            name (``"sentiment"``, ``"themes"``, ``"rating"``) or an
+            inline JSON Schema dict.
+        synthesis_temperature: Temperature for the synthesis step,
+            independent of the panelist temperature.
+        variants: Number of persona variants per base persona. ``0``
+            disables the robustness path. ``1..20`` generates variants
+            and computes robustness scores in the result.
+
+    Returns:
+        :class:`PanelResult` — rounds, routing path, synthesis, cost.
+
+    Example:
+        >>> from synth_panel import run_panel
+        >>> panel = run_panel(
+        ...     pack_id="general-consumer",
+        ...     instrument_pack="pricing-discovery",
+        ... )
+        >>> print(panel.path)
+    """
+    if variants < 0 or variants > 20:
+        raise ValueError("variants must be between 0 and 20.")
+    merged = _resolve_personas(personas, pack_id)
+    model = model or _default_model()
+
+    resolved_extract_schema = resolve_extract_schema(extract_schema)
+
+    # Resolve instrument source (pack > inline instrument > questions).
+    instrument_obj: Instrument | None = None
+    if instrument_pack is not None:
+        pack_body = _data_load_instrument_pack(instrument_pack)
+        raw = pack_body.get("instrument", pack_body)
+        instrument_obj = parse_instrument(raw)
+    elif instrument is not None:
+        raw = instrument.get("instrument", instrument)
+        instrument_obj = parse_instrument(raw)
+
+    client = _get_client()
+
+    if instrument_obj is not None:
+        timer = PanelTimer()
+        mr = run_multi_round_sync(
+            client=client,
+            personas=merged,
+            instrument=instrument_obj,
+            model=model,
+            response_schema=response_schema,
+            synthesis=synthesis,
+            synthesis_model=synthesis_model,
+            synthesis_prompt=synthesis_prompt,
+            temperature=temperature,
+            top_p=top_p,
+            persona_models=persona_models,
+            extract_schema=resolved_extract_schema,
+            synthesis_temperature=synthesis_temperature,
+        )
+        pricing, _ = lookup_pricing(model)
+        total_cost = estimate_cost(mr.usage, pricing)
+        panelist_usage = ZERO_USAGE
+        for rr in mr.rounds:
+            for pr in rr.panelist_results:
+                panelist_usage = panelist_usage + pr.usage
+        panelist_cost_est = estimate_cost(panelist_usage, pricing)
+
+        synthesis_usage_for_meta: CostTokenUsage | None = None
+        synthesis_cost_for_meta = None
+        if mr.final_synthesis is not None and hasattr(mr.final_synthesis, "usage"):
+            synthesis_usage_for_meta = mr.final_synthesis.usage
+            synth_model = getattr(mr.final_synthesis, "model", model)
+            synth_pricing, _ = lookup_pricing(synth_model)
+            synthesis_cost_for_meta = estimate_cost(synthesis_usage_for_meta, synth_pricing)
+        timer.stop()
+
+        total_question_count = sum(
+            len(next((r.questions for r in instrument_obj.rounds if r.name == rr.name), [])) for rr in mr.rounds
+        )
+        metadata = build_metadata(
+            panelist_model=model,
+            synthesis_model=getattr(mr.final_synthesis, "model", None) if mr.final_synthesis else None,
+            panelist_usage=panelist_usage,
+            panelist_cost=panelist_cost_est,
+            synthesis_usage=synthesis_usage_for_meta,
+            synthesis_cost=synthesis_cost_for_meta,
+            total_usage=mr.usage,
+            total_cost=total_cost,
+            persona_count=len(merged),
+            question_count=total_question_count,
+            timer=timer,
+        )
+
+        # Flat results for persistence — take the terminal round's panelist list.
+        from synth_panel._runners import format_panelist_result
+
+        flat_results = [format_panelist_result(pr, model) for pr in mr.rounds[-1].panelist_results] if mr.rounds else []
+
+        result_id = save_panel_result(
+            results=flat_results,
+            model=model,
+            total_usage=mr.usage.to_dict(),
+            total_cost=total_cost.format_usd(),
+            persona_count=len(merged),
+            question_count=total_question_count,
+        )
+        return _build_panel_result_from_multi_round(
+            result_id,
+            model,
+            merged,
+            instrument_obj,
+            mr,
+            metadata,
+        )
+
+    # No instrument — fall back to the flat questions list.
+    if not questions:
+        raise ValueError("Provide one of: questions=..., instrument=..., or instrument_pack=...")
+    normalised_questions = _coerce_questions(questions)
+    _validate_questions(normalised_questions)
+
+    timer = PanelTimer()
+    (
+        _panelist_results,
+        result_dicts,
+        panelist_usage,
+        panelist_cost,
+        synthesis_dict,
+        variant_data,
+    ) = run_panel_sync(
+        client=client,
+        personas=merged,
+        questions=normalised_questions,
+        model=model,
+        response_schema=response_schema,
+        synthesis=synthesis,
+        synthesis_model=synthesis_model,
+        synthesis_prompt=synthesis_prompt,
+        temperature=temperature,
+        top_p=top_p,
+        persona_models=persona_models,
+        extract_schema=resolved_extract_schema,
+        synthesis_temperature=synthesis_temperature,
+        variants=variants,
+    )
+
+    synthesis_usage_obj: CostTokenUsage | None = None
+    synthesis_cost_obj = None
+    if synthesis_dict and "usage" in synthesis_dict:
+        synthesis_usage_obj = CostTokenUsage.from_dict(synthesis_dict["usage"])
+        synthesis_pricing, _ = lookup_pricing(synthesis_dict.get("model"))
+        synthesis_cost_obj = estimate_cost(synthesis_usage_obj, synthesis_pricing)
+        total_usage = panelist_usage + synthesis_usage_obj
+        total_cost = panelist_cost + synthesis_cost_obj
+    else:
+        total_usage = panelist_usage
+        total_cost = panelist_cost
+
+    timer.stop()
+    metadata = build_metadata(
+        panelist_model=model,
+        synthesis_model=synthesis_dict.get("model") if synthesis_dict else None,
+        panelist_usage=panelist_usage,
+        panelist_cost=panelist_cost,
+        synthesis_usage=synthesis_usage_obj,
+        synthesis_cost=synthesis_cost_obj,
+        total_usage=total_usage,
+        total_cost=total_cost,
+        persona_count=len(merged),
+        question_count=len(normalised_questions),
+        timer=timer,
+    )
+
+    variant_count = variant_data["variant_count"] if variant_data else 0
+    result_id = save_panel_result(
+        results=result_dicts,
+        model=model,
+        total_usage=total_usage.to_dict(),
+        total_cost=total_cost.format_usd(),
+        persona_count=len(merged),
+        question_count=len(normalised_questions),
+        variant_count=variant_count,
+    )
+
+    panel = _build_panel_result_from_single_round(
+        result_id=result_id,
+        model=model,
+        personas=merged,
+        questions=normalised_questions,
+        result_dicts=result_dicts,
+        panelist_usage=panelist_usage,
+        panelist_cost=panelist_cost,
+        synthesis_dict=synthesis_dict,
+        metadata=metadata,
+        total_usage=total_usage,
+        total_cost=total_cost,
+    )
+    if variant_data:
+        panel.metadata = dict(panel.metadata or {})
+        panel.metadata["robustness_scores"] = variant_data["robustness_scores"]
+        panel.metadata["per_persona_robustness"] = variant_data["per_persona_robustness"]
+        panel.metadata["variant_count"] = variant_data["variant_count"]
+    return panel
+
+
+def extend_panel(
+    result_id: str,
+    questions: list[dict[str, Any]] | list[str] | str,
+    *,
+    model: str | None = None,
+    synthesis: bool = True,
+    synthesis_model: str | None = None,
+    synthesis_prompt: str | None = None,
+) -> PanelResult:
+    """Append one ad-hoc round to a saved panel result.
+
+    Always appends exactly **one** improvised round on top of an
+    existing result, reusing each panelist's saved session so the
+    follow-up sees full conversational context. It is **not** a way to
+    re-enter the authored v3 DAG: the original instrument's
+    ``route_when`` clauses are not consulted, no routing decision is
+    made, and the result's ``path`` grows by one entry flagged as an
+    extension. For adaptive branching, run a fresh :func:`run_panel`
+    against a v3 instrument instead.
+
+    A pre-extend snapshot is preserved alongside the result file
+    (``<result_id>.pre-extend.json``) so the operation is reversible.
+
+    Args:
+        result_id: ID of a previously saved panel result.
+        questions: One or more follow-up questions. Strings are
+            auto-wrapped.
+        model: Model alias for the new round. Defaults per environment.
+        synthesis: Synthesize the new round.
+        synthesis_model: Override synthesis model.
+        synthesis_prompt: Custom synthesis prompt for the new round.
+
+    Returns:
+        :class:`PanelResult` with the full result after extension,
+        including the new round.
+
+    Example:
+        >>> from synth_panel import extend_panel
+        >>> result = extend_panel(
+        ...     result_id="result-20260416-...",
+        ...     questions="What would change your mind?",
+        ... )
+    """
+    existing = _data_get_panel_result(result_id)
+    model = model or _default_model()
+    normalised_questions = _coerce_questions(questions)
+    if not normalised_questions:
+        raise ValueError("At least one follow-up question is required.")
+
+    sessions = load_panel_sessions(result_id)
+    personas: list[dict[str, Any]] = [{"name": name} for name in sessions]
+    if not personas:
+        raise ValueError(f"No saved panelist sessions for result {result_id!r}.")
+
+    client = _get_client()
+    panelist_results, _registry, _sessions = run_panel_parallel(
+        client=client,
+        personas=personas,
+        questions=normalised_questions,
+        model=model,
+        system_prompt_fn=persona_system_prompt,
+        question_prompt_fn=build_question_prompt,
+        sessions=sessions,
+    )
+
+    synth = None
+    if synthesis:
+        try:
+            synth = synthesize_panel(
+                client,
+                panelist_results,
+                normalised_questions,
+                model=synthesis_model,
+                panelist_model=model,
+                custom_prompt=synthesis_prompt,
+            )
+        except Exception:
+            synth = None
+
+    from synth_panel._runners import format_panelist_result
+
+    new_round_results = [format_panelist_result(pr, model) for pr in panelist_results]
+
+    rounds = list(existing.get("rounds") or [])
+    appended_name = f"extension-{len(rounds) + 1}"
+    rounds.append(
+        {
+            "name": appended_name,
+            "results": new_round_results,
+            "synthesis": synth.to_dict() if synth is not None and hasattr(synth, "to_dict") else None,
+            "extension": True,
+        }
+    )
+    path = list(existing.get("path") or [])
+    path.append(
+        {
+            "round": appended_name,
+            "branch": "extension (ad-hoc, not DAG re-entry)",
+            "next": "__end__",
+        }
+    )
+
+    updated = dict(existing)
+    updated["rounds"] = rounds
+    updated["path"] = path
+    updated["results"] = new_round_results
+    updated["question_count"] = int(existing.get("question_count", 0)) + len(normalised_questions)
+    update_panel_result(result_id, updated)
+
+    return get_panel_result(result_id)
+
+
+def list_personas() -> list[dict[str, Any]]:
+    """Return metadata for every persona pack — bundled and user-saved.
+
+    Each entry carries ``id``, ``name``, ``persona_count``, and a
+    ``builtin`` flag. Use the ``id`` with :func:`quick_poll` or
+    :func:`run_panel` via ``pack_id=...``.
+
+    Example:
+        >>> from synth_panel import list_personas
+        >>> for pack in list_personas():
+        ...     print(pack["id"], pack["persona_count"])
+    """
+    return _data_list_persona_packs()
+
+
+def list_instruments() -> list[dict[str, Any]]:
+    """Return metadata for every installed instrument pack.
+
+    Each entry carries the manifest fields (``id``, ``name``,
+    ``version``, ``description``, ``author``) plus ``source``
+    (``"bundled"`` or ``"user"``). Use the ``id`` with
+    :func:`run_panel` via ``instrument_pack=...``.
+
+    Example:
+        >>> from synth_panel import list_instruments
+        >>> for pack in list_instruments():
+        ...     print(pack["id"], "—", pack["description"])
+    """
+    return _data_list_instrument_packs()
+
+
+def list_panel_results() -> list[dict[str, Any]]:
+    """Return summaries for every saved panel result.
+
+    Each entry carries ``id``, ``created_at``, ``model``,
+    ``persona_count``, and ``question_count``. Use the ``id`` with
+    :func:`get_panel_result` to load a full result.
+
+    Example:
+        >>> from synth_panel import list_panel_results, get_panel_result
+        >>> latest = list_panel_results()[0]
+        >>> full = get_panel_result(latest["id"])
+    """
+    return _data_list_panel_results()
+
+
+def get_panel_result(result_id: str) -> PanelResult:
+    """Load a saved panel result by id.
+
+    Args:
+        result_id: The id returned by an earlier :func:`run_panel`,
+            :func:`quick_poll`, or :func:`extend_panel` call.
+
+    Returns:
+        :class:`PanelResult`. Results saved before certain fields
+        existed may return ``None`` / ``[]`` for those fields.
+
+    Example:
+        >>> from synth_panel import get_panel_result
+        >>> panel = get_panel_result("result-20260416-123456-abcdef")
+        >>> print(panel.synthesis)
+    """
+    data = _data_get_panel_result(result_id)
+    rounds = data.get("rounds") or []
+    results = data.get("results") or (rounds[-1]["results"] if rounds else [])
+    return PanelResult(
+        result_id=data.get("id", result_id),
+        model=data.get("model", ""),
+        persona_count=int(data.get("persona_count", 0)),
+        question_count=int(data.get("question_count", 0)),
+        rounds=rounds,
+        path=data.get("path") or [],
+        synthesis=data.get("synthesis"),
+        total_cost=data.get("total_cost", ""),
+        total_usage=data.get("total_usage") or {},
+        warnings=data.get("warnings") or [],
+        terminal_round=data.get("terminal_round"),
+        results=results,
+        metadata=data.get("metadata"),
+    )

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1,0 +1,361 @@
+"""Tests for the public SDK surface in :mod:`synth_panel.sdk`.
+
+Covers:
+* Import surface — the eight exported functions and three dataclasses
+  are reachable from the package root.
+* ``__all__`` correctness — no stray internals leak, no dead names.
+* ``run_prompt`` round-trip against a mocked :class:`LLMClient`.
+* ``quick_poll`` / ``run_panel`` wiring — verify they reach the
+  shared runners with the right inputs.
+* ``list_*`` / ``get_panel_result`` — delegate to :mod:`synth_panel.mcp.data`.
+* Validation errors for empty personas/questions + persona schema.
+* ``PanelResult`` dict-like compatibility (``__getitem__``, ``.to_dict``).
+* Zero reliance on the optional ``mcp`` extra — the SDK must import
+  cleanly without the ``mcp`` package.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_dir(tmp_path, monkeypatch):
+    """Point the persistence layer at a temp dir for every test."""
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    # Reset the module-level shared client so each test starts fresh.
+    import synth_panel.sdk as _sdk
+
+    _sdk._shared_client = None
+
+
+# ---------------------------------------------------------------------------
+# Surface: imports and __all__ contract
+# ---------------------------------------------------------------------------
+
+
+class TestImportSurface:
+    def test_eight_public_functions_reachable_from_root(self):
+        import synth_panel
+
+        for name in (
+            "run_prompt",
+            "quick_poll",
+            "run_panel",
+            "extend_panel",
+            "list_personas",
+            "list_instruments",
+            "list_panel_results",
+            "get_panel_result",
+        ):
+            assert hasattr(synth_panel, name), f"synth_panel.{name} is missing"
+            assert callable(getattr(synth_panel, name))
+
+    def test_three_result_dataclasses_reachable_from_root(self):
+        from synth_panel import PanelResult, PollResult, PromptResult
+
+        assert PanelResult.__name__ == "PanelResult"
+        assert PollResult.__name__ == "PollResult"
+        assert PromptResult.__name__ == "PromptResult"
+
+    def test_all_is_explicit_and_sorted(self):
+        import synth_panel
+
+        assert "__all__" in dir(synth_panel)
+        # No duplicates and each name is actually exported.
+        assert len(synth_panel.__all__) == len(set(synth_panel.__all__))
+        for name in synth_panel.__all__:
+            assert hasattr(synth_panel, name), f"__all__ names missing attribute: {name}"
+
+    def test_sdk_does_not_require_mcp_extra(self):
+        """Importing the SDK module must not trigger the mcp library.
+
+        synth_panel.sdk reaches into synth_panel.mcp.data (pure
+        yaml/json) but NOT into synth_panel.mcp.server (which imports
+        fastmcp). This test runs in an env where `mcp` is installed, so
+        we can only assert that fresh importing does not raise — the
+        stronger guarantee (SDK works without `[mcp]` extras) is
+        verified by the no-extras leg of CI.
+        """
+        import importlib
+
+        # Force a re-import to prove the module is self-sufficient.
+        import synth_panel.sdk
+
+        reloaded = importlib.reload(synth_panel.sdk)
+        assert hasattr(reloaded, "run_prompt")
+        assert hasattr(reloaded, "quick_poll")
+
+
+# ---------------------------------------------------------------------------
+# run_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestRunPrompt:
+    def test_returns_prompt_result_with_cost_and_usage(self):
+        from synth_panel import run_prompt
+        from synth_panel.llm.models import CompletionResponse, TextBlock, TokenUsage
+
+        mock_response = CompletionResponse(
+            id="resp-1",
+            model="claude-haiku-4-5-20251001",
+            content=[TextBlock(text="Hello back")],
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        )
+        with patch("synth_panel.sdk.LLMClient") as MockClient:
+            MockClient.return_value.send.return_value = mock_response
+            result = run_prompt("Say hello", model="haiku")
+
+        assert result.response == "Hello back"
+        assert result.model == "claude-haiku-4-5-20251001"
+        assert result.usage["input_tokens"] == 10
+        assert result.cost.startswith("$")
+
+    def test_empty_prompt_raises(self):
+        from synth_panel import run_prompt
+
+        with pytest.raises(ValueError, match="non-empty"):
+            run_prompt("")
+
+    def test_default_model_chosen_from_environment(self, monkeypatch):
+        """Default model follows the provider-preference chain in env."""
+        from synth_panel.sdk import _default_model
+
+        for key in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(key, raising=False)
+        assert _default_model() == "sonnet"
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert _default_model() == "gpt-4o-mini"
+
+
+# ---------------------------------------------------------------------------
+# quick_poll / run_panel
+# ---------------------------------------------------------------------------
+
+
+class TestQuickPoll:
+    def test_empty_question_raises(self):
+        from synth_panel import quick_poll
+
+        with pytest.raises(ValueError, match="non-empty"):
+            quick_poll("", personas=[{"name": "A"}])
+
+    def test_requires_personas_or_pack_id(self):
+        from synth_panel import quick_poll
+
+        with pytest.raises(ValueError, match="No personas"):
+            quick_poll("q?")
+
+    def test_calls_run_panel_sync_with_single_question(self):
+        """quick_poll wraps the question and drives the shared runner."""
+        from synth_panel import quick_poll
+        from synth_panel.cost import TokenUsage
+
+        fake_usage = TokenUsage(input_tokens=1, output_tokens=1)
+        fake_cost = MagicMock()
+        fake_cost.format_usd.return_value = "$0.01"
+        fake_cost.__add__ = lambda self, other: self
+
+        with (
+            patch("synth_panel.sdk.LLMClient"),
+            patch("synth_panel.sdk.run_panel_sync") as mock_runner,
+        ):
+            mock_runner.return_value = (
+                [],  # panelist_results
+                [{"persona": "A", "responses": [{"response": "ok"}], "usage": {}, "cost": "$0.01", "error": None}],
+                fake_usage,
+                fake_cost,
+                None,
+                None,
+            )
+            result = quick_poll("Does this work?", personas=[{"name": "A"}])
+
+        assert result.question == "Does this work?"
+        assert len(result.responses) == 1
+        # The runner was passed exactly one question, wrapping the string.
+        kwargs = mock_runner.call_args.kwargs
+        assert kwargs["questions"] == [{"text": "Does this work?"}]
+
+
+class TestRunPanel:
+    def test_requires_question_source(self):
+        from synth_panel import run_panel
+
+        with pytest.raises(ValueError, match="questions|instrument|instrument_pack"):
+            run_panel(personas=[{"name": "A"}])
+
+    def test_variants_out_of_range_raises(self):
+        from synth_panel import run_panel
+
+        with pytest.raises(ValueError, match="variants must be"):
+            run_panel(personas=[{"name": "A"}], questions=["q?"], variants=99)
+
+    def test_persona_without_name_raises(self):
+        from synth_panel import run_panel
+
+        with pytest.raises(ValueError, match="name"):
+            run_panel(personas=[{"age": 30}], questions=["q?"])
+
+    def test_question_strings_are_auto_wrapped(self):
+        """Pass a list of strings and they become question dicts."""
+        from synth_panel import run_panel
+        from synth_panel.cost import TokenUsage
+
+        fake_usage = TokenUsage(input_tokens=1, output_tokens=1)
+        fake_cost = MagicMock()
+        fake_cost.format_usd.return_value = "$0.01"
+
+        with (
+            patch("synth_panel.sdk.LLMClient"),
+            patch("synth_panel.sdk.run_panel_sync") as mock_runner,
+        ):
+            mock_runner.return_value = ([], [], fake_usage, fake_cost, None, None)
+            run_panel(
+                personas=[{"name": "Alice"}],
+                questions=["First?", "Second?"],
+            )
+            kwargs = mock_runner.call_args.kwargs
+            assert kwargs["questions"] == [{"text": "First?"}, {"text": "Second?"}]
+
+    def test_instrument_pack_takes_precedence_over_questions(self, monkeypatch):
+        """If instrument_pack is given, questions/instrument are ignored."""
+        from synth_panel import run_panel
+
+        # Mock the pack loader to return a tiny v1 instrument.
+        def fake_load_pack(name):
+            assert name == "dummy-pack"
+            return {
+                "name": "dummy-pack",
+                "instrument": {
+                    "version": 1,
+                    "questions": [{"text": "From pack"}],
+                },
+            }
+
+        monkeypatch.setattr("synth_panel.sdk._data_load_instrument_pack", fake_load_pack)
+
+        from synth_panel.cost import TokenUsage
+        from synth_panel.orchestrator import MultiRoundResult, RoundResult
+
+        # Stub the multi-round runner so we don't hit the network.
+        fake_mr = MultiRoundResult(
+            rounds=[
+                RoundResult(
+                    name="round_1",
+                    panelist_results=[],
+                    synthesis=None,
+                    usage=TokenUsage(input_tokens=0, output_tokens=0),
+                )
+            ],
+            path=[],
+            terminal_round="round_1",
+            final_synthesis=None,
+            warnings=[],
+            usage=TokenUsage(input_tokens=0, output_tokens=0),
+        )
+        with (
+            patch("synth_panel.sdk.LLMClient"),
+            patch("synth_panel.sdk.run_multi_round_sync", return_value=fake_mr) as mock_mr,
+        ):
+            out = run_panel(
+                personas=[{"name": "A"}],
+                instrument_pack="dummy-pack",
+                questions=["IGNORED"],
+            )
+        # The multi-round runner was called (instrument path won), not the
+        # single-round runner.
+        assert mock_mr.called
+        assert out.result_id
+
+
+# ---------------------------------------------------------------------------
+# list_* and get_panel_result
+# ---------------------------------------------------------------------------
+
+
+class TestListDelegates:
+    def test_list_personas_returns_bundled_packs(self):
+        from synth_panel import list_personas
+
+        packs = list_personas()
+        # At least one bundled pack ships with the package.
+        assert len(packs) >= 1
+        assert all("id" in p for p in packs)
+
+    def test_list_instruments_returns_bundled_packs(self):
+        from synth_panel import list_instruments
+
+        packs = list_instruments()
+        assert len(packs) >= 1
+        assert all("id" in p for p in packs)
+
+    def test_list_panel_results_empty_in_clean_dir(self):
+        from synth_panel import list_panel_results
+
+        assert list_panel_results() == []
+
+
+class TestGetPanelResult:
+    def test_returns_panel_result_dataclass(self):
+        from synth_panel import get_panel_result
+        from synth_panel.mcp.data import save_panel_result
+
+        rid = save_panel_result(
+            results=[{"persona": "A", "responses": [{"response": "hi"}]}],
+            model="haiku",
+            total_usage={"input_tokens": 1, "output_tokens": 1},
+            total_cost="$0.01",
+            persona_count=1,
+            question_count=1,
+        )
+
+        out = get_panel_result(rid)
+        assert out.result_id == rid
+        assert out.model == "haiku"
+        assert out.persona_count == 1
+        # Dict-like access for back-compat with callers that used to
+        # read the raw MCP payload.
+        assert out["model"] == "haiku"
+        assert "model" in out
+        assert out.to_dict()["model"] == "haiku"
+
+    def test_missing_result_raises_filenotfound(self):
+        from synth_panel import get_panel_result
+
+        with pytest.raises(FileNotFoundError):
+            get_panel_result("nope-does-not-exist")
+
+
+# ---------------------------------------------------------------------------
+# Extension path
+# ---------------------------------------------------------------------------
+
+
+class TestExtendPanel:
+    def test_missing_sessions_raises(self):
+        from synth_panel import extend_panel
+        from synth_panel.mcp.data import save_panel_result
+
+        # Save a result but don't save any sessions for it.
+        rid = save_panel_result(
+            results=[{"persona": "A", "responses": []}],
+            model="haiku",
+            total_usage={},
+            total_cost="$0",
+            persona_count=1,
+            question_count=1,
+        )
+        with pytest.raises((ValueError, FileNotFoundError)):
+            extend_panel(rid, "Follow-up?")


### PR DESCRIPTION
## Summary

Introduces a public Python SDK (`synth_panel.sdk`) — a thin, stable convenience layer over the existing runtime so external Python code can drive SynthPanel without going through the MCP server. Refactors the MCP server to share logic via a new internal `_runners` module, eliminating ~300 lines of duplication.

## Bead
- **Issue**: sp-2cw.1
- **Type**: task (P3)
- **Polecat**: capable

## Changes

- `src/synth_panel/sdk.py` (new, 1036 lines) — public SDK surface: one-shot prompt, panel runs, quick polls, extend-panel, persona/instrument pack helpers, result persistence
- `src/synth_panel/_runners.py` (new, 369 lines) — shared runner logic extracted from the MCP server
- `src/synth_panel/mcp/server.py` — slimmed from 366 → ~59 kept lines by delegating to `_runners` (net −307)
- `src/synth_panel/__init__.py` — re-export the public SDK names
- `tests/test_sdk.py` (new, 361 lines) — 21 new tests covering SDK entry points
- `examples/sdk_usage.py` — working example driving the SDK directly
- `README.md` — SDK quick-start section

## Testing
- Quality checks: pytest 943 passed (21 new), 86.65% coverage (≥80% gate)
- Rebase on main: clean, single commit

---
*Created by Gas Town Refinery*