### PR TITLE
feat(mcp): sampling fallback for run_prompt + run_quick_poll (sp-6at)

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ Add to your editor's MCP config (Claude Code, Cursor, Windsurf):
 }
 ```
 
+### Zero-config first run via sampling
+
+No API key? No problem. When the invoking MCP client (Claude Desktop,
+Claude Code, Cursor, Windsurf) advertises the `sampling` capability,
+synthpanel falls back to asking the client to run the LLM completion on
+its behalf — using the client's own subscription. That means `run_prompt`
+and small `run_quick_poll` calls (up to 3 personas) work with zero env
+setup:
+
+```json
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"]
+    }
+  }
+}
+```
+
+Sampling mode is great for first-touch UX and quick exploratory polls.
+For cross-provider ensembles, larger panels, and reproducible model
+versioning, set a provider key in `env` to graduate to BYOK. See
+[docs/mcp.md#sampling-mode](docs/mcp.md#sampling-mode) for the full
+matrix of when sampling kicks in and what it costs.
+
 ### Tools (12)
 
 | Tool | Description |

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -30,6 +30,9 @@ Add to your MCP config (e.g., `.claude/mcp.json`, `.cursor/mcp.json`):
 
 Set the environment variable for whichever LLM provider you want to use. See the main [README](../README.md#llm-provider-support) for the full provider table.
 
+Prefer a zero-config first run? Skip the `env` block entirely — see
+[Sampling Mode](#sampling-mode) below.
+
 ### Claude Code Plugin
 
 ```
@@ -137,6 +140,75 @@ All panel runs (`run_panel`, `run_quick_poll`, `extend_panel`) return a uniform 
 - `results` — back-compat flat array mirroring the terminal round's panelist results
 
 For v1/v2 instruments and raw `questions` input, `path` is empty or linear and `warnings` is typically empty — the shape is uniform across versions.
+
+## Sampling Mode
+
+MCP has a spec-level feature called
+[**sampling**](https://modelcontextprotocol.io/specification/2025-03-26/client/sampling)
+where the server can ask the invoking client to run an LLM completion
+on its behalf. synthpanel uses this to deliver a zero-configuration
+first-run UX: if you haven't set a provider API key and your client
+advertises `sampling`, the `run_prompt` and `run_quick_poll` tools
+borrow the client's own LLM access instead of failing.
+
+### When sampling kicks in
+
+| Client supports sampling? | Provider key set? | `use_sampling` flag | Mode |
+|---------------------------|-------------------|---------------------|------|
+| yes                       | no                | (auto)              | **sampling** |
+| yes                       | yes               | (auto)              | BYOK |
+| yes                       | (any)             | `true`              | **sampling** |
+| yes                       | (any)             | `false`             | BYOK |
+| no                        | no                | (auto)              | **friendly error** |
+| no                        | yes               | (auto)              | BYOK |
+| no                        | (any)             | `true`              | **error** — client lacks sampling |
+
+The auto logic only routes to sampling when it's *necessary* for a
+first-run experience (no keys set) — existing BYOK users see no change
+in behaviour.
+
+### Tradeoffs
+
+Sampling mode is intentionally less capable than BYOK:
+
+- **One provider.** The host agent picks the model (Claude Desktop →
+  Claude; other clients may route through whichever provider they have
+  configured). Cross-provider ensembles require BYOK.
+- **No cost accounting.** Token usage is charged to the host agent's
+  subscription; synthpanel returns `"usage": null` and `"cost": null`.
+- **Capped panel size.** `run_quick_poll` is limited to 3 personas in
+  sampling mode to protect the host agent's context window. Larger
+  runs require BYOK.
+- **No structured output extraction.** Free-text only.
+
+These limits keep sampling mode focused on what it's for: a frictionless
+first invocation that produces real results, not a replacement for the
+research-grade BYOK path.
+
+### Response fields
+
+Sampling responses include two extra fields:
+
+- `"mode"` — `"sampling"` or `"byok"` so downstream tooling can
+  condition on the execution mode.
+- `"hint"` — a one-line hint on the first sampling run explaining how
+  to upgrade to BYOK. Safe to surface to end users.
+
+### Opting in explicitly
+
+Pass `use_sampling=True` (or `use_sampling=False`) to either tool to
+override the automatic decision — useful when you have keys configured
+but want a quick sampling-mode preview, or when you want to force BYOK
+inside a sampling-capable client for reproducibility.
+
+### Tools that support sampling
+
+- `run_prompt` — no persona/question caps, fully supported.
+- `run_quick_poll` — up to `SAMPLING_MAX_PERSONAS` (3) personas.
+
+The remaining tools (`run_panel`, `extend_panel`, pack/result
+management) always use BYOK — heavier workflows benefit from direct
+provider access and structured outputs.
 
 ## Data Storage
 

--- a/src/synth_panel/mcp/sampling.py
+++ b/src/synth_panel/mcp/sampling.py
@@ -1,0 +1,236 @@
+"""MCP sampling bridge.
+
+MCP's *sampling* feature lets an MCP server ask the invoking client
+(Claude Desktop, Claude Code, Cursor, Windsurf, ...) to run an LLM
+completion on the server's behalf, using the client's own subscription
+or credentials. This lets synthpanel give first-time users a
+zero-configuration experience — no ``ANTHROPIC_API_KEY`` setup needed
+to fire their first prompt or quick poll.
+
+Design
+======
+
+Two routing decisions live here:
+
+1. **Can we sample?** — the client must advertise ``sampling`` capability
+   in its ``initialize`` handshake and a :class:`Context` must actually
+   be threaded through from the tool call. Exposed via
+   :func:`client_supports_sampling`.
+
+2. **Should we sample?** — we honour an explicit ``use_sampling`` flag
+   on the calling tool; otherwise we fall back to sampling only when no
+   BYOK credentials are present in the environment. Exposed via
+   :func:`decide_mode`.
+
+Tool handlers call :func:`sample_text` once the decision is made.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+# Sampling mode guardrails — keep invocations light so we don't blast
+# the host agent's context window. Heavy research panels still require
+# BYOK credentials.
+SAMPLING_MAX_PERSONAS = 3
+SAMPLING_MAX_QUESTIONS = 5
+SAMPLING_MAX_TOKENS_DEFAULT = 2048
+
+# Environment variables we treat as "BYOK present". Matches the provider
+# set in synth_panel.llm.providers.
+SAMPLING_CRED_ENV_VARS: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "XAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+)
+
+# First-run hint surfaced on successful sampling runs so users know they
+# can graduate to BYOK for larger panels / ensembles.
+SAMPLING_FIRST_RUN_HINT = (
+    "Running in host-agent sampling mode — synthpanel is borrowing your "
+    "MCP client's LLM access instead of calling a provider directly. For "
+    "cross-provider ensembles and larger panels, set ANTHROPIC_API_KEY "
+    "(or another provider key) in your environment and re-run. "
+    "See https://synthpanel.dev/mcp#credentials."
+)
+
+
+@dataclass
+class SamplingDecision:
+    """Outcome of :func:`decide_mode`.
+
+    Attributes:
+        mode: One of ``"sampling"``, ``"byok"``, or ``"error"``.
+        hint: When ``mode == "sampling"``, a one-line user hint to
+            surface in the response. ``None`` otherwise.
+        error: When ``mode == "error"``, a friendly error message
+            explaining how to unblock. ``None`` otherwise.
+    """
+
+    mode: str
+    hint: str | None = None
+    error: str | None = None
+
+
+def has_byok_credentials(env: dict[str, str] | None = None) -> bool:
+    """Return True when any provider env var is present and non-empty."""
+    source = env if env is not None else os.environ
+    return any(source.get(var, "").strip() for var in SAMPLING_CRED_ENV_VARS)
+
+
+def client_supports_sampling(ctx: Any) -> bool:
+    """Return True when the invoking MCP client advertised sampling.
+
+    ``ctx`` is a FastMCP :class:`mcp.server.fastmcp.Context`. We go
+    through the underlying :class:`ServerSession` because
+    ``check_client_capability`` is the supported way to interrogate the
+    client's declared capabilities. Any failure (no context, no session,
+    capability object not importable) is treated as "no sampling" — we
+    never want capability detection to raise into the tool handler.
+    """
+    if ctx is None:
+        return False
+
+    # ``ctx.session`` is a property that raises ValueError when the
+    # Context is constructed outside a live request (FastMCP test
+    # harness, synthetic invocations). We swallow any such failure —
+    # capability detection must never raise into a tool handler.
+    try:
+        session = ctx.session
+    except Exception:
+        return False
+    if session is None:
+        return False
+
+    try:
+        from mcp.types import ClientCapabilities, SamplingCapability
+
+        check = session.check_client_capability(ClientCapabilities(sampling=SamplingCapability()))
+    except Exception:
+        return False
+    return bool(check)
+
+
+def decide_mode(
+    ctx: Any,
+    *,
+    use_sampling: bool | None = None,
+    env: dict[str, str] | None = None,
+) -> SamplingDecision:
+    """Choose between sampling and BYOK for this tool call.
+
+    Args:
+        ctx: The FastMCP :class:`Context` passed into the tool.
+        use_sampling: Explicit override from the tool caller. ``True``
+            forces sampling (error if unsupported), ``False`` forces
+            BYOK, ``None`` picks automatically.
+        env: Optional env dict for testing. Defaults to ``os.environ``.
+
+    Rules (in order):
+        * ``use_sampling=True`` + client supports sampling → sampling.
+        * ``use_sampling=True`` + client does NOT support sampling →
+          error (explains the client must advertise ``sampling``).
+        * ``use_sampling=False`` → BYOK unconditionally.
+        * Auto + no creds + client supports sampling → sampling.
+        * Auto + no creds + no sampling → error (set an API key OR use
+          a sampling-capable client).
+        * Auto + creds present → BYOK (preserves existing behaviour
+          and keeps ensemble / multi-provider features available).
+    """
+    supports = client_supports_sampling(ctx)
+    has_creds = has_byok_credentials(env)
+
+    if use_sampling is True:
+        if supports:
+            return SamplingDecision(mode="sampling", hint=SAMPLING_FIRST_RUN_HINT)
+        return SamplingDecision(
+            mode="error",
+            error=(
+                "use_sampling=True was requested, but the invoking MCP "
+                "client did not advertise the 'sampling' capability. "
+                "Either run synthpanel from a sampling-capable client "
+                "(Claude Desktop, Claude Code, Cursor, Windsurf) or set "
+                "a provider API key (e.g. ANTHROPIC_API_KEY) to use BYOK."
+            ),
+        )
+
+    if use_sampling is False:
+        return SamplingDecision(mode="byok")
+
+    # Auto mode.
+    if has_creds:
+        return SamplingDecision(mode="byok")
+    if supports:
+        return SamplingDecision(mode="sampling", hint=SAMPLING_FIRST_RUN_HINT)
+    return SamplingDecision(
+        mode="error",
+        error=(
+            "No provider credentials found (ANTHROPIC_API_KEY / "
+            "OPENAI_API_KEY / XAI_API_KEY / GOOGLE_API_KEY) and the "
+            "invoking MCP client did not advertise 'sampling' capability. "
+            "Set a provider key in your environment, or run synthpanel "
+            "from a sampling-capable client such as Claude Desktop. "
+            "See https://synthpanel.dev/mcp#credentials."
+        ),
+    )
+
+
+async def sample_text(
+    ctx: Any,
+    *,
+    prompt: str,
+    system_prompt: str | None = None,
+    max_tokens: int = SAMPLING_MAX_TOKENS_DEFAULT,
+    temperature: float | None = None,
+) -> dict[str, Any]:
+    """Run one sampling round via ``ctx.session.create_message``.
+
+    Returns a dict with keys ``text``, ``model``, ``stop_reason``, and
+    ``role``. The model string is whatever the host agent chose to run
+    (e.g. ``"claude-opus-4-6"`` when invoked from Claude Desktop). We
+    normalise content blocks to a single joined string so downstream
+    consumers don't have to special-case multi-block responses.
+    """
+    from mcp.types import SamplingMessage, TextContent
+
+    messages = [
+        SamplingMessage(
+            role="user",
+            content=TextContent(type="text", text=prompt),
+        )
+    ]
+    result = await ctx.session.create_message(
+        messages=messages,
+        max_tokens=max_tokens,
+        system_prompt=system_prompt,
+        temperature=temperature,
+    )
+
+    text = _extract_text(result.content)
+    return {
+        "text": text,
+        "model": result.model,
+        "stop_reason": getattr(result, "stopReason", None),
+        "role": result.role,
+    }
+
+
+def _extract_text(content: Any) -> str:
+    """Flatten sampling result content into a single text string."""
+    # ``content`` may be a single TextContent/ImageContent or a list of
+    # them. We only surface text — image/audio content from the host
+    # agent isn't useful to the panel simulation, so it's silently
+    # dropped with a newline join between blocks.
+    if content is None:
+        return ""
+    blocks = content if isinstance(content, list) else [content]
+    parts: list[str] = []
+    for block in blocks:
+        btype = getattr(block, "type", None)
+        if btype == "text":
+            parts.append(getattr(block, "text", ""))
+    return "\n".join(p for p in parts if p)

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -93,6 +93,16 @@ from synth_panel.mcp.data import (
 from synth_panel.mcp.data import (
     save_persona_pack as _data_save_persona_pack,
 )
+from synth_panel.mcp.sampling import (
+    SAMPLING_MAX_PERSONAS,
+    SAMPLING_MAX_QUESTIONS,
+)
+from synth_panel.mcp.sampling import (
+    decide_mode as _decide_sampling_mode,
+)
+from synth_panel.mcp.sampling import (
+    sample_text as _sample_text,
+)
 from synth_panel.metadata import PanelTimer, build_metadata
 from synth_panel.orchestrator import (
     MultiRoundResult,
@@ -114,6 +124,8 @@ __all__ = [
     "MAX_QUESTIONS",
     "MCP_DEFAULT_MODEL",
     "PANELIST_TIMEOUT",
+    "SAMPLING_MAX_PERSONAS",
+    "SAMPLING_MAX_QUESTIONS",
     "_compute_variant_data",
     "mcp",
     "serve",
@@ -513,20 +525,63 @@ async def run_prompt(
     model: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    use_sampling: bool | None = None,
+    ctx: Context = None,
 ) -> str:
     """Send a single prompt to an LLM and get a response. No personas required.
 
     The simplest tool — ask a quick research question without constructing
     personas or running a full panel.
 
+    Two execution modes:
+
+    * **BYOK** (bring-your-own-key): calls a provider directly using env
+      credentials (``ANTHROPIC_API_KEY``, etc.). Supports the full model
+      list and per-call cost accounting.
+    * **Sampling**: when no creds are set and the invoking MCP client
+      (Claude Desktop, Claude Code, Cursor, Windsurf) advertises the
+      ``sampling`` capability, synthpanel asks the client to run the
+      completion itself. Model is whatever the host agent is using, and
+      token cost is charged to the host agent's subscription rather
+      than reported here.
+
     Args:
         prompt: The question or prompt to send.
-        model: LLM model to use. Defaults to haiku.
+        model: LLM model to use. Defaults to haiku. Ignored in sampling
+            mode (the host agent picks its own model).
         temperature: Sampling temperature (0.0-1.0). Controls randomness.
-        top_p: Nucleus sampling threshold (0.0-1.0). Alternative to temperature.
+        top_p: Nucleus sampling threshold (0.0-1.0). Alternative to
+            temperature. Ignored in sampling mode.
+        use_sampling: Explicit mode override. ``True`` forces sampling
+            (error if unsupported), ``False`` forces BYOK. ``None``
+            auto-picks based on creds + client capability.
     """
     model = model or MCP_DEFAULT_MODEL
-    logger.info("run_prompt: model=%s prompt_len=%d", model, len(prompt))
+    decision = _decide_sampling_mode(ctx, use_sampling=use_sampling)
+    logger.info("run_prompt: mode=%s model=%s prompt_len=%d", decision.mode, model, len(prompt))
+
+    if decision.mode == "error":
+        return json.dumps({"error": decision.error})
+
+    if decision.mode == "sampling":
+        sample = await _sample_text(
+            ctx,
+            prompt=prompt,
+            max_tokens=4096,
+            temperature=temperature,
+        )
+        return json.dumps(
+            {
+                "response": sample["text"],
+                "model": sample["model"],
+                "mode": "sampling",
+                "usage": None,
+                "cost": None,
+                "hint": decision.hint,
+            },
+            indent=2,
+        )
+
     client = _get_shared_client()
     request = CompletionRequest(
         model=model,
@@ -548,6 +603,7 @@ async def run_prompt(
         {
             "response": response.text,
             "model": response.model,
+            "mode": "byok",
             "usage": usage.to_dict(),
             "cost": cost.format_usd(),
         },
@@ -768,6 +824,7 @@ async def run_quick_poll(
     synthesis_prompt: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    use_sampling: bool | None = None,
     ctx: Context = None,
 ) -> str:
     """Quick single-question poll across personas.
@@ -775,22 +832,35 @@ async def run_quick_poll(
     A simplified version of run_panel for quick feedback on one question.
     Includes synthesis by default.
 
+    When no provider credentials are set and the invoking MCP client
+    advertises the ``sampling`` capability, the poll runs in
+    **sampling mode**: synthpanel asks the host agent to run each
+    persona's completion using its own LLM access, so the user can run
+    their first poll with zero configuration. Sampling mode is capped
+    at :data:`SAMPLING_MAX_PERSONAS` personas to keep the host agent's
+    context footprint small — larger panels require BYOK credentials.
+
     Args:
         question: The question to ask all personas.
         personas: List of persona definitions.
-        model: LLM model to use. Defaults to haiku.
+        model: LLM model to use. Defaults to haiku. Ignored in sampling
+            mode (the host agent picks its own model).
         response_schema: Optional JSON Schema for structured output. When
             provided, responses are extracted as structured JSON matching
-            this schema instead of free text.
+            this schema instead of free text. Not supported in sampling
+            mode — raw text is returned instead.
         synthesis: Whether to run synthesis after collecting responses.
-            Defaults to true.
+            Defaults to true. In sampling mode synthesis is also
+            performed via the host agent.
         synthesis_model: Model to use for synthesis. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt. Replaces the default.
         temperature: Sampling temperature (0.0-1.0). Controls randomness.
         top_p: Nucleus sampling threshold (0.0-1.0). Alternative to temperature.
+        use_sampling: Explicit mode override. ``True`` forces sampling
+            (error if unsupported), ``False`` forces BYOK. ``None``
+            auto-picks based on creds + client capability.
     """
     model = model or MCP_DEFAULT_MODEL
-    logger.info("run_quick_poll: model=%s personas=%d", model, len(personas))
 
     if not question or not question.strip():
         return json.dumps({"error": "Question text must be a non-empty string."})
@@ -805,6 +875,36 @@ async def run_quick_poll(
     if len(personas) > MAX_PERSONAS:
         return json.dumps({"error": f"Too many personas ({len(personas)}). Maximum is {MAX_PERSONAS}."})
 
+    decision = _decide_sampling_mode(ctx, use_sampling=use_sampling)
+    logger.info("run_quick_poll: mode=%s model=%s personas=%d", decision.mode, model, len(personas))
+
+    if decision.mode == "error":
+        return json.dumps({"error": decision.error})
+
+    if decision.mode == "sampling":
+        if len(personas) > SAMPLING_MAX_PERSONAS:
+            return json.dumps(
+                {
+                    "error": (
+                        f"Sampling mode is capped at {SAMPLING_MAX_PERSONAS} personas "
+                        f"to protect the host agent's context window (got "
+                        f"{len(personas)}). Set ANTHROPIC_API_KEY (or another "
+                        f"provider key) in your environment to run larger panels "
+                        f"via BYOK."
+                    )
+                }
+            )
+        result = await _run_quick_poll_sampling(
+            ctx,
+            question=question,
+            personas=personas,
+            synthesis=synthesis,
+            synthesis_prompt=synthesis_prompt,
+            temperature=temperature,
+            hint=decision.hint,
+        )
+        return json.dumps(result, indent=2)
+
     questions = [{"text": question}]
     result = await _run_panel_async(
         personas,
@@ -818,7 +918,103 @@ async def run_quick_poll(
         temperature=temperature,
         top_p=top_p,
     )
+    result["mode"] = "byok"
     return json.dumps(result, indent=2)
+
+
+async def _run_quick_poll_sampling(
+    ctx: Context,
+    *,
+    question: str,
+    personas: list[dict[str, Any]],
+    synthesis: bool,
+    synthesis_prompt: str | None,
+    temperature: float | None,
+    hint: str | None,
+) -> dict[str, Any]:
+    """Run a quick poll via MCP sampling.
+
+    One ``create_message`` call per persona (serial — host agents
+    generally rate-limit sampling), plus one synthesis call when
+    enabled. The result shape deliberately mirrors the BYOK
+    :func:`_run_panel_async` output for the fields callers care about
+    (``results``, ``synthesis``, ``rounds``, ``persona_count``,
+    ``question_count``) so downstream tooling works uniformly across
+    modes. Fields that only make sense in BYOK (``usage``, ``cost``,
+    ``metadata``) are ``None``.
+    """
+    from synth_panel.prompts import SYNTHESIS_PROMPT
+
+    await ctx.report_progress(0, len(personas))
+    panelist_entries: list[dict[str, Any]] = []
+    host_model: str | None = None
+    for i, persona in enumerate(personas):
+        system_prompt = persona_system_prompt(persona)
+        user_prompt = build_question_prompt({"text": question})
+        sample = await _sample_text(
+            ctx,
+            prompt=user_prompt,
+            system_prompt=system_prompt,
+            max_tokens=2048,
+            temperature=temperature,
+        )
+        host_model = sample["model"]
+        panelist_entries.append(
+            {
+                "persona": persona,
+                "responses": [
+                    {
+                        "question": question,
+                        "answer": sample["text"],
+                    }
+                ],
+                "model": sample["model"],
+                "usage": None,
+            }
+        )
+        await ctx.report_progress(i + 1, len(personas))
+
+    synthesis_block: dict[str, Any] | None = None
+    if synthesis and panelist_entries:
+        synth_prompt = synthesis_prompt or SYNTHESIS_PROMPT
+        rendered_panel = "\n\n".join(
+            f"Panelist: {entry['persona'].get('name', 'anon')}\nQ: {question}\nA: {entry['responses'][0]['answer']}"
+            for entry in panelist_entries
+        )
+        synth = await _sample_text(
+            ctx,
+            prompt=rendered_panel,
+            system_prompt=synth_prompt,
+            max_tokens=2048,
+            temperature=temperature,
+        )
+        synthesis_block = {
+            "summary": synth["text"],
+            "model": synth["model"],
+            "usage": None,
+        }
+
+    return {
+        "mode": "sampling",
+        "hint": hint,
+        "model": host_model,
+        "persona_count": len(personas),
+        "question_count": 1,
+        "results": panelist_entries,
+        "rounds": [
+            {
+                "name": "default",
+                "results": panelist_entries,
+                "synthesis": synthesis_block,
+            }
+        ],
+        "synthesis": synthesis_block,
+        "path": [],
+        "warnings": [],
+        "usage": None,
+        "cost": None,
+        "metadata": None,
+    }
 
 
 @mcp.tool()

--- a/tests/test_mcp_sampling.py
+++ b/tests/test_mcp_sampling.py
@@ -1,0 +1,333 @@
+"""Tests for MCP sampling bridge (``synth_panel.mcp.sampling``).
+
+Covers the four routing branches required by sp-6at:
+
+1. sampling supported + no creds  → sampling path
+2. sampling supported + creds     → BYOK path (default)
+3. sampling supported + creds + ``use_sampling=True`` → sampling path
+4. no sampling + no creds         → friendly error
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+# ---------------------------------------------------------------------------
+# Env fixture — sampling tests own their env explicitly, overriding the
+# BYOK-simulating default from tests/test_mcp_server.py.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(tmp_path, monkeypatch):
+    """Scrub provider env vars — sampling tests opt into them per-case."""
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the pure helpers in synth_panel.mcp.sampling
+# ---------------------------------------------------------------------------
+
+
+class TestHasByokCredentials:
+    def test_no_creds_returns_false(self):
+        from synth_panel.mcp.sampling import has_byok_credentials
+
+        assert has_byok_credentials({}) is False
+
+    def test_any_known_var_returns_true(self, monkeypatch):
+        from synth_panel.mcp.sampling import has_byok_credentials
+
+        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+            assert has_byok_credentials({var: "x"}) is True, var
+
+    def test_empty_string_is_not_creds(self):
+        from synth_panel.mcp.sampling import has_byok_credentials
+
+        assert has_byok_credentials({"ANTHROPIC_API_KEY": "   "}) is False
+
+
+class TestClientSupportsSampling:
+    def test_none_ctx_returns_false(self):
+        from synth_panel.mcp.sampling import client_supports_sampling
+
+        assert client_supports_sampling(None) is False
+
+    def test_session_raising_property_returns_false(self):
+        """``ctx.session`` outside a request raises — must not propagate."""
+        from synth_panel.mcp.sampling import client_supports_sampling
+
+        ctx = MagicMock()
+        # Simulate FastMCP Context.session property raising ValueError
+        type(ctx).session = property(lambda self: (_ for _ in ()).throw(ValueError("outside request")))
+        assert client_supports_sampling(ctx) is False
+
+    def test_session_check_returns_true(self):
+        from synth_panel.mcp.sampling import client_supports_sampling
+
+        ctx = MagicMock()
+        ctx.session.check_client_capability.return_value = True
+        assert client_supports_sampling(ctx) is True
+
+    def test_session_check_returns_false(self):
+        from synth_panel.mcp.sampling import client_supports_sampling
+
+        ctx = MagicMock()
+        ctx.session.check_client_capability.return_value = False
+        assert client_supports_sampling(ctx) is False
+
+
+class TestDecideMode:
+    """The four-branch routing matrix — the heart of the acceptance tests."""
+
+    def _ctx(self, *, supports: bool):
+        ctx = MagicMock()
+        ctx.session.check_client_capability.return_value = supports
+        return ctx
+
+    def test_auto_sampling_supported_no_creds_picks_sampling(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        d = decide_mode(self._ctx(supports=True), env={})
+        assert d.mode == "sampling"
+        assert d.hint is not None  # first-run hint
+
+    def test_auto_sampling_supported_with_creds_picks_byok(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        d = decide_mode(
+            self._ctx(supports=True),
+            env={"ANTHROPIC_API_KEY": "sk-x"},
+        )
+        assert d.mode == "byok"
+        assert d.hint is None
+
+    def test_auto_no_sampling_no_creds_returns_friendly_error(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        d = decide_mode(self._ctx(supports=False), env={})
+        assert d.mode == "error"
+        assert d.error is not None
+        assert "ANTHROPIC_API_KEY" in d.error
+        assert "sampling-capable" in d.error
+
+    def test_explicit_use_sampling_true_with_creds_picks_sampling(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        d = decide_mode(
+            self._ctx(supports=True),
+            use_sampling=True,
+            env={"ANTHROPIC_API_KEY": "sk-x"},
+        )
+        assert d.mode == "sampling"
+
+    def test_explicit_use_sampling_true_but_unsupported_errors(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        d = decide_mode(self._ctx(supports=False), use_sampling=True, env={})
+        assert d.mode == "error"
+        assert "use_sampling=True" in d.error
+
+    def test_explicit_use_sampling_false_forces_byok(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        d = decide_mode(self._ctx(supports=True), use_sampling=False, env={})
+        assert d.mode == "byok"
+
+
+# ---------------------------------------------------------------------------
+# Integration — run_prompt across the four branches
+# ---------------------------------------------------------------------------
+
+
+def _make_sampling_ctx(supports: bool, *, sample_text: str = "sampled!"):
+    """Build a MagicMock Context that the tool can invoke without
+    hitting the FastMCP test harness's Context auto-injection path."""
+    ctx = MagicMock()
+    ctx.session.check_client_capability.return_value = supports
+
+    async def _create_message(**kwargs: Any):
+        # Mimic CreateMessageResult — only the fields _sample_text reads.
+        msg = MagicMock()
+        text_block = MagicMock()
+        text_block.type = "text"
+        text_block.text = sample_text
+        msg.content = text_block
+        msg.model = "host-agent-model"
+        msg.role = "assistant"
+        msg.stopReason = "endTurn"
+        return msg
+
+    ctx.session.create_message = AsyncMock(side_effect=_create_message)
+    ctx.report_progress = AsyncMock()
+    return ctx
+
+
+class TestRunPromptSamplingBranches:
+    @pytest.mark.asyncio
+    async def test_sampling_supported_no_creds_uses_sampling(self):
+        from synth_panel.mcp.server import run_prompt
+
+        ctx = _make_sampling_ctx(supports=True, sample_text="hi from host")
+        raw = await run_prompt(prompt="Say hi", ctx=ctx)
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        assert data["response"] == "hi from host"
+        assert data["model"] == "host-agent-model"
+        assert data["hint"] is not None
+        ctx.session.create_message.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_sampling_supported_with_creds_uses_byok(self, monkeypatch):
+        from synth_panel.llm.models import CompletionResponse, TextBlock, TokenUsage
+        from synth_panel.mcp.server import run_prompt
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        ctx = _make_sampling_ctx(supports=True)
+
+        mock_response = CompletionResponse(
+            id="r",
+            model="claude-haiku-4-5-20251001",
+            content=[TextBlock(text="byok-output")],
+            usage=TokenUsage(input_tokens=3, output_tokens=2),
+        )
+        with (
+            patch("synth_panel.mcp.server._shared_client", None),
+            patch("synth_panel.mcp.server.LLMClient") as MockClient,
+        ):
+            MockClient.return_value.send.return_value = mock_response
+            raw = await run_prompt(prompt="Hi", ctx=ctx)
+
+        data = json.loads(raw)
+        assert data["mode"] == "byok"
+        assert data["response"] == "byok-output"
+        ctx.session.create_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_explicit_use_sampling_overrides_creds(self, monkeypatch):
+        from synth_panel.mcp.server import run_prompt
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        ctx = _make_sampling_ctx(supports=True, sample_text="sampled-anyway")
+
+        raw = await run_prompt(prompt="Hi", use_sampling=True, ctx=ctx)
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        assert data["response"] == "sampled-anyway"
+
+    @pytest.mark.asyncio
+    async def test_no_sampling_no_creds_returns_friendly_error(self):
+        from synth_panel.mcp.server import run_prompt
+
+        ctx = _make_sampling_ctx(supports=False)
+        raw = await run_prompt(prompt="Hi", ctx=ctx)
+        data = json.loads(raw)
+
+        assert "error" in data
+        assert "ANTHROPIC_API_KEY" in data["error"]
+        ctx.session.create_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_use_sampling_true_but_unsupported_errors(self):
+        from synth_panel.mcp.server import run_prompt
+
+        ctx = _make_sampling_ctx(supports=False)
+        raw = await run_prompt(prompt="Hi", use_sampling=True, ctx=ctx)
+        data = json.loads(raw)
+
+        assert "error" in data
+        assert "use_sampling=True" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — run_quick_poll sampling path
+# ---------------------------------------------------------------------------
+
+
+class TestRunQuickPollSampling:
+    @pytest.mark.asyncio
+    async def test_sampling_runs_per_persona_and_synthesis(self):
+        from synth_panel.mcp.server import run_quick_poll
+
+        ctx = _make_sampling_ctx(supports=True, sample_text="persona response")
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        raw = await run_quick_poll(
+            question="Is the sky blue?",
+            personas=personas,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        assert data["persona_count"] == 2
+        assert data["question_count"] == 1
+        assert len(data["results"]) == 2
+        assert data["synthesis"] is not None
+        # 2 persona calls + 1 synthesis call
+        assert ctx.session.create_message.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_sampling_persona_cap_enforced(self):
+        from synth_panel.mcp.server import SAMPLING_MAX_PERSONAS, run_quick_poll
+
+        ctx = _make_sampling_ctx(supports=True)
+        personas = [{"name": f"P{i}"} for i in range(SAMPLING_MAX_PERSONAS + 1)]
+        raw = await run_quick_poll(
+            question="test?",
+            personas=personas,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        assert "error" in data
+        assert f"{SAMPLING_MAX_PERSONAS} personas" in data["error"]
+        ctx.session.create_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_byok_path_unchanged_with_creds(self, monkeypatch):
+        from synth_panel.mcp.server import run_quick_poll
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        ctx = _make_sampling_ctx(supports=True)
+
+        mock_run = AsyncMock(return_value={"results": [], "model": "haiku"})
+        with patch("synth_panel.mcp.server._run_panel_async", mock_run):
+            raw = await run_quick_poll(
+                question="q?",
+                personas=[{"name": "Alice"}],
+                ctx=ctx,
+            )
+        data = json.loads(raw)
+        assert data["mode"] == "byok"
+        mock_run.assert_awaited_once()
+        ctx.session.create_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_sampling_no_creds_returns_error(self):
+        from synth_panel.mcp.server import run_quick_poll
+
+        ctx = _make_sampling_ctx(supports=False)
+        raw = await run_quick_poll(
+            question="q?",
+            personas=[{"name": "Alice"}],
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        assert "error" in data
+        assert "ANTHROPIC_API_KEY" in data["error"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -12,8 +12,14 @@ pytest.importorskip("mcp")
 
 @pytest.fixture(autouse=True)
 def _data_dir(tmp_path, monkeypatch):
-    """Point data dir at temp for all tests."""
+    """Point data dir at temp for all tests.
+
+    Also sets a fake ``ANTHROPIC_API_KEY`` so tests simulate the BYOK
+    path by default — the sampling-mode tests clear these env vars
+    explicitly to exercise the sampling branch.
+    """
     monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-placeholder")
 
 
 from synth_panel.mcp.server import MCP_DEFAULT_MODEL, mcp


### PR DESCRIPTION
## Summary

Adds MCP sampling fallback (spec 2025-03-26) so first-time users in Claude Desktop/Cursor/Windsurf get a working experience without configuring their own provider API key.

- `run_prompt` and `run_quick_poll` now detect missing provider credentials and fall back to `ctx.sample()` via the invoking agent.
- Budget guard: sampling mode is restricted to lightweight calls (configurable persona/question caps); heavy `run_panel` ensembles still require BYOK.
- New `src/synth_panel/mcp/sampling.py` (236 lines) isolates the fallback adapter.
- Docs: `docs/mcp.md` (+72) and README (+26) document the new default behavior and BYOK-vs-sampling tradeoffs.
- Tests: `tests/test_mcp_sampling.py` (333 lines, new) + `tests/test_mcp_server.py` adjustments.

## Source
- MR: sp-wisp-azk
- Source issue: sp-6at (MCP sampling support for lightweight tools)
- Worker: synthpanel/polecats/capable

## Test plan
- [ ] CI: lint / typecheck / security / coverage / test (3.10–3.14)
- [ ] CodeQL (actions + python)
- [ ] Dependency Review
- [ ] Cloudflare Pages preview