### PR TITLE
feat(docker): publish runtime image to GHCR + Docker Hub on tagged releases (sp-2cw.5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,71 @@
+# Keep the build context lean. Anything not listed in the Dockerfile's
+# COPY statements is dead weight and slows builds + leaks size into layers.
+
+# VCS / CI / dev-only tooling
+.git
+.github
+.gitignore
+.pre-commit-config.yaml
+.devcontainer
+.claude
+.claude-plugin
+.runtime
+.logs
+.beads
+.ruff_cache
+
+# Build / test artifacts
+__pycache__
+*.py[cod]
+*.egg-info
+*.egg
+.eggs
+build
+dist
+.coverage
+.coverage.*
+htmlcov
+.pytest_cache
+.mypy_cache
+.tox
+
+# Virtual environments
+.venv
+venv
+env
+
+# uv
+uv.lock
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Runtime state
+state.json
+
+# Docs / site / examples / tests are not needed in the runtime image
+docs
+site
+examples
+tests
+templates
+skills
+SPEC.md
+CHANGELOG.md
+CONTRIBUTING.md
+CODE_OF_CONDUCT.md
+SECURITY.md
+CLAUDE.md
+CLAUDE.local.md
+AGENTS.md
+
+# Environment files — never bake credentials into images
+.env
+.env.*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,167 @@
+name: Build and Publish Docker Image
+
+# Builds the production runtime image (Dockerfile at repo root) and pushes
+# it to both GitHub Container Registry and Docker Hub. Tagged-release-only;
+# main pushes do not republish images (mirrors the publish.yml policy).
+#
+# Triggers:
+#   - tag push matching v*           (normal release path)
+#   - workflow_dispatch              (manual republish, takes a tag input)
+#
+# Required repo secrets:
+#   DOCKERHUB_USERNAME   Docker Hub user/org with push access to synthpanel/synthpanel
+#   DOCKERHUB_TOKEN      Docker Hub access token (NOT account password)
+#
+# GHCR uses GITHUB_TOKEN with packages:write — no extra secret needed.
+#
+# Action refs are tag-pinned for now; renovate (config:recommended +
+# matchManagers github-actions) will pin them to SHAs on its next run,
+# matching the pattern in ci.yml / publish.yml.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to (re)publish (e.g. v0.9.1). Must exist in the repo."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: docker
+    steps:
+      - name: Determine tag, version, and build date
+        id: ref
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "$INPUT_TAG" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
+          if [ -z "$TAG" ]; then
+            echo "::error::Could not determine release tag from event context"
+            exit 1
+          fi
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$ ]]; then
+            echo "::error::Tag '$TAG' does not look like a semver release (vMAJOR.MINOR.PATCH[-pre])."
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          # Pre-releases (anything with a hyphen, e.g. v0.9.1-rc.1) get only
+          # the exact version tag; stable releases also get latest + major +
+          # major.minor floats.
+          if [[ "$TAG" == *-* ]]; then
+            IS_STABLE=false
+          else
+            IS_STABLE=true
+          fi
+          {
+            echo "tag=$TAG"
+            echo "version=$VERSION"
+            echo "is_stable=$IS_STABLE"
+            echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          } >> "$GITHUB_OUTPUT"
+          echo "Building tag $TAG (version $VERSION, stable=$IS_STABLE)"
+
+      - name: Checkout at tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ steps.ref.outputs.tag }}
+          persist-credentials: false
+
+      - name: Set up QEMU (multi-arch emulation)
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute image tag list
+        id: tags
+        env:
+          VERSION: ${{ steps.ref.outputs.version }}
+          IS_STABLE: ${{ steps.ref.outputs.is_stable }}
+        run: |
+          set -euo pipefail
+          IMAGES=("ghcr.io/dataviking-tech/synthpanel" "synthpanel/synthpanel")
+          MAJOR="${VERSION%%.*}"
+          REST="${VERSION#*.}"
+          MINOR="${REST%%.*}"
+          TAGS=()
+          for img in "${IMAGES[@]}"; do
+            TAGS+=("${img}:${VERSION}")
+            if [ "$IS_STABLE" = "true" ]; then
+              TAGS+=("${img}:${MAJOR}.${MINOR}" "${img}:${MAJOR}" "${img}:latest")
+            fi
+          done
+          # Newline-separated for build-push-action's `tags:` input.
+          {
+            echo "tags<<EOF"
+            printf '%s\n' "${TAGS[@]}"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            SYNTHPANEL_VERSION=${{ steps.ref.outputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.ref.outputs.build_date }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summarize push
+        env:
+          VERSION: ${{ steps.ref.outputs.version }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.tags.outputs.tags }}
+        run: |
+          {
+            echo "## Pushed synthpanel ${VERSION}"
+            echo ""
+            echo "**Digest:** \`${DIGEST}\`"
+            echo ""
+            echo "**Tags:**"
+            echo ""
+            echo '```'
+            echo "${TAGS}"
+            echo '```'
+            echo ""
+            echo "**Try it:**"
+            echo '```bash'
+            echo "docker pull ghcr.io/dataviking-tech/synthpanel:${VERSION}"
+            echo "docker run --rm -e ANTHROPIC_API_KEY=\$KEY synthpanel/synthpanel:${VERSION} prompt 'hello'"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Added
+- (sp-2cw.5) Production Docker image published to `ghcr.io/dataviking-tech/synthpanel` and `synthpanel/synthpanel` on tagged releases. Multi-arch (linux/amd64, linux/arm64), python:3.12-slim base, default CMD is `synthpanel mcp-serve`. Reads provider keys from env (`ANTHROPIC_API_KEY` etc.). New CI workflow `.github/workflows/docker.yml` builds and pushes on `v*` tag push or `workflow_dispatch`. README gains a "Run via Docker" section and a GHCR badge.
+
 ## [0.9.0] - 2026-04-15
 
 ### Public Launch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,87 @@
+# syntax=docker/dockerfile:1.7
+#
+# Production runtime image for synthpanel.
+#
+# This image is sized for ephemeral / serverless invocation (Lambda, Cloud Run,
+# GitHub Actions, n8n, etc.) — small footprint, no editor tooling. The
+# devcontainer at .devcontainer/devcontainer.json remains the source of truth
+# for *development*; this file is a slimmed-down production sibling.
+#
+# Default CMD launches the MCP server on stdio. Override with any synthpanel
+# subcommand:
+#
+#   docker run --rm -e ANTHROPIC_API_KEY=$KEY synthpanel/synthpanel \
+#     prompt "Say hello"
+#
+# Build:
+#   docker build -t synthpanel:local .
+#
+# Multi-arch builds happen in CI via .github/workflows/docker.yml.
+
+ARG PYTHON_VERSION=3.12
+
+# ---------- builder ----------
+FROM python:${PYTHON_VERSION}-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /build
+
+# Copy only what's needed to build the wheel. Source layout matches
+# pyproject.toml's [tool.setuptools.packages.find] (where = ["src"]).
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+
+RUN pip install --upgrade pip build \
+ && python -m build --wheel --outdir /build/dist
+
+# ---------- runtime ----------
+FROM python:${PYTHON_VERSION}-slim AS runtime
+
+ARG SYNTHPANEL_VERSION=unknown
+ARG VCS_REF=unknown
+ARG BUILD_DATE=unknown
+
+LABEL org.opencontainers.image.title="synthpanel" \
+      org.opencontainers.image.description="Run synthetic focus groups using AI personas. CLI, Python library, and MCP server." \
+      org.opencontainers.image.url="https://synthpanel.dev" \
+      org.opencontainers.image.documentation="https://github.com/DataViking-Tech/SynthPanel#readme" \
+      org.opencontainers.image.source="https://github.com/DataViking-Tech/SynthPanel" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="DataViking-Tech" \
+      org.opencontainers.image.version="${SYNTHPANEL_VERSION}" \
+      org.opencontainers.image.revision="${VCS_REF}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Non-root user — Lambda and Cloud Run both honor USER, and avoiding root
+# is good practice for any ephemeral container. UID 1000 (not --system) so
+# bind mounts from host UID 1000 are writable in dev workflows.
+RUN groupadd --gid 1000 synthpanel \
+ && useradd --uid 1000 --gid synthpanel --create-home --home-dir /home/synthpanel synthpanel
+
+COPY --from=builder /build/dist/*.whl /tmp/
+
+# Install with [mcp] extras so `mcp-serve` works out of the box. The MCP
+# server is the primary use case for this image (agent tool-call target).
+# The shell-form RUN resolves the wheel via a variable so the [mcp] extras
+# suffix doesn't get interpreted as a shell character class against the
+# glob.
+RUN set -eux \
+ && wheel="$(ls /tmp/synthpanel-*.whl | head -n1)" \
+ && pip install "${wheel}[mcp]" \
+ && rm -f /tmp/synthpanel-*.whl
+
+USER synthpanel
+WORKDIR /home/synthpanel
+
+# stdin must stay open for the MCP stdio transport. Callers running
+# non-MCP subcommands can ignore this — it's only meaningful for mcp-serve.
+ENTRYPOINT ["synthpanel"]
+CMD ["mcp-serve"]

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Python versions](https://img.shields.io/pypi/pyversions/synthpanel.svg)](https://pypi.org/project/synthpanel/)
 [![MCP](https://img.shields.io/badge/MCP-enabled-brightgreen.svg)](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md)
+[![GHCR](https://img.shields.io/badge/ghcr.io-dataviking--tech%2Fsynthpanel-2496ED?logo=docker&logoColor=white)](https://github.com/DataViking-Tech/SynthPanel/pkgs/container/synthpanel)
 
 Site: <https://synthpanel.dev> · Benchmark: <https://synthbench.org>
 
@@ -86,6 +87,46 @@ server — all clients in that list install SynthPanel with
 > `synthpanel mcp-serve` over stdio) — or
 > [file an issue](https://github.com/DataViking-Tech/SynthPanel/issues)
 > so we can add a sibling example.
+
+## Run via Docker
+
+A pre-built image is published to both
+[GitHub Container Registry](https://github.com/DataViking-Tech/SynthPanel/pkgs/container/synthpanel)
+and Docker Hub on every tagged release. Use it for ephemeral or serverless
+invocation (Lambda, Cloud Run, GitHub Actions, n8n) where you'd rather
+spin up a container than pip-install.
+
+```bash
+# Pull (either registry works — same image, multi-arch: amd64 + arm64)
+docker pull ghcr.io/dataviking-tech/synthpanel:latest
+docker pull synthpanel/synthpanel:latest
+
+# One-off prompt
+docker run --rm \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  synthpanel/synthpanel \
+  prompt "What makes a name feel trustworthy?"
+
+# MCP server on stdio (default CMD — wire this into an agent's MCP config)
+docker run --rm -i \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  synthpanel/synthpanel
+
+# Panel run with a mounted instrument file
+docker run --rm \
+  -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
+  -v "$PWD":/work -w /work \
+  synthpanel/synthpanel \
+  panel run --personas personas.yaml --instrument survey.yaml
+```
+
+The image's default `CMD` is `mcp-serve`, so omitting the command starts
+the MCP stdio server. Any `synthpanel` subcommand can be passed as
+arguments to override. Provider keys are read from environment variables
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`/`GEMINI_API_KEY`,
+`XAI_API_KEY`) — pass whichever your model requires.
+
+Pin to a specific version (`:0.9.1`) in production rather than `:latest`.
 
 ## Use as a Python Library
 


### PR DESCRIPTION
## Summary
- Adds production `Dockerfile`, `.dockerignore`, and `.github/workflows/docker.yml` that builds & pushes a multi-arch (amd64+arm64) image to both `ghcr.io/dataviking-tech/synthpanel` and `synthpanel/synthpanel` on every `v*` tag (plus `workflow_dispatch`).
- `python:3.12-slim` base (~189 MB), default CMD `synthpanel mcp-serve` (stdio), overridable with any subcommand, provider keys via env, runs as non-root UID 1000.
- README gains a "Run via Docker" section and GHCR badge. CHANGELOG entry added under Unreleased.
- Image verified locally with podman: `--help` / `--version` / `instruments list` all work; bundled persona+instrument packs load correctly.

## ⚠ Operator action required before first tag
CI will fail without:
- Repo secrets: `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`
- A GitHub environment named `docker`

GHCR auth uses `GITHUB_TOKEN` with `packages:write` (set in the workflow's permissions block — no extra secret needed).

## Conflict watch
Touches `README.md`; may conflict with open PR #158 (README restructure). Whichever lands second will need a rebase.

## Test plan
- [x] Local podman build (189 MB, CMD works, packs load)
- [ ] CI lint/typecheck/tests pass
- [ ] docker.yml workflow does NOT run on this PR (triggers on tag push only) — first proof happens on next `v*` tag
- [ ] CODEOWNER review (workflow + Dockerfile)

Source issue: sp-2cw.5
Worker: furiosa
MR: sp-wisp-7a6