### PR TITLE
chore(release): cut v0.9.2 to ship SDK public surface (sp-6gd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,22 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.9.2] - 2026-04-19
+
+### Fixed
+- (sp-6gd) P0 demo blocker: confirm `from synth_panel import quick_poll` works. The public SDK re-exports landed in `src/synth_panel/__init__.py` via sp-2cw.1 but were never published to PyPI — 0.9.0 shipped an empty `__init__.py`. This release cuts the first PyPI build that actually exposes the advertised surface (`quick_poll`, `run_prompt`, `run_panel`, `extend_panel`, `get_panel_result`, `list_instruments`, `list_panel_results`, `list_personas`, plus `PanelResult`, `PollResult`, `PromptResult`).
+
 ### Added
+- (sp-2cw.1) Public Python SDK convenience layer: `from synth_panel import quick_poll, run_prompt, run_panel, …` now resolves against `synth_panel.sdk`. See `docs/stability.md` for the supported surface.
+- (sp-2cw.2) `docs/examples/` — "Works with X" integration examples for 6 agent frameworks (Claude Agent SDK, OpenAI Agents, LangGraph, AutoGen, CrewAI, LlamaIndex).
+- (sp-2cw.3) Composio toolkit registration manifest.
+- (sp-2cw.4) Expanded Claude Code skills library under `skills/`.
 - (sp-2cw.5) Production Docker image published to `ghcr.io/dataviking-tech/synthpanel` and `synthpanel/synthpanel` on tagged releases. Multi-arch (linux/amd64, linux/arm64), python:3.12-slim base, default CMD is `synthpanel mcp-serve`. Reads provider keys from env (`ANTHROPIC_API_KEY` etc.). New CI workflow `.github/workflows/docker.yml` builds and pushes on `v*` tag push or `workflow_dispatch`. README gains a "Run via Docker" section and a GHCR badge.
+- (sp-6at) MCP sampling fallback for `run_prompt` and `run_quick_poll` so tools still function when the host supports MCP sampling but no provider key is configured.
+
+### Documentation
+- (sp-2cw.6) README "Works with" section lifted above the fold and expanded to seven frameworks.
+- (sp-4rp) Landing-page sync for v0.9.x and demo polish.
 
 ## [0.9.0] - 2026-04-15
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.9.1"
+version = "0.9.2"
 description = "Run synthetic focus groups using AI personas, with an MCP server for Claude Code / Cursor / Windsurf. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- **sp-6gd P0 demo blocker**: `from synth_panel import quick_poll` fails on the PyPI 0.9.0 wheel because it ships an empty `src/synth_panel/__init__.py`. The re-exports have been on `main` since #155 (sp-2cw.1) but no release has been cut, so end users still get an `ImportError`.
- This PR is a release trigger: bumps `pyproject.toml` → `0.9.2` and rolls up `[Unreleased]` into a `[0.9.2]` section in `CHANGELOG.md` covering sp-2cw.* + sp-6at + sp-4rp + sp-6gd.
- No runtime code changes — the fix itself is already on `main`.

## Verification
- `PYTHONPATH=src python -c 'from synth_panel import quick_poll'` → OK (all 12 public symbols resolve on Python 3.10+)
- `pytest tests/` → 976 passed, 26 deselected, coverage 87.10%
- `ruff check` + `ruff format --check` → clean

## Release mechanics
Apply `semver:patch` label at merge and push tag manually as `v0.9.2` (auto-tag would naturally compute `v0.9.1` from latest tag `v0.9.0` + patch, but sp-6gd asks for `v0.9.2` to avoid confusion with the stale `pyproject` pin from #162). `publish.yml` overwrites `pyproject.toml` from the tag at build time, so `v0.9.2` will ship correctly either way.

## Test plan
- [x] Unit tests pass locally (976/976)
- [x] Lint + format clean
- [x] Import smoke test against current `src/` tree
- [ ] CI green on this PR
- [ ] Post-merge: `v0.9.2` tag pushed, PyPI artifact contains SDK exports

Closes sp-6gd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)