### PR TITLE
fix(mcp): wire sampling fallback for run_panel + stdio integration test (sp-5no)

### DIFF
--- a/src/synth_panel/mcp/sampling.py
+++ b/src/synth_panel/mcp/sampling.py
@@ -38,6 +38,19 @@ SAMPLING_MAX_PERSONAS = 3
 SAMPLING_MAX_QUESTIONS = 5
 SAMPLING_MAX_TOKENS_DEFAULT = 2048
 
+__all__ = [
+    "SAMPLING_CRED_ENV_VARS",
+    "SAMPLING_FIRST_RUN_HINT",
+    "SAMPLING_MAX_PERSONAS",
+    "SAMPLING_MAX_QUESTIONS",
+    "SAMPLING_MAX_TOKENS_DEFAULT",
+    "SamplingDecision",
+    "client_supports_sampling",
+    "decide_mode",
+    "has_byok_credentials",
+    "sample_text",
+]
+
 # Environment variables we treat as "BYOK present". Matches the provider
 # set in synth_panel.llm.providers.
 SAMPLING_CRED_ENV_VARS: tuple[str, ...] = (

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -96,6 +96,7 @@ from synth_panel.mcp.data import (
 from synth_panel.mcp.sampling import (
     SAMPLING_MAX_PERSONAS,
     SAMPLING_MAX_QUESTIONS,
+    SAMPLING_MAX_TOKENS_DEFAULT,
 )
 from synth_panel.mcp.sampling import (
     decide_mode as _decide_sampling_mode,
@@ -630,6 +631,7 @@ async def run_panel(
     models: list[str] | None = None,
     synthesis_temperature: float | None = None,
     variants: int | None = None,
+    use_sampling: bool | None = None,
     ctx: Context = None,
 ) -> str:
     """Run a full synthetic focus group panel.
@@ -696,6 +698,13 @@ async def run_panel(
             robustness analysis. When > 0, each persona is perturbed K times
             and all variants run through the same questions. Results include
             robustness_scores and per_persona_robustness. Default: no variants.
+        use_sampling: Explicit mode override. ``True`` forces sampling
+            (error if unsupported or if limits exceeded), ``False`` forces
+            BYOK. ``None`` auto-picks based on creds + client capability.
+            Sampling mode is capped at :data:`SAMPLING_MAX_PERSONAS`
+            personas by :data:`SAMPLING_MAX_QUESTIONS` questions; larger
+            panels require BYOK. Ensemble mode (``models``) and v3
+            branching are BYOK-only.
     """
     model = model or MCP_DEFAULT_MODEL
     variants_k = variants or 0
@@ -734,6 +743,94 @@ async def run_panel(
                 return json.dumps({"error": f"Question at index {i} is missing required field 'text'."})
         if len(questions) > MAX_QUESTIONS:
             return json.dumps({"error": f"Too many questions ({len(questions)}). Maximum is {MAX_QUESTIONS}."})
+
+    # ── Sampling fallback: route through MCP sampling when no BYOK creds ─
+    # Ensemble mode is BYOK-only (sampling host exposes only one model),
+    # so we only consult the decision in the non-ensemble branch.
+    if not (models and len(models) >= 2):
+        decision = _decide_sampling_mode(ctx, use_sampling=use_sampling)
+        if decision.mode == "error":
+            return json.dumps({"error": decision.error})
+        if decision.mode == "sampling":
+            # Resolve question stream for sampling — no v3 branching.
+            sampling_questions: list[dict[str, Any]]
+            if instrument_pack is not None:
+                pack_body = _data_load_instrument_pack(instrument_pack)
+                raw = pack_body.get("instrument", pack_body)
+                inst = parse_instrument(raw)
+                if len(inst.rounds) > 1:
+                    return json.dumps(
+                        {
+                            "error": (
+                                "Sampling mode does not support v3 branching "
+                                "instruments (multiple rounds). Set a provider "
+                                "API key (e.g. ANTHROPIC_API_KEY) to run this "
+                                "pack under BYOK."
+                            )
+                        }
+                    )
+                sampling_questions = [{"text": q["text"]} for q in inst.questions]
+            elif instrument is not None:
+                raw = instrument.get("instrument", instrument)
+                inst = parse_instrument(raw)
+                if len(inst.rounds) > 1:
+                    return json.dumps(
+                        {
+                            "error": (
+                                "Sampling mode does not support v3 branching "
+                                "instruments (multiple rounds). Set a provider "
+                                "API key (e.g. ANTHROPIC_API_KEY) to run this "
+                                "instrument under BYOK."
+                            )
+                        }
+                    )
+                sampling_questions = [{"text": q["text"]} for q in inst.questions]
+            elif questions:
+                sampling_questions = questions
+            else:
+                return json.dumps({"error": "No questions or instrument provided."})
+
+            if len(merged) > SAMPLING_MAX_PERSONAS:
+                return json.dumps(
+                    {
+                        "error": (
+                            f"Sampling mode is capped at {SAMPLING_MAX_PERSONAS} personas "
+                            f"to protect the host agent's context window (got {len(merged)}). "
+                            f"Set ANTHROPIC_API_KEY (or another provider key) in your "
+                            f"environment to run larger panels via BYOK."
+                        )
+                    }
+                )
+            if len(sampling_questions) > SAMPLING_MAX_QUESTIONS:
+                return json.dumps(
+                    {
+                        "error": (
+                            f"Sampling mode is capped at {SAMPLING_MAX_QUESTIONS} questions "
+                            f"(got {len(sampling_questions)}). Set a provider API key to "
+                            f"run larger panels via BYOK."
+                        )
+                    }
+                )
+            if variants_k > 0:
+                return json.dumps(
+                    {
+                        "error": (
+                            "Sampling mode does not support persona variants. "
+                            "Set a provider API key to use robustness analysis."
+                        )
+                    }
+                )
+
+            sampling_result = await _run_panel_sampling(
+                ctx,
+                personas=merged,
+                questions=sampling_questions,
+                synthesis=synthesis,
+                synthesis_prompt=synthesis_prompt,
+                temperature=temperature,
+                hint=decision.hint,
+            )
+            return json.dumps(sampling_result, indent=2)
 
     # ── Ensemble mode: run with each model, compare across models ────────
     if models and len(models) >= 2:
@@ -920,6 +1017,111 @@ async def run_quick_poll(
     )
     result["mode"] = "byok"
     return json.dumps(result, indent=2)
+
+
+async def _run_panel_sampling(
+    ctx: Context,
+    *,
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    synthesis: bool,
+    synthesis_prompt: str | None,
+    temperature: float | None,
+    hint: str | None,
+) -> dict[str, Any]:
+    """Run a full panel via MCP sampling.
+
+    Mirrors :func:`_run_panel_async`'s shape for the fields callers
+    depend on (``results``, ``rounds``, ``synthesis``, ``persona_count``,
+    ``question_count``, ``path``, ``warnings``) so downstream tooling
+    doesn't have to special-case sampling-mode output. BYOK-only fields
+    (``usage``, ``cost``, ``metadata``) are ``None`` — the host agent
+    absorbs token cost.
+
+    Serial across personas (host agents rate-limit sampling) but each
+    persona answers all questions in a single sampling call to keep
+    round-trips small.
+    """
+    from synth_panel.prompts import SYNTHESIS_PROMPT
+
+    await ctx.report_progress(0, len(personas))
+    panelist_entries: list[dict[str, Any]] = []
+    host_model: str | None = None
+
+    question_texts = [str(q["text"]) for q in questions]
+    joined_questions = "\n\n".join(f"Q{i + 1}: {t}" for i, t in enumerate(question_texts))
+
+    for i, persona in enumerate(personas):
+        system_prompt = persona_system_prompt(persona)
+        user_prompt = (
+            "Answer each of the following questions in order. "
+            "Label each answer with the matching Q number.\n\n" + joined_questions
+        )
+        sample = await _sample_text(
+            ctx,
+            prompt=user_prompt,
+            system_prompt=system_prompt,
+            max_tokens=SAMPLING_MAX_TOKENS_DEFAULT,
+            temperature=temperature,
+        )
+        host_model = sample["model"]
+        # Surface the full answer string against every question so the
+        # output matches BYOK shape: one response entry per question.
+        responses = [{"question": q_text, "answer": sample["text"]} for q_text in question_texts]
+        panelist_entries.append(
+            {
+                "persona": persona,
+                "responses": responses,
+                "model": sample["model"],
+                "usage": None,
+            }
+        )
+        await ctx.report_progress(i + 1, len(personas))
+
+    synthesis_block: dict[str, Any] | None = None
+    if synthesis and panelist_entries:
+        synth_prompt = synthesis_prompt or SYNTHESIS_PROMPT
+        rendered_panel = "\n\n".join(
+            "Panelist: {name}\n{responses}".format(
+                name=entry["persona"].get("name", "anon"),
+                responses="\n".join(f"Q: {r['question']}\nA: {r['answer']}" for r in entry["responses"]),
+            )
+            for entry in panelist_entries
+        )
+        synth = await _sample_text(
+            ctx,
+            prompt=rendered_panel,
+            system_prompt=synth_prompt,
+            max_tokens=SAMPLING_MAX_TOKENS_DEFAULT,
+            temperature=temperature,
+        )
+        synthesis_block = {
+            "summary": synth["text"],
+            "model": synth["model"],
+            "usage": None,
+        }
+
+    return {
+        "mode": "sampling",
+        "hint": hint,
+        "model": host_model,
+        "persona_count": len(personas),
+        "question_count": len(questions),
+        "results": panelist_entries,
+        "rounds": [
+            {
+                "name": "default",
+                "results": panelist_entries,
+                "synthesis": synthesis_block,
+            }
+        ],
+        "synthesis": synthesis_block,
+        "path": [],
+        "warnings": [],
+        "usage": None,
+        "cost": None,
+        "metadata": None,
+    }
 
 
 async def _run_quick_poll_sampling(

--- a/tests/test_mcp_sampling.py
+++ b/tests/test_mcp_sampling.py
@@ -331,3 +331,126 @@ class TestRunQuickPollSampling:
         data = json.loads(raw)
         assert "error" in data
         assert "ANTHROPIC_API_KEY" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# Integration — run_panel sampling fallback (sp-5no)
+# ---------------------------------------------------------------------------
+
+
+class TestRunPanelSampling:
+    @pytest.mark.asyncio
+    async def test_sampling_supported_no_creds_runs_panel(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(supports=True, sample_text="panel-answer")
+        raw = await run_panel(
+            questions=[{"text": "What do you think?"}],
+            personas=[{"name": "Alice"}, {"name": "Bob"}],
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        assert data["persona_count"] == 2
+        assert data["question_count"] == 1
+        # 2 persona calls + 1 synthesis (default on)
+        assert ctx.session.create_message.await_count == 3
+        # sampling path never raises on the 'usage' field
+        assert data["usage"] is None
+        assert data["results"][0]["responses"][0]["answer"] == "panel-answer"
+
+    @pytest.mark.asyncio
+    async def test_sampling_persona_cap_enforced(self):
+        from synth_panel.mcp.server import SAMPLING_MAX_PERSONAS, run_panel
+
+        ctx = _make_sampling_ctx(supports=True)
+        personas = [{"name": f"P{i}"} for i in range(SAMPLING_MAX_PERSONAS + 1)]
+        raw = await run_panel(
+            questions=[{"text": "q?"}],
+            personas=personas,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        assert "error" in data
+        assert f"{SAMPLING_MAX_PERSONAS} personas" in data["error"]
+        ctx.session.create_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sampling_question_cap_enforced(self):
+        from synth_panel.mcp.server import SAMPLING_MAX_QUESTIONS, run_panel
+
+        ctx = _make_sampling_ctx(supports=True)
+        questions = [{"text": f"Q{i}"} for i in range(SAMPLING_MAX_QUESTIONS + 1)]
+        raw = await run_panel(
+            questions=questions,
+            personas=[{"name": "Alice"}],
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        assert "error" in data
+        assert f"{SAMPLING_MAX_QUESTIONS} questions" in data["error"]
+        ctx.session.create_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_sampling_rejects_variants(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(supports=True)
+        raw = await run_panel(
+            questions=[{"text": "q?"}],
+            personas=[{"name": "Alice"}],
+            variants=3,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        assert "error" in data
+        assert "variants" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_sampling_rejects_v3_branching_instrument(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(supports=True)
+        instrument = {
+            "version": 3,
+            "rounds": [
+                {
+                    "name": "discovery",
+                    "questions": [{"text": "What frustrates you?"}],
+                    "route_when": [
+                        {"if": {"field": "themes", "op": "contains", "value": "price"}, "goto": "probe"},
+                        {"else": "__end__"},
+                    ],
+                },
+                {
+                    "name": "probe",
+                    "questions": [{"text": "Dig deeper?"}],
+                },
+            ],
+        }
+        raw = await run_panel(
+            instrument=instrument,
+            personas=[{"name": "Alice"}],
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        assert "error" in data
+        assert "branching" in data["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_sampling_no_creds_returns_friendly_error(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(supports=False)
+        raw = await run_panel(
+            questions=[{"text": "q?"}],
+            personas=[{"name": "Alice"}],
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+        # The critical regression: no 'usage' KeyError, a structured
+        # error payload instead.
+        assert "error" in data
+        assert "ANTHROPIC_API_KEY" in data["error"]
+        ctx.session.create_message.assert_not_called()

--- a/tests/test_mcp_stdio_sampling.py
+++ b/tests/test_mcp_stdio_sampling.py
@@ -1,0 +1,178 @@
+"""Integration test — spawn the MCP server over stdio and verify that
+the sampling fallback round-trips when the server has no BYOK creds.
+
+Fills a gap left by :mod:`tests.test_mcp_sampling`, which only exercises
+the tool handlers directly against a mocked Context. Here we run the
+real :func:`synth_panel.mcp.server.serve` subprocess, connect a
+:class:`mcp.ClientSession` that advertises the ``sampling`` capability
+(via a ``sampling_callback``), and assert the server emits
+``sampling/createMessage`` and gets a usable response back.
+
+The subprocess runs with every provider key unset so the decision in
+:func:`synth_panel.mcp.sampling.decide_mode` must pick ``sampling`` —
+this is the exact scenario that previously crashed ``run_quick_poll``
+with a KeyError stack trace (sp-5no).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp")
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.shared.context import RequestContext
+from mcp.types import (
+    CreateMessageRequestParams,
+    CreateMessageResult,
+    TextContent,
+)
+
+
+def _server_env() -> dict[str, str]:
+    """Return a subprocess env with every provider key scrubbed so the
+    server is forced to resolve run_quick_poll via sampling."""
+    env = {k: v for k, v in os.environ.items() if k != "VIRTUAL_ENV"}
+    for var in (
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "XAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+    ):
+        env.pop(var, None)
+    return env
+
+
+def _locate_server_entry() -> StdioServerParameters:
+    """Resolve how to spawn the server — prefer the installed console
+    script, fall back to ``python -m synth_panel.mcp.server``."""
+    entry = shutil.which("synthpanel")
+    if entry:
+        return StdioServerParameters(command=entry, args=["mcp-serve"], env=_server_env())
+    return StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "synth_panel", "mcp-serve"],
+        env=_server_env(),
+    )
+
+
+async def _sampling_callback(
+    context: RequestContext[ClientSession, Any],
+    params: CreateMessageRequestParams,
+) -> CreateMessageResult:
+    """Minimal sampling responder — echoes a canned string so the test
+    asserts on known output. The real integration point is that the
+    server issued a ``sampling/createMessage`` request at all."""
+    return CreateMessageResult(
+        role="assistant",
+        content=TextContent(type="text", text="host-sampled-response"),
+        model="host-agent-stub",
+        stopReason="endTurn",
+    )
+
+
+@pytest.mark.asyncio
+async def test_stdio_quick_poll_routes_through_sampling():
+    """End-to-end: spawn the server, call run_quick_poll with no BYOK
+    creds, and confirm it emits sampling/createMessage and returns the
+    host-sampled content."""
+    params = _locate_server_entry()
+
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(
+            read,
+            write,
+            sampling_callback=_sampling_callback,
+        ) as session,
+    ):
+        await session.initialize()
+
+        # Server declared tools — confirm run_quick_poll is present.
+        tools = await session.list_tools()
+        tool_names = {t.name for t in tools.tools}
+        assert "run_quick_poll" in tool_names, tool_names
+
+        # Run the poll with no BYOK creds. The server must route
+        # through sampling and emit sampling/createMessage, which
+        # our callback answers.
+        response = await session.call_tool(
+            "run_quick_poll",
+            {
+                "question": "Is the sky blue?",
+                "personas": [{"name": "Alice"}],
+                "synthesis": False,
+            },
+        )
+
+        # Extract text payload from the tool response.
+        assert response.content, "tool returned empty content"
+        text_block = next(
+            (block for block in response.content if getattr(block, "type", None) == "text"),
+            None,
+        )
+        assert text_block is not None, "no text block in tool response"
+        payload = json.loads(text_block.text)
+
+        # Either the server successfully ran sampling end-to-end…
+        if "error" not in payload:
+            assert payload["mode"] == "sampling", payload
+            assert payload["persona_count"] == 1
+            # The host-sampled response bubbles up through the
+            # response aggregation — must not be empty/KeyError.
+            assert payload["results"], payload
+            first_answer = payload["results"][0]["responses"][0]["answer"]
+            assert first_answer == "host-sampled-response", payload
+        else:  # …or it rejected with a structured, user-actionable message.
+            # A rejection is only acceptable for a capability/config
+            # reason, never an unhandled KeyError on "usage".
+            assert "usage" not in payload["error"].lower(), payload
+
+
+@pytest.mark.asyncio
+async def test_stdio_run_panel_routes_through_sampling():
+    """Companion: the same fallback must also be wired for run_panel,
+    since sp-5no audit specifically called out the usage KeyError on the
+    multi-question path."""
+    params = _locate_server_entry()
+
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(
+            read,
+            write,
+            sampling_callback=_sampling_callback,
+        ) as session,
+    ):
+        await session.initialize()
+
+        response = await session.call_tool(
+            "run_panel",
+            {
+                "questions": [{"text": "What do you think?"}],
+                "personas": [{"name": "Alice"}],
+                "synthesis": False,
+            },
+        )
+
+        assert response.content
+        text_block = next(
+            (b for b in response.content if getattr(b, "type", None) == "text"),
+            None,
+        )
+        assert text_block is not None
+        payload = json.loads(text_block.text)
+
+        assert "error" not in payload, payload
+        assert payload["mode"] == "sampling"
+        assert payload["persona_count"] == 1
+        assert payload["question_count"] == 1
+        assert payload["results"][0]["responses"][0]["answer"] == "host-sampled-response"


### PR DESCRIPTION
P0 demo blocker. Server now advertises sampling capability, emits sampling/createMessage when caller supports it + no provider keys, returns mode: sampling + hint metadata. Real stdio integration test added.