### PR TITLE
fix(mcp): advertise sampling + pin serverInfo.version + zero-config run_quick_poll (sp-lsc)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.9.2"
+version = "0.9.3"
 description = "Run synthetic focus groups using AI personas, with an MCP server for Claude Code / Cursor / Windsurf. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
 
+from synth_panel import __version__ as _synthpanel_version
 from synth_panel._runners import (
     EXTRACT_SCHEMA_REGISTRY,
     MAX_PERSONAS,
@@ -140,6 +141,40 @@ mcp = FastMCP(
         "structured qualitative feedback on products, concepts, and names."
     ),
 )
+# FastMCP forwards to an internal low-level Server whose ``version`` falls
+# back to ``importlib.metadata.version("mcp")`` when left unset — that
+# leaks the MCP SDK version into serverInfo. Pin the synthpanel package
+# version so clients see the correct release string on initialize.
+mcp._mcp_server.version = _synthpanel_version
+
+
+# Minimal default persona set for ``run_quick_poll`` — three diverse
+# voices so the first-run story works without hand-crafting personas.
+# Kept intentionally small: sampling mode caps at SAMPLING_MAX_PERSONAS
+# and we want the BYOK path to stay cheap by default too.
+DEFAULT_QUICK_POLL_PERSONAS: list[dict[str, Any]] = [
+    {
+        "name": "Alex Rivera",
+        "age": 29,
+        "occupation": "Software Engineer",
+        "background": "Early-career developer at a mid-sized SaaS company.",
+        "personality_traits": ["analytical", "curious", "pragmatic"],
+    },
+    {
+        "name": "Jordan Park",
+        "age": 42,
+        "occupation": "Small Business Owner",
+        "background": "Runs an independent retail shop; values clarity and ROI.",
+        "personality_traits": ["practical", "skeptical", "value-driven"],
+    },
+    {
+        "name": "Sam Okafor",
+        "age": 35,
+        "occupation": "Marketing Manager",
+        "background": "Leads growth at a consumer brand; follows trends closely.",
+        "personality_traits": ["creative", "social", "brand-aware"],
+    },
+]
 
 # Shared LLM client — reused across tool calls to avoid rebuilding the
 # provider cache on every invocation.  Thread-safe by design (see LLMClient).
@@ -913,7 +948,7 @@ async def run_panel(
 @mcp.tool()
 async def run_quick_poll(
     question: str,
-    personas: list[dict[str, Any]],
+    personas: list[dict[str, Any]] | None = None,
     model: str | None = None,
     response_schema: dict[str, Any] | None = None,
     synthesis: bool = True,
@@ -939,7 +974,9 @@ async def run_quick_poll(
 
     Args:
         question: The question to ask all personas.
-        personas: List of persona definitions.
+        personas: List of persona definitions. Optional — when omitted,
+            a small built-in pack of diverse personas is used so the
+            tool works with zero configuration.
         model: LLM model to use. Defaults to haiku. Ignored in sampling
             mode (the host agent picks its own model).
         response_schema: Optional JSON Schema for structured output. When
@@ -961,6 +998,11 @@ async def run_quick_poll(
 
     if not question or not question.strip():
         return json.dumps({"error": "Question text must be a non-empty string."})
+
+    # Fall back to the built-in diverse persona set when the caller
+    # omits personas — preserves the zero-config first-run story.
+    if personas is None or len(personas) == 0:
+        personas = [dict(p) for p in DEFAULT_QUICK_POLL_PERSONAS]
 
     # Validate personas: must be dicts with "name"
     for i, p in enumerate(personas):
@@ -1572,6 +1614,30 @@ def concept_test(
 
 
 def serve() -> None:
-    """Run the MCP server on stdio transport."""
+    """Run the MCP server on stdio transport.
+
+    FastMCP's default ``run_stdio_async`` calls
+    ``create_initialization_options()`` with no arguments, so synthpanel
+    cannot advertise that it *uses* MCP sampling. We reimplement the
+    stdio loop here with ``experimental_capabilities={"sampling": {}}``
+    so MCP clients can surface the dependency in their capability UI
+    and users can see at-a-glance that this server will ask the host
+    agent to run completions when no BYOK creds are set.
+    """
+    import anyio
+    from mcp.server.stdio import stdio_server
+
     logger.info("MCP server starting (stdio transport)")
-    mcp.run(transport="stdio")
+
+    async def _run() -> None:
+        server = mcp._mcp_server
+        async with stdio_server() as (read_stream, write_stream):
+            await server.run(
+                read_stream,
+                write_stream,
+                server.create_initialization_options(
+                    experimental_capabilities={"sampling": {}},
+                ),
+            )
+
+    anyio.run(_run)

--- a/tests/test_mcp_stdio_sampling.py
+++ b/tests/test_mcp_stdio_sampling.py
@@ -138,6 +138,84 @@ async def test_stdio_quick_poll_routes_through_sampling():
 
 
 @pytest.mark.asyncio
+async def test_stdio_initialize_advertises_sampling_and_version():
+    """sp-lsc regression: the server's initialize handshake must declare
+    that it uses MCP sampling (under experimental capabilities) and must
+    report the synthpanel package version in serverInfo — not the MCP
+    SDK version leaked through FastMCP's default behaviour."""
+    import synth_panel
+
+    params = _locate_server_entry()
+
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(
+            read,
+            write,
+            sampling_callback=_sampling_callback,
+        ) as session,
+    ):
+        init_result = await session.initialize()
+
+        assert init_result.serverInfo.name == "synthpanel"
+        assert init_result.serverInfo.version == synth_panel.__version__, (
+            f"serverInfo.version should be the synthpanel package version "
+            f"({synth_panel.__version__}); got {init_result.serverInfo.version}. "
+            f"FastMCP defaults to importlib.metadata.version('mcp') when the "
+            f"underlying Server.version is unset, which leaks the SDK version."
+        )
+
+        experimental = init_result.capabilities.experimental or {}
+        assert "sampling" in experimental, (
+            f"Server must advertise the 'sampling' experimental capability "
+            f"so MCP clients can surface the dependency in their UI. "
+            f"Got capabilities.experimental = {experimental!r}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stdio_quick_poll_without_personas_uses_defaults():
+    """sp-lsc regression: run_quick_poll must work with zero configuration
+    — omitting personas falls back to the built-in diverse persona set so
+    first-run users aren't forced to hand-craft a personas list."""
+    params = _locate_server_entry()
+
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(
+            read,
+            write,
+            sampling_callback=_sampling_callback,
+        ) as session,
+    ):
+        await session.initialize()
+
+        response = await session.call_tool(
+            "run_quick_poll",
+            {
+                "question": "Is the sky blue?",
+                "synthesis": False,
+            },
+        )
+
+        assert response.content
+        text_block = next(
+            (b for b in response.content if getattr(b, "type", None) == "text"),
+            None,
+        )
+        assert text_block is not None
+        payload = json.loads(text_block.text)
+
+        # Must not be a 'personas field required' validation error — that
+        # was the exact regression introduced by sp-5no.
+        assert "error" not in payload or "personas" not in payload["error"].lower(), payload
+
+        if "error" not in payload:
+            assert payload["mode"] == "sampling"
+            assert payload["persona_count"] >= 1
+
+
+@pytest.mark.asyncio
 async def test_stdio_run_panel_routes_through_sampling():
     """Companion: the same fallback must also be wired for run_panel,
     since sp-5no audit specifically called out the usage KeyError on the


### PR DESCRIPTION
## Summary

sp-5no (PR #164) wired the sampling fallback but left three gaps that a fresh `pip install synthpanel==0.9.2` stdio test exposed:

1. **Server capabilities list omitted `sampling`.** FastMCP's `run_stdio_async` calls `create_initialization_options()` with no args, so synthpanel couldn't declare that it uses MCP sampling. `serve()` now reimplements the stdio loop with `experimental_capabilities={"sampling": {}}` so MCP clients can surface the dependency in their capability UI.
2. **`serverInfo.version` leaked MCP SDK version (1.27.0).** FastMCP's underlying `Server.version` falls back to `importlib.metadata.version("mcp")` when unset. Pin to `synth_panel.__version__` at module-load time.
3. **`run_quick_poll` required `personas`** (validation error `personas field required`), breaking the zero-config first-run story. The parameter is now `Optional` and falls back to `DEFAULT_QUICK_POLL_PERSONAS` — 3 diverse built-in voices — when omitted.

Bumps `pyproject.toml` 0.9.2 → 0.9.3.

## Verification

Smoke test (`python -m synth_panel mcp-serve` + raw JSON-RPC initialize):

```json
{"capabilities":{"experimental":{"sampling":{}},"prompts":{...},"resources":{...},"tools":{...}},
 "serverInfo":{"name":"synthpanel","version":"0.9.3"},...}
```

Adds two stdio regression tests:
- `test_stdio_initialize_advertises_sampling_and_version`
- `test_stdio_quick_poll_without_personas_uses_defaults`

## Test plan

- [x] `pytest tests/` — 986 passed, 26 deselected
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check` — 96 files already formatted
- [x] Stdio smoke test confirms new initialize response shape
- [ ] After merge, tag and publish v0.9.3 to PyPI (requires `semver:patch` label — see sp-r61)

Closes sp-lsc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)