### PR TITLE
fix(site): bump hero + footer version to v0.9.3 (sp-xzf)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ arguments to override. Provider keys are read from environment variables
 (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`/`GEMINI_API_KEY`,
 `XAI_API_KEY`) — pass whichever your model requires.
 
-Pin to a specific version (`:0.9.1`) in production rather than `:latest`.
+Pin to a specific version (`:0.9.3`) in production rather than `:latest`.
 
 ## Use as a Python Library
 

--- a/site/index.html
+++ b/site/index.html
@@ -76,7 +76,7 @@
           class="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-3 py-1 text-xs font-medium text-emerald-300"
         >
           <span class="h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
-          v0.9.1 — public beta
+          v0.9.3 — public beta
         </p>
         <h1
           class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-5xl font-bold tracking-tight text-transparent sm:text-6xl"
@@ -317,7 +317,7 @@ synthpanel panel run \
       >
         <div class="flex flex-wrap items-center justify-between gap-3">
           <span>
-            MIT-licensed · v0.9.1 ·
+            MIT-licensed · v0.9.3 ·
             <a
               href="https://github.com/DataViking-Tech/SynthPanel"
               class="hover:text-slate-300"


### PR DESCRIPTION
## Summary
- Sync hero badge and footer version display from v0.9.1 to v0.9.3 to match shipped PyPI version
- Fix README docker-pin example version reference

## Source
- Polecat: capable
- Issue: sp-xzf
- MR: sp-wisp-10y
- Branch: polecat/capable-mo66j85e

## Test plan
- [ ] CI (tests + coverage + lint + typecheck + security) passes
- [ ] Site preview shows v0.9.3 in hero and footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)