### PR TITLE
fix(mcp): recognise OPENROUTER_API_KEY as BYOK + smart default model (sp-t6r)

### DIFF
--- a/src/synth_panel/mcp/sampling.py
+++ b/src/synth_panel/mcp/sampling.py
@@ -52,13 +52,17 @@ __all__ = [
 ]
 
 # Environment variables we treat as "BYOK present". Matches the provider
-# set in synth_panel.llm.providers.
+# set in synth_panel.llm.providers — must stay in sync with the CLI's
+# _DEFAULT_MODEL_PREFERENCE and sdk._DEFAULT_MODEL_PREFERENCE, otherwise
+# a user who set (e.g.) OPENROUTER_API_KEY gets routed to sampling or a
+# "missing credentials" error despite the CLI recognising the same key.
 SAMPLING_CRED_ENV_VARS: tuple[str, ...] = (
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
     "XAI_API_KEY",
     "GOOGLE_API_KEY",
     "GEMINI_API_KEY",
+    "OPENROUTER_API_KEY",
 )
 
 # First-run hint surfaced on successful sampling runs so users know they
@@ -183,8 +187,9 @@ def decide_mode(
         mode="error",
         error=(
             "No provider credentials found (ANTHROPIC_API_KEY / "
-            "OPENAI_API_KEY / XAI_API_KEY / GOOGLE_API_KEY) and the "
-            "invoking MCP client did not advertise 'sampling' capability. "
+            "OPENAI_API_KEY / XAI_API_KEY / GOOGLE_API_KEY / "
+            "GEMINI_API_KEY / OPENROUTER_API_KEY) and the invoking "
+            "MCP client did not advertise 'sampling' capability. "
             "Set a provider key in your environment, or run synthpanel "
             "from a sampling-capable client such as Claude Desktop. "
             "See https://synthpanel.dev/mcp#credentials."

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -116,8 +117,40 @@ from synth_panel.synthesis import synthesize_panel
 
 logger = logging.getLogger(__name__)
 
-# Default model for MCP mode
+# Default model for MCP mode — used as the terminal fallback when no
+# provider credentials are present in the environment. Prefer
+# :func:`_resolve_mcp_default_model` at call sites so users with a
+# non-Anthropic key (OpenRouter, Gemini, xAI, OpenAI) aren't silently
+# routed into the Anthropic provider and a misleading missing-key error.
 MCP_DEFAULT_MODEL = "haiku"
+
+# Preference chain for the MCP default model. Mirrors the CLI's
+# _DEFAULT_MODEL_PREFERENCE and sdk._DEFAULT_MODEL_PREFERENCE, but picks
+# the cheap/fast model per provider since MCP is optimised for
+# iterative use (whereas the CLI defaults to workhorse models).
+_MCP_DEFAULT_MODEL_PREFERENCE: list[tuple[str, str]] = [
+    ("ANTHROPIC_API_KEY", "haiku"),
+    ("OPENAI_API_KEY", "gpt-4o-mini"),
+    ("GEMINI_API_KEY", "gemini-2.5-flash"),
+    ("GOOGLE_API_KEY", "gemini-2.5-flash"),
+    ("XAI_API_KEY", "grok-3"),
+    ("OPENROUTER_API_KEY", "openrouter/auto"),
+]
+
+
+def _resolve_mcp_default_model() -> str:
+    """Pick a cheap/fast default model based on available provider creds.
+
+    Walks :data:`_MCP_DEFAULT_MODEL_PREFERENCE` and returns the first
+    alias whose env var is set. Falls back to :data:`MCP_DEFAULT_MODEL`
+    when nothing is set so the LLM client's missing-credentials error
+    is the one the user sees.
+    """
+    for env_var, alias in _MCP_DEFAULT_MODEL_PREFERENCE:
+        if os.environ.get(env_var, "").strip():
+            return alias
+    return MCP_DEFAULT_MODEL
+
 
 # Re-export for backward compatibility — callers patch these names.
 __all__ = [
@@ -592,7 +625,7 @@ async def run_prompt(
             (error if unsupported), ``False`` forces BYOK. ``None``
             auto-picks based on creds + client capability.
     """
-    model = model or MCP_DEFAULT_MODEL
+    model = model or _resolve_mcp_default_model()
     decision = _decide_sampling_mode(ctx, use_sampling=use_sampling)
     logger.info("run_prompt: mode=%s model=%s prompt_len=%d", decision.mode, model, len(prompt))
 
@@ -741,7 +774,7 @@ async def run_panel(
             panels require BYOK. Ensemble mode (``models``) and v3
             branching are BYOK-only.
     """
-    model = model or MCP_DEFAULT_MODEL
+    model = model or _resolve_mcp_default_model()
     variants_k = variants or 0
     if variants_k < 0 or variants_k > 20:
         return json.dumps({"error": "variants must be between 0 and 20."})
@@ -994,7 +1027,7 @@ async def run_quick_poll(
             (error if unsupported), ``False`` forces BYOK. ``None``
             auto-picks based on creds + client capability.
     """
-    model = model or MCP_DEFAULT_MODEL
+    model = model or _resolve_mcp_default_model()
 
     if not question or not question.strip():
         return json.dumps({"error": "Question text must be a non-empty string."})
@@ -1378,7 +1411,7 @@ async def extend_panel(
         synthesis_model: Synthesis model. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt for the new round.
     """
-    model = model or MCP_DEFAULT_MODEL
+    model = model or _resolve_mcp_default_model()
     logger.info("extend_panel: result_id=%s questions=%d model=%s", result_id, len(questions), model)
     existing = _data_get_panel_result(result_id)
 

--- a/tests/test_mcp_sampling.py
+++ b/tests/test_mcp_sampling.py
@@ -35,6 +35,7 @@ def _clean_env(tmp_path, monkeypatch):
         "XAI_API_KEY",
         "GOOGLE_API_KEY",
         "GEMINI_API_KEY",
+        "OPENROUTER_API_KEY",
     ):
         monkeypatch.delenv(var, raising=False)
 
@@ -53,8 +54,30 @@ class TestHasByokCredentials:
     def test_any_known_var_returns_true(self, monkeypatch):
         from synth_panel.mcp.sampling import has_byok_credentials
 
-        for var in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        # Must cover every provider the CLI auto-detects, otherwise a user
+        # whose only key is (e.g.) OPENROUTER_API_KEY gets misrouted into
+        # sampling or a "missing credentials" error despite the CLI
+        # recognising the same key (see sp-t6r).
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
             assert has_byok_credentials({var: "x"}) is True, var
+
+    def test_openrouter_key_is_recognised_in_decide_mode(self):
+        from synth_panel.mcp.sampling import decide_mode
+
+        # sp-t6r regression: OPENROUTER_API_KEY must route to BYOK, not
+        # sampling, even when the client supports sampling — otherwise we
+        # silently downgrade users with a valid provider key.
+        ctx = MagicMock()
+        ctx.session.check_client_capability.return_value = True
+        d = decide_mode(ctx, env={"OPENROUTER_API_KEY": "sk-or-x"})
+        assert d.mode == "byok"
 
     def test_empty_string_is_not_creds(self):
         from synth_panel.mcp.sampling import has_byok_credentials

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -35,6 +35,53 @@ class TestServerRegistration:
     def test_default_model_is_haiku(self):
         assert MCP_DEFAULT_MODEL == "haiku"
 
+    def test_resolve_default_model_prefers_provider_with_credentials(self, monkeypatch):
+        """sp-t6r: when the only key set is non-Anthropic, the MCP default
+        must match that provider — otherwise we default to ``haiku``
+        (Anthropic) and the LLM client rejects the run with a misleading
+        missing-key error despite the user having valid credentials."""
+        from synth_panel.mcp.server import _resolve_mcp_default_model
+
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+
+        # Preference chain — each provider should light up its own alias.
+        cases = [
+            ("ANTHROPIC_API_KEY", "haiku"),
+            ("OPENAI_API_KEY", "gpt-4o-mini"),
+            ("GEMINI_API_KEY", "gemini-2.5-flash"),
+            ("GOOGLE_API_KEY", "gemini-2.5-flash"),
+            ("XAI_API_KEY", "grok-3"),
+            ("OPENROUTER_API_KEY", "openrouter/auto"),
+        ]
+        for env_var, expected_alias in cases:
+            monkeypatch.setenv(env_var, "sk-x")
+            try:
+                assert _resolve_mcp_default_model() == expected_alias, env_var
+            finally:
+                monkeypatch.delenv(env_var, raising=False)
+
+    def test_resolve_default_model_falls_back_to_haiku(self, monkeypatch):
+        from synth_panel.mcp.server import _resolve_mcp_default_model
+
+        for var in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "XAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        assert _resolve_mcp_default_model() == MCP_DEFAULT_MODEL
+
     @pytest.mark.asyncio
     async def test_tools_registered(self):
         tools = await mcp.list_tools()


### PR DESCRIPTION
## Summary
- Recognize OPENROUTER_API_KEY as a valid BYOK provider
- Use smart default model selection via OpenRouter

## Source
- Polecat: dag
- Issue: sp-t6r
- MR: sp-wisp-0l1
- Branch: polecat/dag-mo66jo3y

## Test plan
- [ ] CI (tests + coverage + lint + typecheck + security) passes
- [ ] MCP sampling tests cover the OpenRouter path

🤖 Generated with [Claude Code](https://claude.com/claude-code)