### PR TITLE
fix(site): uppercase 'SynthPanel' in titles, OG/Twitter cards, brand text (sp-yu3)

### DIFF
--- a/site/blog/synthpanel-vs-commercial-alternatives.html
+++ b/site/blog/synthpanel-vs-commercial-alternatives.html
@@ -34,7 +34,7 @@
       property="og:url"
       content="https://synthpanel.dev/blog/synthpanel-vs-commercial-alternatives.html"
     />
-    <meta property="og:site_name" content="synthpanel" />
+    <meta property="og:site_name" content="SynthPanel" />
     <meta property="article:published_time" content="2026-04-15" />
     <meta property="article:author" content="DataViking" />
     <meta property="article:section" content="Positioning" />
@@ -65,7 +65,7 @@
         "description": "SynthPanel is the open-source, LLM-agnostic alternative to commercial synthetic-respondent tools. CLI + 12-tool MCP server, MIT-licensed, SPS 0.90 on SynthBench.",
         "datePublished": "2026-04-15",
         "author": { "@type": "Organization", "name": "DataViking", "url": "https://dataviking.tech" },
-        "publisher": { "@type": "Organization", "name": "synthpanel", "url": "https://synthpanel.dev" },
+        "publisher": { "@type": "Organization", "name": "SynthPanel", "url": "https://synthpanel.dev" },
         "about": [
           { "@type": "SoftwareApplication", "name": "SynthPanel", "applicationCategory": "DeveloperApplication", "operatingSystem": "Cross-platform", "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" } }
         ],

--- a/site/index.html
+++ b/site/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>synthpanel — Run synthetic focus groups with any LLM</title>
+    <title>SynthPanel — Run synthetic focus groups with any LLM</title>
     <meta
       name="description"
       content="Open-source synthetic focus groups. Define personas in YAML, run them against any LLM (Claude, GPT, Gemini, Grok, local), and get structured, reproducible output with full cost transparency."
@@ -11,14 +11,14 @@
     <link rel="canonical" href="https://synthpanel.dev/" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="synthpanel" />
+    <meta property="og:title" content="SynthPanel" />
     <meta
       property="og:description"
       content="Run synthetic focus groups with any LLM. Pip-install, define personas in YAML, get structured output."
     />
     <meta property="og:url" content="https://synthpanel.dev/" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="synthpanel" />
+    <meta name="twitter:title" content="SynthPanel" />
     <meta
       name="twitter:description"
       content="Run synthetic focus groups with any LLM."
@@ -81,7 +81,7 @@
         <h1
           class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-5xl font-bold tracking-tight text-transparent sm:text-6xl"
         >
-          synthpanel
+          SynthPanel
         </h1>
         <p class="mx-auto mt-5 max-w-2xl text-lg text-slate-300 sm:text-xl">
           Run synthetic focus groups with any LLM.

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -4,23 +4,23 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>
-      MCP Server — synthpanel · Run synthetic focus groups from your AI editor
+      MCP Server — SynthPanel · Run synthetic focus groups from your AI editor
     </title>
     <meta
       name="description"
-      content="synthpanel's MCP server exposes 12 tools for AI agents to run synthetic focus groups, manage persona packs, and query panel results. Drop-in config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop."
+      content="SynthPanel's MCP server exposes 12 tools for AI agents to run synthetic focus groups, manage persona packs, and query panel results. Drop-in config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop."
     />
     <link rel="canonical" href="https://synthpanel.dev/mcp" />
 
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="synthpanel MCP Server" />
+    <meta property="og:title" content="SynthPanel MCP Server" />
     <meta
       property="og:description"
       content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop. 12 tools to run synthetic focus groups from chat."
     />
     <meta property="og:url" content="https://synthpanel.dev/mcp" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="synthpanel MCP Server" />
+    <meta name="twitter:title" content="SynthPanel MCP Server" />
     <meta
       name="twitter:description"
       content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop."
@@ -135,7 +135,7 @@
         <h1
           class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-4xl font-bold tracking-tight text-transparent sm:text-5xl"
         >
-          synthpanel MCP server
+          SynthPanel MCP server
         </h1>
         <p class="mt-4 text-lg text-slate-300">
           Give your AI coding assistant tool-call access to synthetic focus


### PR DESCRIPTION
## Summary
- Uppercase SynthPanel across page titles, OG + Twitter social cards, and brand text
- Matches the canonical repo + product name casing

## Source
- Polecat: capable
- Issue: sp-yu3
- MR: sp-wisp-3jf
- Branch: polecat/capable-mo6860dd

## Test plan
- [ ] CI passes
- [ ] Visual check of hero + social preview cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)