### PR TITLE
fix(site): prevent iOS Safari overscroll white flash (sp-d86)

### DIFF
--- a/site/blog/synthpanel-vs-commercial-alternatives.html
+++ b/site/blog/synthpanel-vs-commercial-alternatives.html
@@ -96,6 +96,10 @@
       :root {
         color-scheme: dark;
       }
+      html,
+      body {
+        background-color: #0f172a;
+      }
       body {
         background:
           radial-gradient(

--- a/site/index.html
+++ b/site/index.html
@@ -53,6 +53,10 @@
       :root {
         color-scheme: dark;
       }
+      html,
+      body {
+        background-color: #0f172a;
+      }
       body {
         background:
           radial-gradient(

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -55,6 +55,10 @@
       :root {
         color-scheme: dark;
       }
+      html,
+      body {
+        background-color: #0f172a;
+      }
       body {
         background:
           radial-gradient(


### PR DESCRIPTION
## Summary
- Prevent iOS Safari rubber-band overscroll exposing white body background

## Source
- Polecat: dag
- Issue: sp-d86
- MR: sp-wisp-xpq
- Branch: polecat/dag-mo65ac07

## Test plan
- [ ] CI passes
- [ ] Visual check on iOS Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)