### PR TITLE
fix(site): bump copy-btn touch target to 44px (sp-v1w)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -62,6 +62,10 @@
           ),
           #0f172a;
       }
+      button.copy-btn {
+        min-height: 44px;
+        padding: 8px 14px;
+      }
       .copy-btn:active {
         transform: translateY(1px);
       }

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -64,6 +64,10 @@
           ),
           #0f172a;
       }
+      button.copy-btn {
+        min-height: 44px;
+        padding: 8px 14px;
+      }
       .copy-btn:active {
         transform: translateY(1px);
       }


### PR DESCRIPTION
## Summary
- Raise copy-button touch target to 44px to meet iOS HIG accessibility guidelines

## Source
- Polecat: furiosa
- Issue: sp-v1w
- MR: sp-wisp-7ue
- Branch: polecat/furiosa-mo66k3sh

## Test plan
- [ ] CI passes
- [ ] Click target passes 44px audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)