### PR TITLE
docs: promote sampling-fallback to README/landing first paragraph + align framework count to 8 (sp-dub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Site: <https://synthpanel.dev> · Benchmark: <https://synthbench.org>
 
 Open-source synthetic focus groups. Any LLM. Your terminal or your agent's tool call.
 
-Define personas in YAML. Define your research instrument in YAML. Run against any LLM — from your terminal, from a pipeline, or from an AI agent's MCP tool call. Get structured, reproducible output with full cost transparency.
+**Zero-config inside any MCP host that speaks sampling** (Claude Desktop, Claude Code, Cursor, Windsurf) — drop the config in and run a panel with **no API key set**. The host runs the model on your behalf, using its own subscription. Bring your own provider key (Claude, GPT, Gemini, Grok, local) when you want reproducibility, ensembles, or larger panels. Personas and instruments are plain YAML; every response is schema-validated with per-turn cost telemetry. Runs from your terminal, a pipeline, or an AI agent's MCP tool call.
 
 ```bash
 pip install synthpanel
@@ -72,6 +72,8 @@ examples for each framework live in
 | [LangGraph](https://langchain-ai.github.io/langgraph/) | [langchain_tool.py](examples/integrations/langchain_tool.py) | `langchain-mcp-adapters` | `pip install langchain-mcp-adapters langgraph langchain-anthropic synthpanel[mcp]` |
 | [Microsoft Agent Framework 1.0](https://learn.microsoft.com/en-us/agent-framework/) | [microsoft_agent.py](examples/integrations/microsoft_agent.py) | Built-in `MCPStdioTool` | `pip install agent-framework synthpanel[mcp]` |
 | [n8n](https://n8n.io/) | [n8n_workflow.json](examples/integrations/n8n_workflow.json) | Built-in MCP Client tool | `pip install synthpanel[mcp]` on the n8n runner |
+| [LangChain via Composio](https://composio.dev/) | [composio_langchain.py](examples/integrations/composio_langchain.py) | `synth_panel.integrations.composio` (in-process, non-MCP) | `pip install composio composio_langchain langchain langchain-anthropic synthpanel` |
+| [CrewAI via Composio](https://composio.dev/) | [composio_crewai.py](examples/integrations/composio_crewai.py) | `synth_panel.integrations.composio` (in-process, non-MCP) | `pip install composio composio_crewai crewai synthpanel` |
 
 Also reaches [Zapier MCP](https://zapier.com/mcp) (30K+ actions), the
 [VS Code AI Toolkit](https://code.visualstudio.com/api/extension-guides/ai/mcp),

--- a/docs/ai-engineer-readiness.md
+++ b/docs/ai-engineer-readiness.md
@@ -20,7 +20,7 @@ not for anything missing from the product itself.
 - ✅ 8 agent-framework examples live (OpenAI Agents, LangChain/LangGraph, CrewAI, LlamaIndex, MS Agent Framework, n8n, plus 2 Composio flavors)
 - ✅ awesome-mcp-servers PR #4930 pending — can reference it ("we're getting listed upstream")
 - ⚠️ CLI ergonomic gotcha: `--model` must precede the subcommand (`synthpanel --model sonnet prompt …`). Trivial, but it will trip the founder live if they type it the other way.
-- ⚠️ "Works with 7 frameworks" above-the-fold claim is technically 8 examples / 6 frameworks. Keep the pitch consistent with whichever number is on the site at showtime.
+- ✅ Framework-count drift resolved (sp-dub): README table and `examples/integrations/` both list **8 framework entries** (6 MCP-native + 2 Composio bridges). Founder's script, README, and directory now agree on "eight agent frameworks." Cite that number on stage.
 
 ---
 
@@ -187,7 +187,7 @@ forcing. You get JSON, not vibes."*
 Open `examples/integrations/openai_agents.py` in a second pane (or the
 web page if it renders better). Scroll — do not read. Say:
 
-> "Six agent frameworks, one MCP server. No SynthPanel-specific SDK.
+> "Eight agent frameworks, one MCP server. No SynthPanel-specific SDK.
 > If your framework speaks MCP, you already have a SynthPanel adapter."
 
 Highlight the shortest example (OpenAI Agents SDK is ~20 lines). Call
@@ -242,9 +242,10 @@ booth."*
   direct CLI call instead of MCP-sampling and the laptop doesn't have
   a key set, the demo dies. Mitigation: the aliased `synthpanel demo`
   above should force the MCP-sampling path, not a direct provider call.
-- **Framework-integration claim drift:** six frameworks in the mail,
-  seven on the landing page, eight files in the directory. Pick one
-  number for the founder's script and make the site match before stage.
+- ~~**Framework-integration claim drift:**~~ **Resolved (sp-dub):** README
+  table, `examples/integrations/` directory, and founder's script all
+  now agree on **eight agent frameworks** (6 MCP-native + 2 Composio
+  bridges). Use that number on stage.
 - **Dolt / backend dependency:** if any of the demo assets (panel
   result persistence, saved sessions) touches the Dolt server and it
   hiccups mid-demo, there's no graceful fallback on stage. For tonight,

--- a/site/index.html
+++ b/site/index.html
@@ -87,9 +87,12 @@
           Run synthetic focus groups with any LLM.
         </p>
         <p class="mx-auto mt-3 max-w-2xl text-base text-slate-400">
-          Define personas in YAML. Define your research instrument in YAML. Run
-          against Claude, GPT, Gemini, Grok, or any OpenAI-compatible model —
-          from your terminal, a pipeline, or an AI agent's MCP tool call.
+          <span class="text-emerald-300">Zero-config inside Claude Desktop, Claude Code, Cursor, or any MCP host
+          that advertises sampling</span> — drop the config in, run a panel with
+          <strong class="text-slate-200">no API key set</strong>. Or bring your own
+          key (Claude, GPT, Gemini, Grok, local) for reproducibility, ensembles,
+          and larger panels. Personas and instruments are plain YAML — run from
+          your terminal, a pipeline, or an AI agent's MCP tool call.
         </p>
 
         <!-- Install command -->


### PR DESCRIPTION
## Summary
- Move sampling-fallback messaging to the opening paragraph of README and landing page
- Align framework count to 8 across surface copy

## Source
- Polecat: capable
- Issue: sp-dub
- MR: sp-wisp-lwp
- Branch: polecat/capable-mo6a6vub

## Test plan
- [ ] CI passes
- [ ] Copy reads cleanly in README + landing hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)