### PR TITLE
seo: add Schema.org JSON-LD, tighten meta descriptions, og:site_name (sp-ovl)

### DIFF
--- a/site/blog/synthpanel-vs-commercial-alternatives.html
+++ b/site/blog/synthpanel-vs-commercial-alternatives.html
@@ -9,7 +9,7 @@
     </title>
     <meta
       name="description"
-      content="SynthPanel is the open-source, LLM-agnostic alternative to commercial synthetic-respondent tools (Synthetic Users, FocusPanel.ai, Delve.ai, POPJAM). CLI + MCP server for Claude Code, Cursor, Windsurf, Zed. MIT-licensed. SPS 0.90 on SynthBench."
+      content="Open-source alternative to Synthetic Users, FocusPanel.ai, Delve.ai. CLI + MCP server, any LLM, SPS 0.90 on SynthBench. MIT-licensed."
     />
     <meta
       name="keywords"

--- a/site/index.html
+++ b/site/index.html
@@ -6,23 +6,56 @@
     <title>synthpanel — Run synthetic focus groups with any LLM</title>
     <meta
       name="description"
-      content="Open-source synthetic focus groups. Define personas in YAML, run them against any LLM (Claude, GPT, Gemini, Grok, local), and get structured, reproducible output with full cost transparency."
+      content="Open-source synthetic focus group tool. Personas in YAML, any LLM (Claude, GPT, Gemini, Grok). CLI + MCP server. MIT-licensed."
     />
     <link rel="canonical" href="https://synthpanel.dev/" />
 
+    <meta name="keywords" content="synthetic focus group, MCP server research, open source user research, AI persona research, synthetic respondents, LLM research tool, synthetic survey, AI focus group, market research tool" />
+
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="synthpanel" />
+    <meta property="og:site_name" content="synthpanel" />
+    <meta property="og:title" content="synthpanel — Run synthetic focus groups with any LLM" />
     <meta
       property="og:description"
-      content="Run synthetic focus groups with any LLM. Pip-install, define personas in YAML, get structured output."
+      content="Open-source synthetic focus group tool. Pip-install, define personas in YAML, run against Claude / GPT / Gemini / Grok. CLI + MCP server. MIT-licensed."
     />
     <meta property="og:url" content="https://synthpanel.dev/" />
     <meta name="twitter:card" content="summary" />
-    <meta name="twitter:title" content="synthpanel" />
+    <meta name="twitter:title" content="synthpanel — synthetic focus groups, any LLM" />
     <meta
       name="twitter:description"
-      content="Run synthetic focus groups with any LLM."
+      content="Open-source synthetic focus group tool. CLI + MCP server for Claude Code, Cursor, Windsurf."
     />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "synthpanel",
+        "alternateName": "SynthPanel",
+        "description": "Open-source synthetic focus group tool. Define personas in YAML, run them against any LLM (Claude, GPT, Gemini, Grok), get structured output. CLI + 12-tool MCP server for Claude Code, Cursor, Windsurf, Zed.",
+        "url": "https://synthpanel.dev/",
+        "applicationCategory": "DeveloperApplication",
+        "applicationSubCategory": "Research Tool",
+        "operatingSystem": "Cross-platform",
+        "softwareVersion": "0.9.1",
+        "license": "https://opensource.org/licenses/MIT",
+        "codeRepository": "https://github.com/DataViking-Tech/SynthPanel",
+        "downloadUrl": "https://pypi.org/project/synthpanel/",
+        "programmingLanguage": "Python",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "author": {
+          "@type": "Organization",
+          "name": "DataViking",
+          "url": "https://dataviking.tech"
+        },
+        "keywords": "synthetic focus group, MCP server, open source user research, AI persona research, synthetic respondents, LLM research"
+      }
+    </script>
 
     <link
       rel="icon"

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -8,23 +8,59 @@
     </title>
     <meta
       name="description"
-      content="synthpanel's MCP server exposes 12 tools for AI agents to run synthetic focus groups, manage persona packs, and query panel results. Drop-in config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop."
+      content="MCP server with 12 tools for synthetic focus group research. Drop-in config for Claude Code, Cursor, Windsurf, Zed, Claude Desktop."
     />
     <link rel="canonical" href="https://synthpanel.dev/mcp" />
 
+    <meta name="keywords" content="MCP server, Model Context Protocol, synthetic focus group, Claude Code MCP, Cursor MCP, Windsurf MCP, AI agent research tool, synthpanel MCP" />
+
     <meta property="og:type" content="article" />
-    <meta property="og:title" content="synthpanel MCP Server" />
+    <meta property="og:site_name" content="synthpanel" />
+    <meta property="og:title" content="synthpanel MCP Server — synthetic focus groups from your AI editor" />
     <meta
       property="og:description"
-      content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop. 12 tools to run synthetic focus groups from chat."
+      content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, Claude Desktop. 12 tools to run synthetic focus groups, manage persona packs, and query panel results from chat."
     />
     <meta property="og:url" content="https://synthpanel.dev/mcp" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="synthpanel MCP Server" />
     <meta
       name="twitter:description"
-      content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop."
+      content="12 MCP tools for synthetic focus groups. Works with Claude Code, Cursor, Windsurf, Zed, Claude Desktop."
     />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "synthpanel MCP Server",
+        "description": "Model Context Protocol server exposing 12 tools for AI agents to run synthetic focus groups, manage persona packs, and query panel results. Drop-in integration for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop.",
+        "url": "https://synthpanel.dev/mcp",
+        "applicationCategory": "DeveloperApplication",
+        "applicationSubCategory": "MCP Server",
+        "operatingSystem": "Cross-platform",
+        "license": "https://opensource.org/licenses/MIT",
+        "codeRepository": "https://github.com/DataViking-Tech/SynthPanel",
+        "downloadUrl": "https://pypi.org/project/synthpanel/",
+        "programmingLanguage": "Python",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "isPartOf": {
+          "@type": "SoftwareApplication",
+          "name": "synthpanel",
+          "url": "https://synthpanel.dev/"
+        },
+        "author": {
+          "@type": "Organization",
+          "name": "DataViking",
+          "url": "https://dataviking.tech"
+        },
+        "featureList": "run_prompt, run_panel, run_quick_poll, extend_panel, list_persona_packs, get_persona_pack, save_persona_pack, list_instrument_packs, get_instrument_pack, save_instrument_pack, list_panel_results, get_panel_result"
+      }
+    </script>
 
     <link
       rel="icon"


### PR DESCRIPTION
## Summary
- Add Schema.org JSON-LD structured data for richer search previews
- Tighten meta descriptions across landing, blog, and MCP pages
- Add og:site_name for consistent social share attribution

## Source
- Polecat: dag
- Issue: sp-ovl
- MR: sp-wisp-4gp
- Branch: polecat/dag-mo75rmn4

## Test plan
- [ ] CI passes
- [ ] JSON-LD validates via Google Rich Results tester
- [ ] Meta tags render correctly in social card preview

## Conflict note
Touches site/index.html (overlaps with PRs #169, #171, #172, #173, #174). Rebase required after siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)