### PR TITLE
feat(cli): add synthpanel login/logout/whoami credential store (sp-lve)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ pip install synthpanel[mcp]
 # Or install from source for the latest unreleased changes
 pip install git+https://github.com/DataViking-Tech/SynthPanel.git@main
 
-# Set your API key (Claude, OpenAI, Gemini, xAI, or any OpenAI-compatible provider)
+# Provide an API key (Claude, OpenAI, Gemini, xAI, or any OpenAI-compatible provider)
+# — either export it in your shell:
 export ANTHROPIC_API_KEY="sk-..."
+# — or persist it once with `synthpanel login` (stored at
+#   ~/.config/synthpanel/credentials.json, mode 0600):
+synthpanel login --provider anthropic --api-key sk-...
+synthpanel whoami   # see which providers have credentials available
 
 # Run a single prompt
 synthpanel prompt "What do you think of the name Traitprint for a career app?"

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -16,6 +16,7 @@ import yaml
 
 from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cost import ZERO_USAGE, TokenUsage, estimate_cost, format_summary, lookup_pricing
+from synth_panel.credentials import has_credential
 from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
 from synth_panel.metadata import PanelTimer, build_metadata
@@ -51,15 +52,14 @@ _DEFAULT_MODEL_PREFERENCE: list[tuple[str, str]] = [
 def _resolve_default_model() -> tuple[str, str | None]:
     """Pick a default model alias based on which API keys are present.
 
-    Returns ``(model_alias, source_env_var)``. If no provider credentials
-    are available the fallback is still ``"sonnet"`` (the previous
-    hard-coded default) so the LLM client's own credential check can
-    emit its canonical error message.
+    Returns ``(model_alias, source_env_var)``. Consults both the
+    environment and the on-disk credential store so ``synthpanel login``
+    is enough to get a working default. If nothing is available the
+    fallback is still ``"sonnet"`` so the LLM client's own credential
+    check emits the canonical error message.
     """
-    import os
-
     for env_var, alias in _DEFAULT_MODEL_PREFERENCE:
-        if os.environ.get(env_var, "").strip():
+        if has_credential(env_var):
             return alias, env_var
     return "sonnet", None
 
@@ -1695,3 +1695,177 @@ def _format_path(path: list[dict[str, Any]]) -> str:
         else:
             parts.append(f"-> {nxt}")
     return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Credential commands (sp-lve)
+# ---------------------------------------------------------------------------
+
+
+_PROVIDER_ENV_VAR: dict[str, str] = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "xai": "XAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+
+def _read_api_key_interactive() -> str:
+    """Read an API key from stdin.
+
+    Uses :func:`getpass.getpass` when attached to a TTY so the key
+    doesn't echo; falls back to a plain ``input`` read when stdin is
+    piped (CI, scripts) so ``echo sk-... | synthpanel login`` still
+    works.
+    """
+    import getpass
+
+    if sys.stdin.isatty():
+        return getpass.getpass("API key: ").strip()
+    return sys.stdin.readline().strip()
+
+
+def handle_login(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Store an API key for the selected provider.
+
+    Reads the key from ``--api-key`` or stdin (hidden on TTY) and writes
+    it to the on-disk credential store. Validates that the provider
+    name maps to a recognised env var so typos don't silently persist.
+    """
+    from synth_panel.credentials import (
+        KNOWN_CREDENTIAL_ENV_VARS,
+        PROVIDER_LABELS,
+        save_credential,
+    )
+
+    provider = getattr(args, "provider", None) or "anthropic"
+    env_var = _PROVIDER_ENV_VAR.get(provider)
+    if env_var is None or env_var not in KNOWN_CREDENTIAL_ENV_VARS:
+        msg = f"Unknown provider: {provider!r}"
+        if fmt is OutputFormat.TEXT:
+            print(msg, file=sys.stderr)
+        else:
+            emit(fmt, message=msg, extra={"error": "unknown_provider"})
+        return 2
+
+    key = (getattr(args, "api_key", None) or "").strip()
+    if not key:
+        key = _read_api_key_interactive()
+    if not key:
+        msg = "No API key provided."
+        if fmt is OutputFormat.TEXT:
+            print(msg, file=sys.stderr)
+        else:
+            emit(fmt, message=msg, extra={"error": "empty_key"})
+        return 2
+
+    path = save_credential(env_var, key)
+    label = PROVIDER_LABELS.get(env_var, provider)
+    if fmt is OutputFormat.TEXT:
+        print(f"Stored {label} key ({env_var}) in {path}")
+    else:
+        emit(
+            fmt,
+            message="credential_stored",
+            extra={"provider": provider, "env_var": env_var, "path": str(path)},
+        )
+    return 0
+
+
+def handle_logout(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Remove one or all stored API keys."""
+    from synth_panel.credentials import (
+        KNOWN_CREDENTIAL_ENV_VARS,
+        delete_credential,
+        load_credentials,
+    )
+
+    provider = getattr(args, "provider", None) or "anthropic"
+
+    if provider == "all":
+        stored = list(load_credentials().keys())
+        removed = [env for env in stored if delete_credential(env)]
+        if fmt is OutputFormat.TEXT:
+            if removed:
+                print(f"Removed {len(removed)} stored credential(s): {', '.join(removed)}")
+            else:
+                print("No stored credentials to remove.")
+        else:
+            emit(fmt, message="credentials_removed", extra={"removed": removed})
+        return 0
+
+    env_var = _PROVIDER_ENV_VAR.get(provider)
+    if env_var is None or env_var not in KNOWN_CREDENTIAL_ENV_VARS:
+        msg = f"Unknown provider: {provider!r}"
+        if fmt is OutputFormat.TEXT:
+            print(msg, file=sys.stderr)
+        else:
+            emit(fmt, message=msg, extra={"error": "unknown_provider"})
+        return 2
+
+    removed = delete_credential(env_var)
+    if fmt is OutputFormat.TEXT:
+        if removed:
+            print(f"Removed stored credential: {env_var}")
+        else:
+            print(f"No stored credential for {env_var}")
+    else:
+        emit(
+            fmt,
+            message="credential_removed" if removed else "credential_absent",
+            extra={"provider": provider, "env_var": env_var, "removed": removed},
+        )
+    return 0
+
+
+def handle_whoami(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Report which providers have credentials available (env or stored)."""
+    import os
+
+    from synth_panel.credentials import (
+        KNOWN_CREDENTIAL_ENV_VARS,
+        PROVIDER_LABELS,
+        credentials_path,
+        load_credentials,
+    )
+
+    stored = load_credentials()
+    rows: list[dict[str, Any]] = []
+    for env_var in KNOWN_CREDENTIAL_ENV_VARS:
+        env_set = bool(os.environ.get(env_var, "").strip())
+        stored_set = env_var in stored
+        source: str | None = None
+        if env_set:
+            source = "env"
+        elif stored_set:
+            source = "stored"
+        rows.append(
+            {
+                "provider": PROVIDER_LABELS.get(env_var, env_var),
+                "env_var": env_var,
+                "available": env_set or stored_set,
+                "source": source,
+            }
+        )
+
+    if fmt is OutputFormat.TEXT:
+        any_available = any(r["available"] for r in rows)
+        if not any_available:
+            print("No provider credentials found.")
+            print("Run `synthpanel login` or export an API key env var.")
+        else:
+            print(f"Credential store: {credentials_path()}")
+            for row in rows:
+                if not row["available"]:
+                    continue
+                print(f"  [{row['source']:<6}] {row['env_var']:<20} — {row['provider']}")
+        return 0
+
+    emit(
+        fmt,
+        message="credentials_status",
+        extra={"credentials_path": str(credentials_path()), "providers": rows},
+    )
+    return 0

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -485,4 +485,41 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start the MCP server (stdio transport).",
     )
 
+    # login (sp-lve: credential UX — persist an API key to disk so CLI
+    # use without exported env vars isn't a dead end).
+    login_parser = subparsers.add_parser(
+        "login",
+        help="Store an LLM provider API key at ~/.config/synthpanel/credentials.json (mode 0600).",
+    )
+    login_parser.add_argument(
+        "--provider",
+        default="anthropic",
+        choices=["anthropic", "openai", "gemini", "google", "xai", "openrouter"],
+        help="Provider to log in to (default: anthropic).",
+    )
+    login_parser.add_argument(
+        "--api-key",
+        default=None,
+        metavar="KEY",
+        help="API key. If omitted, reads from stdin (hidden when attached to a TTY).",
+    )
+
+    # logout
+    logout_parser = subparsers.add_parser(
+        "logout",
+        help="Remove a stored API key from the credential store.",
+    )
+    logout_parser.add_argument(
+        "--provider",
+        default=None,
+        choices=["anthropic", "openai", "gemini", "google", "xai", "openrouter", "all"],
+        help="Provider to log out (default: anthropic). Use 'all' to remove every stored key.",
+    )
+
+    # whoami — show which providers have usable creds
+    subparsers.add_parser(
+        "whoami",
+        help="Show which providers have credentials available (env or stored).",
+    )
+
     return parser

--- a/src/synth_panel/credentials.py
+++ b/src/synth_panel/credentials.py
@@ -1,0 +1,152 @@
+"""On-disk credential store for SynthPanel (sp-lve).
+
+Users who don't want to export an ``ANTHROPIC_API_KEY`` (etc.) in every
+shell can run ``synthpanel login`` to persist a key to
+``~/.config/synthpanel/credentials.json`` (mode ``0600``). Provider code
+then resolves credentials in two steps: environment variable first,
+config file second.
+
+This avoids the broken zero-config experience where a developer with
+Claude Code installed types ``synthpanel prompt`` and hits "Missing API
+key" — Claude Code's OAuth tokens live in the macOS keychain under a
+different auth scheme and aren't reusable as Anthropic API keys, so we
+offer a dedicated ``synthpanel login`` instead of auto-bridging.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+from pathlib import Path
+
+# Recognised provider env var names. ``synthpanel login`` validates
+# against this list so a typo doesn't silently persist a key nothing
+# will ever read.
+KNOWN_CREDENTIAL_ENV_VARS: tuple[str, ...] = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "XAI_API_KEY",
+    "OPENROUTER_API_KEY",
+)
+
+# Friendly provider label for each env var (used by ``whoami`` output).
+PROVIDER_LABELS: dict[str, str] = {
+    "ANTHROPIC_API_KEY": "Anthropic",
+    "OPENAI_API_KEY": "OpenAI",
+    "GEMINI_API_KEY": "Google (Gemini)",
+    "GOOGLE_API_KEY": "Google (Gemini)",
+    "XAI_API_KEY": "xAI",
+    "OPENROUTER_API_KEY": "OpenRouter",
+}
+
+
+def credentials_path() -> Path:
+    """Return the path to the credential store.
+
+    Honors ``SYNTHPANEL_CREDENTIALS_PATH`` for tests and XDG-style
+    overrides, then falls back to ``~/.config/synthpanel/credentials.json``.
+    """
+    override = os.environ.get("SYNTHPANEL_CREDENTIALS_PATH", "").strip()
+    if override:
+        return Path(override).expanduser()
+    xdg = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    base = Path(xdg).expanduser() if xdg else Path.home() / ".config"
+    return base / "synthpanel" / "credentials.json"
+
+
+def load_credentials() -> dict[str, str]:
+    """Return stored credentials as ``{env_var: value}``.
+
+    Returns an empty dict if the file is missing or unreadable. Only
+    string values are kept so malformed entries can't crash the caller.
+    """
+    path = credentials_path()
+    if not path.exists():
+        return {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw) if raw.strip() else {}
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): str(v) for k, v in data.items() if isinstance(k, str) and isinstance(v, str) and v}
+
+
+def save_credential(env_var: str, value: str) -> Path:
+    """Persist ``value`` under ``env_var`` in the credential store.
+
+    Creates the parent directory with mode ``0700`` and writes the file
+    atomically (write temp + rename) with mode ``0600`` so other local
+    users cannot read the API key.
+
+    Returns the path that was written.
+    """
+    env_var = env_var.strip().upper()
+    value = value.strip()
+    if not env_var:
+        raise ValueError("env_var must be non-empty")
+    if not value:
+        raise ValueError("value must be non-empty")
+
+    existing = load_credentials()
+    existing[env_var] = value
+
+    path = credentials_path()
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        os.chmod(parent, 0o700)
+
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return path
+
+
+def delete_credential(env_var: str) -> bool:
+    """Remove ``env_var`` from the credential store.
+
+    Returns True if an entry was removed, False if it was absent.
+    """
+    env_var = env_var.strip().upper()
+    existing = load_credentials()
+    if env_var not in existing:
+        return False
+    del existing[env_var]
+    path = credentials_path()
+    if existing:
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with contextlib.suppress(OSError):
+            os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    else:
+        with contextlib.suppress(FileNotFoundError):
+            path.unlink()
+    return True
+
+
+def get_credential(env_var: str) -> str | None:
+    """Return a credential value for ``env_var``.
+
+    Precedence: environment variable first, then the on-disk store.
+    Returns ``None`` when nothing is set so callers can decide whether
+    that's an error or a pass-through (e.g. provider picking between
+    GEMINI_API_KEY and GOOGLE_API_KEY).
+    """
+    value = os.environ.get(env_var, "").strip()
+    if value:
+        return value
+    stored = load_credentials().get(env_var, "").strip()
+    return stored or None
+
+
+def has_credential(env_var: str) -> bool:
+    """Return True if the env var is set or stored on disk."""
+    return get_credential(env_var) is not None

--- a/src/synth_panel/llm/client.py
+++ b/src/synth_panel/llm/client.py
@@ -83,7 +83,9 @@ class LLMClient:
                     return provider
 
         raise LLMError(
-            "No LLM provider credentials found. Set ANTHROPIC_API_KEY, GEMINI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, or OPENAI_API_KEY.",
+            "No LLM provider credentials found. Run `synthpanel login` or set "
+            "ANTHROPIC_API_KEY, GEMINI_API_KEY, XAI_API_KEY, OPENROUTER_API_KEY, "
+            "or OPENAI_API_KEY.",
             LLMErrorCategory.MISSING_CREDENTIALS,
         )
 

--- a/src/synth_panel/llm/providers/base.py
+++ b/src/synth_panel/llm/providers/base.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from dataclasses import dataclass
 
+from synth_panel.credentials import get_credential, has_credential
 from synth_panel.llm.errors import LLMError, LLMErrorCategory
 from synth_panel.llm.models import CompletionRequest, CompletionResponse, StreamEvent
 
@@ -21,11 +22,11 @@ class ProviderConfig:
     model_prefixes: tuple[str, ...]
 
     def get_api_key(self) -> str:
-        """Read the API key from the environment, raising on missing."""
-        key = os.environ.get(self.api_key_env, "").strip()
+        """Return the API key from env or the on-disk credential store."""
+        key = get_credential(self.api_key_env)
         if not key:
             raise LLMError(
-                f"Missing API key: set {self.api_key_env}",
+                f"Missing API key: set {self.api_key_env} or run `synthpanel login`",
                 LLMErrorCategory.MISSING_CREDENTIALS,
             )
         return key
@@ -35,8 +36,8 @@ class ProviderConfig:
         return os.environ.get(self.base_url_env, "").strip() or self.default_base_url
 
     def has_credentials(self) -> bool:
-        """Return True if the API key is present in the environment."""
-        return bool(os.environ.get(self.api_key_env, "").strip())
+        """Return True if the API key is set in env or on disk."""
+        return has_credential(self.api_key_env)
 
 
 class LLMProvider(ABC):

--- a/src/synth_panel/llm/providers/gemini.py
+++ b/src/synth_panel/llm/providers/gemini.py
@@ -7,11 +7,11 @@ so this provider translates our internal request/response models to that format.
 from __future__ import annotations
 
 import json
-import os
 from collections.abc import Iterator
 
 import httpx
 
+from synth_panel.credentials import get_credential
 from synth_panel.llm.errors import LLMError, LLMErrorCategory, classify_http_status
 from synth_panel.llm.models import (
     CompletionRequest,
@@ -39,13 +39,12 @@ class GeminiProvider(LLMProvider):
     config = GEMINI_CONFIG
 
     def __init__(self) -> None:
-        # Support both GEMINI_API_KEY and GOOGLE_API_KEY
-        key = os.environ.get("GEMINI_API_KEY", "").strip()
-        if not key:
-            key = os.environ.get("GOOGLE_API_KEY", "").strip()
+        # Support both GEMINI_API_KEY and GOOGLE_API_KEY, resolved via env
+        # or the on-disk credential store.
+        key = get_credential("GEMINI_API_KEY") or get_credential("GOOGLE_API_KEY")
         if not key:
             raise LLMError(
-                "Missing API key: set GEMINI_API_KEY or GOOGLE_API_KEY",
+                "Missing API key: set GEMINI_API_KEY / GOOGLE_API_KEY or run `synthpanel login --provider gemini`",
                 LLMErrorCategory.MISSING_CREDENTIALS,
             )
         self._api_key = key

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -14,6 +14,8 @@ from synth_panel.cli.commands import (
     handle_instruments_install,
     handle_instruments_list,
     handle_instruments_show,
+    handle_login,
+    handle_logout,
     handle_mcp_serve,
     handle_pack_export,
     handle_pack_generate,
@@ -23,6 +25,7 @@ from synth_panel.cli.commands import (
     handle_panel_run,
     handle_panel_synthesize,
     handle_prompt,
+    handle_whoami,
 )
 from synth_panel.cli.output import OutputFormat
 from synth_panel.cli.parser import build_parser
@@ -87,6 +90,12 @@ def main(argv: list[str] | None = None) -> int:
         return handle_analyze(args, output_format)
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
+    elif args.command == "login":
+        return handle_login(args, output_format)
+    elif args.command == "logout":
+        return handle_logout(args, output_format)
+    elif args.command == "whoami":
+        return handle_whoami(args, output_format)
     else:
         # No subcommand → interactive REPL
         return run_repl(args, output_format)

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -29,7 +29,6 @@ that used to receive the raw MCP payload.
 
 from __future__ import annotations
 
-import os
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -112,15 +111,18 @@ _DEFAULT_MODEL_PREFERENCE: list[tuple[str, str]] = [
 
 
 def _default_model() -> str:
-    """Pick a default alias from the first provider with credentials in the env.
+    """Pick a default alias from the first provider with credentials.
 
     Mirrors the CLI's resolution order so ``from synth_panel import quick_poll``
-    works with whichever API key the user has set, falling back to
-    ``"sonnet"`` when nothing is set (so the LLM client's missing-
-    credentials error is the one the user sees).
+    works with whichever API key the user has set (env var or
+    ``synthpanel login``), falling back to ``"sonnet"`` when nothing is
+    set (so the LLM client's missing-credentials error is the one the
+    user sees).
     """
+    from synth_panel.credentials import has_credential
+
     for env_var, alias in _DEFAULT_MODEL_PREFERENCE:
-        if os.environ.get(env_var, "").strip():
+        if has_credential(env_var):
             return alias
     return "sonnet"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ class of bugs structurally impossible in CI.
 from __future__ import annotations
 
 import socket
+from pathlib import Path
 
 import pytest
 
@@ -41,3 +42,16 @@ def _block_network(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPat
     if "acceptance" in markers:
         return  # Let acceptance tests use real network
     monkeypatch.setattr(socket.socket, "connect", _guarded_connect)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_credentials_store(tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the SynthPanel credential store at a unique tmp path per test.
+
+    Prevents a developer's real ``~/.config/synthpanel/credentials.json``
+    from bleeding into tests that assume ``MISSING_CREDENTIALS`` (sp-lve).
+    Individual tests can still write to the path by calling
+    :func:`synth_panel.credentials.save_credential`.
+    """
+    sandbox: Path = tmp_path_factory.mktemp("synthpanel-creds")
+    monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(sandbox / "credentials.json"))

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -1,0 +1,154 @@
+"""Tests for the login / logout / whoami CLI (sp-lve)."""
+
+from __future__ import annotations
+
+import io
+import json
+from unittest.mock import patch
+
+from synth_panel.cli.parser import build_parser
+from synth_panel.credentials import load_credentials, save_credential
+from synth_panel.main import main
+
+
+class TestParser:
+    def test_login_defaults_to_anthropic(self):
+        parser = build_parser()
+        args = parser.parse_args(["login"])
+        assert args.command == "login"
+        assert args.provider == "anthropic"
+        assert args.api_key is None
+
+    def test_login_accepts_provider_and_api_key(self):
+        parser = build_parser()
+        args = parser.parse_args(["login", "--provider", "openai", "--api-key", "sk-123"])
+        assert args.provider == "openai"
+        assert args.api_key == "sk-123"
+
+    def test_logout_has_all_option(self):
+        parser = build_parser()
+        args = parser.parse_args(["logout", "--provider", "all"])
+        assert args.command == "logout"
+        assert args.provider == "all"
+
+    def test_whoami_is_registered(self):
+        parser = build_parser()
+        args = parser.parse_args(["whoami"])
+        assert args.command == "whoami"
+
+
+class TestLogin:
+    def test_login_stores_key_from_flag(self, capsys):
+        rc = main(["login", "--provider", "anthropic", "--api-key", "sk-cli"])
+        assert rc == 0
+        assert load_credentials() == {"ANTHROPIC_API_KEY": "sk-cli"}
+        assert "Stored" in capsys.readouterr().out
+
+    def test_login_reads_key_from_piped_stdin(self, capsys):
+        with patch("sys.stdin", new=io.StringIO("sk-piped\n")):
+            rc = main(["login", "--provider", "openai"])
+        assert rc == 0
+        assert load_credentials() == {"OPENAI_API_KEY": "sk-piped"}
+
+    def test_login_rejects_empty_key(self, capsys):
+        with patch("sys.stdin", new=io.StringIO("\n")):
+            rc = main(["login", "--provider", "anthropic"])
+        assert rc == 2
+        assert load_credentials() == {}
+
+    def test_login_emits_json_when_requested(self, capsys):
+        rc = main(["--output-format", "json", "login", "--provider", "xai", "--api-key", "xk"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["message"] == "credential_stored"
+        assert payload["env_var"] == "XAI_API_KEY"
+
+
+class TestLogout:
+    def test_logout_removes_single_provider(self, capsys):
+        save_credential("ANTHROPIC_API_KEY", "sk-a")
+        save_credential("OPENAI_API_KEY", "sk-b")
+        rc = main(["logout", "--provider", "anthropic"])
+        assert rc == 0
+        assert load_credentials() == {"OPENAI_API_KEY": "sk-b"}
+
+    def test_logout_all_clears_store(self, capsys):
+        save_credential("ANTHROPIC_API_KEY", "sk-a")
+        save_credential("OPENAI_API_KEY", "sk-b")
+        rc = main(["logout", "--provider", "all"])
+        assert rc == 0
+        assert load_credentials() == {}
+
+    def test_logout_missing_provider_still_exits_zero(self, capsys):
+        rc = main(["logout", "--provider", "anthropic"])
+        assert rc == 0
+        assert "No stored credential" in capsys.readouterr().out
+
+
+class TestWhoami:
+    def test_whoami_reports_no_credentials(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        rc = main(["whoami"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No provider credentials found" in out
+
+    def test_whoami_reports_stored_credential(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        save_credential("ANTHROPIC_API_KEY", "sk-disk")
+        rc = main(["whoami"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "ANTHROPIC_API_KEY" in out
+        assert "stored" in out
+
+    def test_whoami_reports_env_source_when_set(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+        rc = main(["whoami"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "env" in out
+
+    def test_whoami_json_output(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        save_credential("XAI_API_KEY", "sk-x")
+        rc = main(["--output-format", "json", "whoami"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["message"] == "credentials_status"
+        xai = next(p for p in payload["providers"] if p["env_var"] == "XAI_API_KEY")
+        assert xai["available"] is True
+        assert xai["source"] == "stored"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,0 +1,212 @@
+"""Tests for the credential store (sp-lve)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from synth_panel.credentials import (
+    credentials_path,
+    delete_credential,
+    get_credential,
+    has_credential,
+    load_credentials,
+    save_credential,
+)
+
+
+class TestCredentialsPath:
+    def test_honors_override_env_var(self, monkeypatch, tmp_path):
+        override = tmp_path / "custom.json"
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(override))
+        assert credentials_path() == override
+
+    def test_respects_xdg_config_home(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        assert credentials_path() == tmp_path / "synthpanel" / "credentials.json"
+
+    def test_default_is_under_home_dot_config(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+        assert credentials_path() == tmp_path / ".config" / "synthpanel" / "credentials.json"
+
+
+class TestSaveAndLoad:
+    def test_save_then_load_roundtrip(self):
+        save_credential("ANTHROPIC_API_KEY", "sk-test-1")
+        save_credential("OPENAI_API_KEY", "sk-test-2")
+        loaded = load_credentials()
+        assert loaded == {"ANTHROPIC_API_KEY": "sk-test-1", "OPENAI_API_KEY": "sk-test-2"}
+
+    def test_save_overwrites_existing_value(self):
+        save_credential("ANTHROPIC_API_KEY", "sk-old")
+        save_credential("ANTHROPIC_API_KEY", "sk-new")
+        assert load_credentials() == {"ANTHROPIC_API_KEY": "sk-new"}
+
+    def test_save_normalises_whitespace_and_case(self):
+        path = save_credential("  anthropic_api_key  ", "  sk-val  ")
+        data = json.loads(path.read_text())
+        assert data == {"ANTHROPIC_API_KEY": "sk-val"}
+
+    def test_save_rejects_empty_value(self):
+        with pytest.raises(ValueError):
+            save_credential("ANTHROPIC_API_KEY", "   ")
+
+    def test_save_rejects_empty_env_var(self):
+        with pytest.raises(ValueError):
+            save_credential("", "sk-test")
+
+    def test_load_returns_empty_when_missing(self):
+        assert load_credentials() == {}
+
+    def test_load_tolerates_malformed_json(self, monkeypatch, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json")
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(path))
+        assert load_credentials() == {}
+
+    def test_load_tolerates_wrong_top_level_type(self, monkeypatch, tmp_path):
+        path = tmp_path / "list.json"
+        path.write_text("[1, 2, 3]")
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(path))
+        assert load_credentials() == {}
+
+    def test_load_drops_non_string_entries(self, monkeypatch, tmp_path):
+        path = tmp_path / "mixed.json"
+        path.write_text(json.dumps({"ANTHROPIC_API_KEY": "sk-ok", "N": 42, "X": ""}))
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(path))
+        assert load_credentials() == {"ANTHROPIC_API_KEY": "sk-ok"}
+
+
+class TestFilePermissions:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions")
+    def test_credential_file_is_mode_0600(self):
+        path = save_credential("ANTHROPIC_API_KEY", "sk-test")
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == 0o600
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions")
+    def test_parent_directory_is_mode_0700(self):
+        path = save_credential("ANTHROPIC_API_KEY", "sk-test")
+        parent_mode = stat.S_IMODE(path.parent.stat().st_mode)
+        assert parent_mode == 0o700
+
+
+class TestDelete:
+    def test_delete_removes_entry(self):
+        save_credential("ANTHROPIC_API_KEY", "sk-a")
+        save_credential("OPENAI_API_KEY", "sk-b")
+        assert delete_credential("ANTHROPIC_API_KEY") is True
+        assert load_credentials() == {"OPENAI_API_KEY": "sk-b"}
+
+    def test_delete_missing_returns_false(self):
+        assert delete_credential("ANTHROPIC_API_KEY") is False
+
+    def test_delete_last_entry_removes_file(self):
+        save_credential("ANTHROPIC_API_KEY", "sk-only")
+        path = credentials_path()
+        assert path.exists()
+        assert delete_credential("ANTHROPIC_API_KEY") is True
+        assert not path.exists()
+
+
+class TestGetCredential:
+    def test_env_var_wins_over_stored(self, monkeypatch):
+        save_credential("ANTHROPIC_API_KEY", "sk-stored")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env")
+        assert get_credential("ANTHROPIC_API_KEY") == "sk-env"
+
+    def test_falls_back_to_stored_when_env_empty(self, monkeypatch):
+        save_credential("ANTHROPIC_API_KEY", "sk-stored")
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert get_credential("ANTHROPIC_API_KEY") == "sk-stored"
+
+    def test_whitespace_only_env_is_treated_as_unset(self, monkeypatch):
+        save_credential("ANTHROPIC_API_KEY", "sk-stored")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+        assert get_credential("ANTHROPIC_API_KEY") == "sk-stored"
+
+    def test_returns_none_when_nowhere(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert get_credential("ANTHROPIC_API_KEY") is None
+
+    def test_has_credential_mirrors_get_credential(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert has_credential("ANTHROPIC_API_KEY") is False
+        save_credential("ANTHROPIC_API_KEY", "sk-x")
+        assert has_credential("ANTHROPIC_API_KEY") is True
+
+
+class TestProviderIntegration:
+    """Provider config reads credentials through ``get_credential``."""
+
+    def test_anthropic_provider_uses_stored_credential(self, monkeypatch):
+        from synth_panel.llm.providers.anthropic import AnthropicProvider
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        save_credential("ANTHROPIC_API_KEY", "sk-disk")
+        provider = AnthropicProvider()
+        assert provider._api_key == "sk-disk"
+
+    def test_anthropic_provider_env_wins_over_stored(self, monkeypatch):
+        from synth_panel.llm.providers.anthropic import AnthropicProvider
+
+        save_credential("ANTHROPIC_API_KEY", "sk-disk")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-env")
+        provider = AnthropicProvider()
+        assert provider._api_key == "sk-env"
+
+    def test_gemini_provider_uses_stored_credential(self, monkeypatch):
+        from synth_panel.llm.providers.gemini import GeminiProvider
+
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        save_credential("GOOGLE_API_KEY", "sk-gem")
+        provider = GeminiProvider()
+        assert provider._api_key == "sk-gem"
+
+    def test_missing_credentials_error_mentions_login(self, monkeypatch):
+        from synth_panel.llm.errors import LLMErrorCategory
+        from synth_panel.llm.providers.anthropic import AnthropicProvider
+
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        # No stored credential thanks to the autouse conftest fixture.
+        with pytest.raises(Exception) as exc_info:
+            AnthropicProvider()
+        err = exc_info.value
+        assert getattr(err, "category", None) == LLMErrorCategory.MISSING_CREDENTIALS
+        assert "synthpanel login" in str(err)
+
+
+class TestClientErrorMessage:
+    def test_no_credentials_error_mentions_login(self, monkeypatch):
+        from synth_panel.llm.client import LLMClient
+        from synth_panel.llm.errors import LLMError, LLMErrorCategory
+        from synth_panel.llm.models import CompletionRequest, InputMessage, TextBlock
+
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+
+        client = LLMClient()
+        req = CompletionRequest(
+            model="mystery-unknown-model",
+            max_tokens=16,
+            messages=[InputMessage(role="user", content=[TextBlock(text="hi")])],
+        )
+        with pytest.raises(LLMError) as exc_info:
+            client.send(req)
+        assert exc_info.value.category == LLMErrorCategory.MISSING_CREDENTIALS
+        assert "synthpanel login" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Add synthpanel login / logout / whoami CLI commands backed by a credential store
- Wire credential lookup into the LLM client + provider base so stored keys can back any provider
- README updates covering the new auth flow

## Source
- Polecat: dag
- Issue: sp-lve
- MR: sp-wisp-ssu
- Branch: polecat/dag-mo7a62y8

## Test plan
- [ ] CI passes (new tests: test_cli_auth.py, test_credentials.py)
- [ ] `synthpanel login` / `whoami` / `logout` round-trip works on macOS keychain + Linux fallback
- [ ] No regressions in existing provider tests

## Conflict note
Touches README.md (overlaps with #169, #174). Rebase required after siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)