### PR TITLE
chore(release): cut v0.9.4 to ship synthpanel login (sp-1ez)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-04-20
+
+### Fixed
+- (sp-1ez) P0 release packaging: `synthpanel login`/`logout`/`whoami` subcommands were merged to main via PR #178 (sp-lve) on 2026-04-20 but the PR carried no `semver:*` label, so auto-tag never fired and 0.9.3 shipped without the credential-store CLI. This release re-cuts the wheel so the advertised commands actually appear in `synthpanel --help`.
+
+### Added
+- (sp-lve) `synthpanel login` / `logout` / `whoami` — persist a per-provider API key to the on-disk credential store so the CLI works without exporting env vars. Key can also be piped (`echo sk-... | synthpanel login`) for CI/script use.
+
+### Fixed
+- (sp-t6r) MCP: recognise `OPENROUTER_API_KEY` as a BYOK credential and pick a sensible default model when OpenRouter is the only configured provider.
+- (sp-d86) Site: prevent iOS Safari overscroll white flash on the landing page.
+- (sp-v1w) Site: bump copy-button touch target to 44px to meet iOS Human Interface Guidelines.
+
+### Documentation
+- (sp-dub) Promote the MCP sampling-fallback story to the README opener and landing page; align framework count at 8 across surfaces.
+- (sp-ovl) SEO: Schema.org JSON-LD, tightened meta descriptions, and `og:site_name`.
+- (sp-fiv) Smithery registry section + refreshed registry-submissions runbook.
+- (sp-f12) Add Anthropic Cookbook notebook as the canonical integration-example source.
+
 ## [0.9.2] - 2026-04-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.9.3"
+version = "0.9.4"
 description = "Run synthetic focus groups using AI personas, with an MCP server for Claude Code / Cursor / Windsurf. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

- Bump `pyproject.toml` 0.9.3 → 0.9.4
- CHANGELOG entry for sp-lve (login/logout/whoami) + the sp-t6r/sp-d86/sp-v1w/sp-dub/sp-ovl/sp-fiv/sp-f12 work that landed since v0.9.3

## Why

PR #178 (sp-lve: `synthpanel login`/`logout`/`whoami` credential store) merged to `main` on 2026-04-20 with **no `semver:*` label**, so `auto-tag.yml` skipped the release. Fresh `pip install synthpanel==0.9.3` therefore does not contain the login subcommand even though the code is on `main`:

```
$ synthpanel --help
...
  {prompt,panel,pack,instruments,analyze,mcp-serve}
```

No `login` / `logout` / `whoami`. Tracked as **sp-1ez** (P0).

## What landed since v0.9.3

- `feat(cli)` sp-lve (#178) — synthpanel login/logout/whoami credential store
- `fix(mcp)` sp-t6r (#170) — recognise `OPENROUTER_API_KEY` as BYOK + smart default model
- `fix(site)` sp-d86 (#172) — prevent iOS Safari overscroll white flash
- `fix(site)` sp-v1w (#173) — bump copy-btn touch target to 44px
- `docs` sp-dub (#174) — promote sampling-fallback to README/landing, align framework count at 8
- `seo` sp-ovl (#177) — Schema.org JSON-LD, meta descriptions, og:site_name
- `docs` sp-fiv (#175) — Smithery section + refreshed registry-submissions runbook
- `docs(cookbook)` sp-f12 (#176) — Anthropic Cookbook notebook as source-of-truth

## Test plan

- [ ] CI green on this PR (lint, tests, build)
- [ ] PR merged with `semver:patch` label so `auto-tag.yml` creates `v0.9.4` + triggers `publish.yml`
- [ ] After publish: `pip install synthpanel==0.9.4 && synthpanel --help` shows `login`, `logout`, `whoami` subcommands
- [ ] `synthpanel whoami` and `echo sk-xxx | synthpanel login anthropic` work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)