### PR TITLE
fix(site): sync landing version badge + JSON-LD to v0.9.3 with guard test (sp-lwy)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -38,7 +38,7 @@
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "Research Tool",
         "operatingSystem": "Cross-platform",
-        "softwareVersion": "0.9.1",
+        "softwareVersion": "0.9.3",
         "license": "https://opensource.org/licenses/MIT",
         "codeRepository": "https://github.com/DataViking-Tech/SynthPanel",
         "downloadUrl": "https://pypi.org/project/synthpanel/",
@@ -117,7 +117,7 @@
           class="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-3 py-1 text-xs font-medium text-emerald-300"
         >
           <span class="h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
-          v0.9.1 — public beta
+          v0.9.3 — public beta
         </p>
         <h1
           class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-5xl font-bold tracking-tight text-transparent sm:text-6xl"
@@ -361,7 +361,7 @@ synthpanel panel run \
       >
         <div class="flex flex-wrap items-center justify-between gap-3">
           <span>
-            MIT-licensed · v0.9.1 ·
+            MIT-licensed · v0.9.3 ·
             <a
               href="https://github.com/DataViking-Tech/SynthPanel"
               class="hover:text-slate-300"

--- a/tests/test_site_version.py
+++ b/tests/test_site_version.py
@@ -1,0 +1,37 @@
+"""Guard against site/index.html version drift vs. pyproject.toml.
+
+sp-lwy: the landing page hero badge, footer, and JSON-LD softwareVersion
+have silently drifted behind pyproject.toml across three separate releases.
+Fail CI whenever they disagree so the next bump can't ship stale.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _pyproject_version() -> str:
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    return data["project"]["version"]
+
+
+def test_site_index_version_matches_pyproject() -> None:
+    version = _pyproject_version()
+    html = (REPO_ROOT / "site" / "index.html").read_text()
+
+    hero = re.search(r"v(\d+\.\d+\.\d+)\s+—\s+public beta", html)
+    assert hero, "hero version badge not found in site/index.html"
+    assert hero.group(1) == version, f"hero badge shows v{hero.group(1)} but pyproject.toml is {version}"
+
+    footer = re.search(r"MIT-licensed · v(\d+\.\d+\.\d+) ·", html)
+    assert footer, "footer version not found in site/index.html"
+    assert footer.group(1) == version, f"footer shows v{footer.group(1)} but pyproject.toml is {version}"
+
+    jsonld = re.search(r'"softwareVersion":\s*"(\d+\.\d+\.\d+)"', html)
+    assert jsonld, "JSON-LD softwareVersion not found in site/index.html"
+    assert jsonld.group(1) == version, f"JSON-LD softwareVersion {jsonld.group(1)} but pyproject.toml is {version}"


### PR DESCRIPTION
## Summary
- Sync site hero badge + JSON-LD version advertisement to v0.9.3 to match pyproject
- Add a guard test that asserts site version stays in sync with pyproject so drift is caught in CI

## Source
- Polecat: nux
- Issue: sp-lwy
- MR: sp-wisp-bo4
- Branch: polecat/nux-mo7dcwti

## Test plan
- [ ] CI passes (new test: test_site_version.py)
- [ ] Guard test fails when pyproject and site drift

## Conflict note
Heavy overlap with PR #169 (same version bump) and PRs #171/#172/#173/#174/#177 on site/index.html. This PR likely supersedes #169 since it adds a CI guard. Recommend closing #169 in favour of this, or rebasing this onto the stack after siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)