### PR TITLE
fix(site): sync landing version badge + JSON-LD to v0.9.4 (sp-oxw)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "Research Tool",
         "operatingSystem": "Cross-platform",
-        "softwareVersion": "0.9.3",
+        "softwareVersion": "0.9.4",
         "license": "https://opensource.org/licenses/MIT",
         "codeRepository": "https://github.com/DataViking-Tech/SynthPanel",
         "downloadUrl": "https://pypi.org/project/synthpanel/",
@@ -123,7 +123,7 @@
           class="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-3 py-1 text-xs font-medium text-emerald-300"
         >
           <span class="h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
-          v0.9.3 — public beta
+          v0.9.4 — public beta
         </p>
         <h1
           class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-5xl font-bold tracking-tight text-transparent sm:text-6xl"
@@ -367,7 +367,7 @@ synthpanel panel run \
       >
         <div class="flex flex-wrap items-center justify-between gap-3">
           <span>
-            MIT-licensed · v0.9.3 ·
+            MIT-licensed · v0.9.4 ·
             <a
               href="https://github.com/DataViking-Tech/SynthPanel"
               class="hover:text-slate-300"


### PR DESCRIPTION
## Summary
- Bump site hero badge + JSON-LD version advertisement to v0.9.4 to match the release cut in PR #183

## Source
- Polecat: furiosa
- Issue: sp-oxw
- MR: sp-wisp-bd4
- Branch: polecat/furiosa-mo7jytg3

## Test plan
- [ ] CI passes
- [ ] Version guard test (from PR #181) passes with v0.9.4

## Supersedes / ordering
- Supersedes PR #169 (v0.9.3 bump, sp-xzf) and PR #181 (v0.9.3 sync + guard test, sp-lwy) on the version digits. PR #181's guard test is still wanted — suggested landing order: #178 → #183 → #181 (rebased to v0.9.4) → this PR becomes redundant, OR close #169/#181 in favour of this + a separate guard-test-only PR.
- Must land AFTER PR #183 (the release cut) so the site version is never ahead of pyproject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)