### PR TITLE
feat(plugin): ship /synthpanel-poll slash command (sp-ftr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Added
+- (sp-ftr) Ship the advertised `/synthpanel-poll` slash command. `commands/synthpanel-poll.md` wraps the `run_quick_poll` MCP tool so installed plugin users get a one-shot poll command — sp-tcf claimed this was done but never actually added the file.
+
 ## [0.9.7] - 2026-04-21
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -273,7 +273,8 @@ Add to `.mcp.json` at your project root (or `~/.claude.json` for all projects):
 }
 ```
 
-Or install the bundled plugin (adds a `/focus-group` skill):
+Or install the bundled plugin (adds the `/focus-group` skill plus the
+`/synthpanel-poll <question>` slash command for one-shot quick polls):
 
 ```
 /plugin install synthpanel

--- a/commands/synthpanel-poll.md
+++ b/commands/synthpanel-poll.md
@@ -1,0 +1,75 @@
+---
+description: Run a one-question synthetic poll across AI personas and synthesize the themes
+allowed-tools:
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+argument-hint: <question to ask the panel>
+---
+
+Run a quick synthetic poll using the SynthPanel MCP server. One question, a
+handful of AI personas, one synthesized writeup.
+
+Question: $ARGUMENTS
+
+## What to do
+
+1. **Resolve the question.** If `$ARGUMENTS` is empty, ask the user for the
+   question before continuing. Do not invent one.
+
+2. **Pick personas.** Default to the built-in zero-config persona set by
+   omitting the `personas` argument. Only build a custom list when the user
+   names a specific audience (e.g. "three enterprise SRE personas"). In that
+   case, either:
+   - Call `mcp__synth_panel__list_persona_packs` and `get_persona_pack` to
+     pull an installed pack, or
+   - Hand-author 3–5 dicts with `name`, `age`, `occupation`, `background`,
+     and `personality_traits`.
+
+   Keep panels small — `run_quick_poll` caps at 3 personas when running in
+   sampling mode (no API key).
+
+3. **Run the poll.** Call `mcp__synth_panel__run_quick_poll` with:
+   - `question`: the user's question
+   - `personas`: omit for the default set, or pass your custom list
+   - `synthesis`: leave as `true` (default) — the synthesis pass is the
+     point of this command
+
+   Do not pass `model` unless the user explicitly asked for a specific one.
+   The MCP server picks a sensible default (haiku in BYOK mode, or the
+   host's own model in sampling mode).
+
+4. **Report the result.** Present the output in this shape:
+
+   ```
+   Question: <the question>
+   Panel: <n> personas (<mode: BYOK model-name | sampling>)
+
+   ## Themes
+   <bulleted list from the synthesis>
+
+   ## Per-persona responses
+   - <persona name>: <one-line summary of their response>
+   - ...
+
+   ## Notable divergences
+   <any disagreements the synthesis flagged>
+
+   Cost: <$X.XX from the response's `cost` field, or "n/a" in sampling mode>
+   ```
+
+   Keep each persona summary to one line. The full transcripts are in the
+   raw tool output — don't re-print them.
+
+## Guardrails
+
+- **Synthetic panels are exploratory, not validating.** End the report with
+  a single-line caveat: "Synthetic panel — directional signal only, not a
+  substitute for real user research."
+- **Don't loop.** If the user wants a second question, that's another
+  `/synthpanel-poll` invocation, not a follow-up inside this one. For
+  multi-question structured studies, suggest the `/focus-group` skill
+  instead.
+- **Report errors honestly.** If the tool returns an `error` field
+  (missing API key, persona cap exceeded, etc.), show it verbatim and
+  suggest the fix — don't silently fall back.

--- a/tests/test_claude_plugin_assets.py
+++ b/tests/test_claude_plugin_assets.py
@@ -1,0 +1,75 @@
+"""Guard tests for the shipped Claude Code plugin assets.
+
+These tests exist because sp-tcf was closed with the claim that
+``/synthpanel-poll`` had shipped, but the file was never actually
+committed (sp-ftr). A filesystem existence check is cheap insurance
+against that regression for every command the plugin advertises.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_MANIFEST = REPO_ROOT / ".claude-plugin" / "plugin.json"
+COMMANDS_DIR = REPO_ROOT / "commands"
+SKILLS_DIR = REPO_ROOT / "skills"
+
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+def _read_frontmatter(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    match = FRONTMATTER_RE.match(text)
+    assert match, f"{path} is missing YAML frontmatter"
+    return match.group(1)
+
+
+def test_plugin_manifest_exists_and_is_valid_json() -> None:
+    assert PLUGIN_MANIFEST.is_file(), f"missing {PLUGIN_MANIFEST}"
+    data = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+    assert data.get("name") == "synthpanel"
+    assert "mcp_servers" in data
+
+
+def test_synthpanel_poll_command_ships() -> None:
+    """The `/synthpanel-poll` slash command must be present on disk.
+
+    Claude Code auto-discovers ``commands/*.md`` at the plugin root, so
+    the existence of this file is what determines whether installed
+    users get the advertised slash command.
+    """
+    path = COMMANDS_DIR / "synthpanel-poll.md"
+    assert path.is_file(), (
+        "commands/synthpanel-poll.md is missing — the README advertises "
+        "/synthpanel-poll as a plugin command, so the file must ship."
+    )
+
+    frontmatter = _read_frontmatter(path)
+    assert "description:" in frontmatter
+    assert "allowed-tools:" in frontmatter
+    assert "mcp__synth_panel__run_quick_poll" in frontmatter, (
+        "synthpanel-poll must list the run_quick_poll MCP tool in "
+        "allowed-tools — otherwise the slash command can't call it."
+    )
+
+
+@pytest.mark.parametrize(
+    "skill_rel_path",
+    [
+        "skills/focus-group/SKILL.md",
+        "skills/name-test/SKILL.md",
+        "skills/concept-test/SKILL.md",
+        "skills/survey-prescreen/SKILL.md",
+        "skills/pricing-probe/SKILL.md",
+    ],
+)
+def test_plugin_manifest_skills_all_exist(skill_rel_path: str) -> None:
+    """Every skill path in plugin.json must resolve to a real file."""
+    manifest = json.loads(PLUGIN_MANIFEST.read_text(encoding="utf-8"))
+    assert skill_rel_path in manifest["skills"], f"plugin.json must list {skill_rel_path} in its skills array"
+    assert (REPO_ROOT / skill_rel_path).is_file(), f"{skill_rel_path} is listed in plugin.json but does not exist"


### PR DESCRIPTION
## Summary
- Ship a new `/synthpanel-poll` slash command in the Claude Code plugin for quick-poll panels
- Test coverage asserts the plugin asset manifest includes the new command

## Source
- Polecat: nux
- Issue: sp-ftr
- MR: sp-wisp-7zx
- Branch: polecat/nux-mo7jzcy2

## Test plan
- [ ] CI passes (new test: test_claude_plugin_assets.py)
- [ ] `/synthpanel-poll` resolves inside a Claude Code session with the plugin installed

## Conflict note
Touches README.md + CHANGELOG.md (overlap with PRs #169, #174, #178, #183). Rebase required after siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)