### PR TITLE
fix(ci): use tomli fallback for Python 3.10 compat (sp-869)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "ruff>=0.4",
     "mypy>=1.10",
     "pip-audit>=2.7",
+    "tomli>=2.0; python_version<'3.11'",
 ]
 
 [project.scripts]

--- a/tests/test_site_version.py
+++ b/tests/test_site_version.py
@@ -8,9 +8,13 @@ Fail CI whenever they disagree so the next bump can't ship stale.
 from __future__ import annotations
 
 import re
+import sys
 from pathlib import Path
 
-import tomllib
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 


### PR DESCRIPTION
## Summary
- `tests/test_site_version.py` imports `tomllib`, which is stdlib only on Python 3.11+. CI job `test (3.10)` has been failing on main for hours, blocking PR automerge.
- Add conditional import with `tomli` fallback on 3.10.
- Declare `tomli>=2.0; python_version<'3.11'` in dev deps.

## Test plan
- [x] `ruff check` / `ruff format --check` pass
- [x] `pytest tests/test_site_version.py` passes locally (3.14)
- [x] Full suite still passes (4 pre-existing `test_mcp_stdio_sampling.py` failures unrelated to this change)
- [ ] CI: `test (3.10)` goes green

Fixes sp-869.

🤖 Generated with [Claude Code](https://claude.com/claude-code)