### PR TITLE
fix(cli): correct --synthesis-model help text and surface model in cost estimate (sp-bzb)

### DIFF
--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -156,7 +156,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--synthesis-model",
         default=None,
         metavar="MODEL",
-        help="Model to use for synthesis (default: sonnet). Overrides --model for the synthesis step only.",
+        help="Model to use for synthesis (default: matches --model). Overrides --model for the synthesis step only.",
     )
     panel_run_parser.add_argument(
         "--synthesis-prompt",

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -156,7 +156,7 @@ def _print_cost_estimate(
     est_output_tokens = 1000  # typical synthesis output
     est_usage = TokenUsage(input_tokens=est_input_tokens, output_tokens=est_output_tokens)
     est = estimate_cost(est_usage, pricing)
-    parts = [f"Synthesis will cost ~{est.format_usd()}"]
+    parts = [f"Synthesis will cost ~{est.format_usd()} using {model}"]
     if panelist_cost is not None:
         parts.append(f"(panelist cost was {panelist_cost.format_usd()})")
     print(" ".join(parts), file=sys.stderr)


### PR DESCRIPTION
## Summary
- Correct misleading `--synthesis-model` help text
- Surface the resolved synthesis model in the cost estimate output so users see exactly what will be billed

## Source
- Polecat: nux
- Issue: sp-bzb
- MR: sp-wisp-dmr
- Branch: polecat/nux-mo820h87

## Test plan
- [ ] CI passes
- [ ] `synthpanel panel run --help` shows corrected text
- [ ] Cost estimate output includes synthesis model identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)