### PR TITLE
feat(cli): add --personas-merge to layer persona files onto --personas (sp-on4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Added
+- (sp-on4) `panel run --personas-merge PATH` (repeatable): layer extra persona files onto the base `--personas` pack without hand-editing YAML. Files merge in order; persona entries sharing a `name` with an earlier one replace it in place.
+
 ## [0.9.4] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -425,6 +425,20 @@ personas:
       - values personal relationships
 ```
 
+### Merging Additional Personas (`--personas-merge`)
+
+Layer extra personas onto a base file (or exported pack) without editing
+the original. `--personas-merge` is repeatable and appends in order; a
+later persona whose `name` matches an earlier one replaces it in place:
+
+```bash
+synthpanel panel run \
+  --personas developer.yaml \
+  --personas-merge contrarian.yaml \
+  --personas-merge intern.yaml \
+  --instrument pricing-discovery
+```
+
 ## Defining Instruments
 
 ```yaml

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -321,6 +321,34 @@ def _load_personas(path: str) -> list[dict[str, Any]]:
     raise ValueError(f"Invalid personas file: expected 'personas' key or a list, got {type(data).__name__}")
 
 
+def _merge_persona_lists(base: list[dict[str, Any]], merge_paths: list[str]) -> list[dict[str, Any]]:
+    """Append personas from each merge path onto *base*.
+
+    Files are loaded in order and their personas appended. If a later
+    persona shares a ``name`` with an earlier one, the later entry
+    replaces the earlier one in place (order of first occurrence is
+    preserved). Personas without a ``name`` are always appended — we
+    cannot safely dedupe them.
+    """
+    by_name: dict[str, int] = {}
+    merged: list[dict[str, Any]] = []
+    for p in base:
+        name = p.get("name") if isinstance(p, dict) else None
+        if isinstance(name, str) and name:
+            by_name[name] = len(merged)
+        merged.append(p)
+    for path in merge_paths:
+        for p in _load_personas(path):
+            name = p.get("name") if isinstance(p, dict) else None
+            if isinstance(name, str) and name and name in by_name:
+                merged[by_name[name]] = p
+            else:
+                if isinstance(name, str) and name:
+                    by_name[name] = len(merged)
+                merged.append(p)
+    return merged
+
+
 def _load_instrument(path_or_name: str) -> Instrument:
     """Load an instrument from a file path *or* an installed pack name.
 
@@ -454,6 +482,17 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error loading personas: {exc}", file=sys.stderr)
         return 1
+
+    # sp-on4: --personas-merge appends personas from additional files onto
+    # the base --personas pack. When a persona name collides, the later
+    # entry wins so callers can override pack defaults with a follow-on file.
+    merge_paths = getattr(args, "personas_merge", None) or []
+    if merge_paths:
+        try:
+            personas = _merge_persona_lists(personas, merge_paths)
+        except (FileNotFoundError, ValueError) as exc:
+            print(f"Error loading --personas-merge: {exc}", file=sys.stderr)
+            return 1
 
     try:
         instrument = _load_instrument(args.instrument)

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -106,6 +106,18 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to a YAML file defining personas.",
     )
     panel_run_parser.add_argument(
+        "--personas-merge",
+        dest="personas_merge",
+        action="append",
+        default=[],
+        metavar="PATH",
+        help=(
+            "Additional YAML file(s) whose personas are appended to --personas. "
+            "Repeatable. Files are merged in order; duplicate names later in the "
+            "list override earlier ones."
+        ),
+    )
+    panel_run_parser.add_argument(
         "--instrument",
         required=True,
         metavar="PATH",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@ from synth_panel.cli.commands import (
     _load_instrument,
     _load_personas,
     _load_schema,
+    _merge_persona_lists,
 )
 from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cli.parser import build_parser
@@ -80,6 +81,38 @@ class TestParser:
         assert args.panel_command == "run"
         assert args.personas == "p.yaml"
         assert args.instrument == "i.yaml"
+
+    def test_panel_run_personas_merge_default_empty(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--instrument",
+                "i.yaml",
+            ]
+        )
+        assert args.personas_merge == []
+
+    def test_panel_run_personas_merge_repeatable(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--personas-merge",
+                "extra1.yaml",
+                "--personas-merge",
+                "extra2.yaml",
+                "--instrument",
+                "i.yaml",
+            ]
+        )
+        assert args.personas_merge == ["extra1.yaml", "extra2.yaml"]
 
     def test_panel_run_synthesis_flags(self):
         parser = build_parser()
@@ -326,6 +359,42 @@ class TestYAMLLoading:
     def test_load_personas_missing_file(self):
         with pytest.raises(FileNotFoundError):
             _load_personas("/nonexistent/path.yaml")
+
+    def test_merge_persona_lists_appends(self, tmp_path):
+        extra = tmp_path / "extra.yaml"
+        extra.write_text("personas:\n  - name: Carol\n    age: 40\n")
+        base = [{"name": "Alice", "age": 30}]
+        merged = _merge_persona_lists(base, [str(extra)])
+        assert [p["name"] for p in merged] == ["Alice", "Carol"]
+
+    def test_merge_persona_lists_multiple_files_in_order(self, tmp_path):
+        f1 = tmp_path / "f1.yaml"
+        f1.write_text("personas:\n  - name: Bob\n")
+        f2 = tmp_path / "f2.yaml"
+        f2.write_text("personas:\n  - name: Dan\n")
+        base = [{"name": "Alice"}]
+        merged = _merge_persona_lists(base, [str(f1), str(f2)])
+        assert [p["name"] for p in merged] == ["Alice", "Bob", "Dan"]
+
+    def test_merge_persona_lists_name_collision_overrides(self, tmp_path):
+        override = tmp_path / "override.yaml"
+        override.write_text("personas:\n  - name: Alice\n    age: 99\n")
+        base = [{"name": "Alice", "age": 30}, {"name": "Bob"}]
+        merged = _merge_persona_lists(base, [str(override)])
+        assert len(merged) == 2
+        assert merged[0] == {"name": "Alice", "age": 99}
+        assert merged[1] == {"name": "Bob"}
+
+    def test_merge_persona_lists_unnamed_always_appended(self, tmp_path):
+        extra = tmp_path / "extra.yaml"
+        extra.write_text("- occupation: Anonymous\n- occupation: Anonymous\n")
+        base: list = []
+        merged = _merge_persona_lists(base, [str(extra)])
+        assert len(merged) == 2
+
+    def test_merge_persona_lists_missing_file(self):
+        with pytest.raises(FileNotFoundError):
+            _merge_persona_lists([], ["/nonexistent/extra.yaml"])
 
     def test_load_instrument_with_key(self, tmp_path):
         p = tmp_path / "survey.yaml"


### PR DESCRIPTION
## Summary
- Add `--personas-merge` flag that layers one or more YAML persona files on top of `--personas`, letting users compose baseline + variant persona decks without copy-paste

## Source
- Polecat: toast
- Issue: sp-on4
- MR: sp-wisp-2og
- Branch: polecat/toast-mo822fre

## Test plan
- [ ] CI passes (new coverage in test_cli.py)
- [ ] `synthpanel panel run --personas base.yaml --personas-merge variant.yaml` runs with the merged deck

## Conflict note
Touches README.md + CHANGELOG.md — may need light rebase against open siblings (#186, #191) that also touch those files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)