### PR TITLE
feat(cli): add --dry-run flag to preview panel inputs (sp-x8g)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -430,6 +430,89 @@ def _load_schema(value: str) -> dict[str, Any]:
     return schema
 
 
+def _emit_dry_run_preview(
+    *,
+    personas: list[dict[str, Any]],
+    instrument: Instrument,
+    system_prompt_fn,
+    model: str,
+    fmt: OutputFormat,
+) -> None:
+    """Print the fully substituted panel inputs without any LLM call.
+
+    Shows each question as it will appear to the LLM (after --var
+    substitution, which has already been applied to the instrument),
+    plus persona/question counts and a rough input-token estimate.
+    """
+    persona_count = len(personas)
+    questions = instrument.questions
+    question_count = len(questions)
+
+    system_prompt_chars = sum(len(system_prompt_fn(p)) for p in personas)
+    question_chars = sum(len(build_question_prompt(q)) for q in questions)
+    follow_up_chars = 0
+    for q in questions:
+        follow_ups = q.get("follow_ups") if isinstance(q, dict) else None
+        if not follow_ups:
+            continue
+        for fu in follow_ups:
+            if isinstance(fu, dict):
+                follow_up_chars += len(str(fu.get("text", "")))
+            else:
+                follow_up_chars += len(str(fu))
+    total_chars = system_prompt_chars + persona_count * (question_chars + follow_up_chars)
+    estimated_input_tokens = max(1, total_chars // 4)
+
+    if fmt is OutputFormat.TEXT:
+        print("DRY RUN — no LLM calls will be made", file=sys.stderr)
+        print(f"Model: {model}", file=sys.stderr)
+        print(f"Personas: {persona_count}", file=sys.stderr)
+        if instrument.is_multi_round:
+            print(f"Questions: {question_count} across {len(instrument.rounds)} rounds", file=sys.stderr)
+        else:
+            print(f"Questions: {question_count}", file=sys.stderr)
+        print("", file=sys.stderr)
+
+        for round_ in instrument.rounds:
+            if instrument.is_multi_round:
+                print(f"Round: {round_.name}", file=sys.stderr)
+            for idx, q in enumerate(round_.questions, start=1):
+                prompt_text = build_question_prompt(q)
+                prefix = f"  {idx}." if instrument.is_multi_round else f"{idx}."
+                print(f"{prefix} {prompt_text}", file=sys.stderr)
+                follow_ups = q.get("follow_ups") if isinstance(q, dict) else None
+                if follow_ups:
+                    for fu in follow_ups:
+                        fu_text = fu.get("text", "") if isinstance(fu, dict) else str(fu)
+                        indent = "     " if instrument.is_multi_round else "   "
+                        print(f"{indent}↳ (follow-up) {fu_text}", file=sys.stderr)
+            if instrument.is_multi_round:
+                print("", file=sys.stderr)
+
+        print(
+            f"Estimated input tokens: ~{estimated_input_tokens:,} "
+            f"({persona_count} personas x {question_count} questions, ~4 chars/token)",
+            file=sys.stderr,
+        )
+        return
+
+    preview: dict[str, Any] = {
+        "dry_run": True,
+        "model": model,
+        "persona_count": persona_count,
+        "question_count": question_count,
+        "estimated_input_tokens": estimated_input_tokens,
+        "rounds": [
+            {
+                "name": r.name,
+                "questions": [build_question_prompt(q) for q in r.questions],
+            }
+            for r in instrument.rounds
+        ],
+    }
+    emit(fmt, message="Dry-run preview", extra=preview)
+
+
 def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run a panel: load personas + instrument, run panelists in parallel."""
     # ── sp-prof: profile loading ──────────────────────────────────────
@@ -523,6 +606,21 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     # Generation parameters
     temperature: float | None = getattr(args, "temperature", None)
     top_p: float | None = getattr(args, "top_p", None)
+
+    # ── sp-x8g: --dry-run preview ────────────────────────────────────────
+    # Short-circuit before any LLM-invoking code (variant expansion,
+    # ensemble, blend, orchestrator). Shows the user what each question
+    # will look like after --var substitution + prompt templating, plus
+    # a rough input-token estimate, without spending any tokens.
+    if getattr(args, "dry_run", False):
+        _emit_dry_run_preview(
+            personas=personas,
+            instrument=instrument,
+            system_prompt_fn=system_prompt_fn,
+            model=model,
+            fmt=fmt,
+        )
+        return 0
 
     # ── sp-blend: multi-model ensemble ───────────────────────────────────
     # Parse --models spec and build per-persona model assignments.

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -283,6 +283,18 @@ def build_parser() -> argparse.ArgumentParser:
             "can be passed to 'synthpanel analyze <RESULT_ID>'."
         ),
     )
+    panel_run_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help=(
+            "Preview the panel without making any LLM calls. Loads personas "
+            "and the instrument, applies --var substitutions, then prints "
+            "each question as it would be sent to the LLM along with "
+            "persona/question counts and a rough input-token estimate. "
+            "Exits without calling any provider."
+        ),
+    )
 
     # panel synthesize (sp-5on.5: post-hoc re-synthesis of a saved result)
     panel_synth_parser = panel_subparsers.add_parser(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2150,3 +2150,187 @@ class TestVariantsFlag:
         assert code == 1
         err = capsys.readouterr().err
         assert "--variants must be between 1 and 20" in err
+
+
+# --- sp-x8g: --dry-run preview -------------------------------------------
+
+
+class TestPanelRunDryRun:
+    """--dry-run previews the substituted panel without any LLM call."""
+
+    def test_parser_accepts_dry_run_flag(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--instrument",
+                "i.yaml",
+                "--dry-run",
+            ]
+        )
+        assert args.dry_run is True
+
+    def test_parser_dry_run_default_false(self):
+        parser = build_parser()
+        args = parser.parse_args(
+            [
+                "panel",
+                "run",
+                "--personas",
+                "p.yaml",
+                "--instrument",
+                "i.yaml",
+            ]
+        )
+        assert args.dry_run is False
+
+    @patch("synth_panel.cli.commands.generate_panel_variants")
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_makes_no_llm_calls(
+        self,
+        mock_client_cls,
+        mock_runtime_cls,
+        mock_run_panel,
+        mock_synth,
+        mock_variants,
+        capsys,
+        tmp_path,
+    ):
+        """--dry-run must not trigger the orchestrator, variants, synthesis, or runtime."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Question 1?\n    - text: Question 2?\n")
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        mock_run_panel.assert_not_called()
+        mock_synth.assert_not_called()
+        mock_variants.assert_not_called()
+        mock_runtime_cls.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_text_output_shows_substituted_questions(self, mock_client_cls, mock_run_panel, capsys, tmp_path):
+        """Question text appears after {var} substitution."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n  - name: Carol\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: How do you feel about {product}?\n"
+            "    - text: What would {product} need to cost?\n"
+        )
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--dry-run",
+                "--var",
+                "product=Acme Widget",
+            ]
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "DRY RUN" in err
+        assert "Personas: 3" in err
+        assert "Questions: 2" in err
+        assert "Acme Widget" in err
+        assert "{product}" not in err
+        assert "Estimated input tokens" in err
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_multi_round_lists_rounds(self, mock_client_cls, mock_run_panel, capsys, tmp_path):
+        """Multi-round instruments show each round's questions."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  version: 2\n"
+            "  rounds:\n"
+            "    - name: discovery\n"
+            "      questions:\n"
+            "        - text: What frustrates you?\n"
+            "    - name: deep_dive\n"
+            "      depends_on: discovery\n"
+            "      questions:\n"
+            "        - text: Tell me more.\n"
+        )
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "Round: discovery" in err
+        assert "Round: deep_dive" in err
+        assert "What frustrates you?" in err
+        assert "Tell me more." in err
+        assert "across 2 rounds" in err
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_json_output(self, mock_client_cls, mock_run_panel, capsys, tmp_path):
+        """JSON output returns a structured dry-run payload on stdout."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Why {x}?\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--dry-run",
+                "--var",
+                "x=now",
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["dry_run"] is True
+        assert data["persona_count"] == 2
+        assert data["question_count"] == 1
+        assert data["estimated_input_tokens"] >= 1
+        assert data["rounds"][0]["questions"] == ["Why now?"]
+        mock_run_panel.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `--dry-run` to `panel run` that previews resolved personas, instrument, and cost estimate without making any LLM calls

## Source
- Polecat: slit
- Issue: sp-x8g
- MR: sp-wisp-3d1
- Branch: polecat/slit-mo821stx

## Test plan
- [ ] CI passes (new coverage in test_cli.py)
- [ ] `synthpanel panel run --dry-run` prints resolved config and exits 0 without calling providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)