### PR TITLE
fix(openrouter): request usage.include + tolerate null usage to stop $0 cost regressions (sp-2xy)

### DIFF
--- a/src/synth_panel/llm/providers/_openai_format.py
+++ b/src/synth_panel/llm/providers/_openai_format.py
@@ -181,10 +181,16 @@ def parse_openai_response(
             )
         )
 
-    usage_raw = data.get("usage", {})
+    # Some OpenAI-compatible providers (notably OpenRouter) occasionally
+    # return ``"usage": null`` or omit the block entirely. Treat any
+    # non-dict value as an absent usage block so the caller still gets
+    # a well-formed TokenUsage (all zeros) instead of an AttributeError.
+    usage_raw = data.get("usage") or {}
+    if not isinstance(usage_raw, dict):
+        usage_raw = {}
     usage = TokenUsage(
-        input_tokens=usage_raw.get("prompt_tokens", 0),
-        output_tokens=usage_raw.get("completion_tokens", 0),
+        input_tokens=usage_raw.get("prompt_tokens") or 0,
+        output_tokens=usage_raw.get("completion_tokens") or 0,
     )
 
     return CompletionResponse(

--- a/src/synth_panel/llm/providers/openrouter.py
+++ b/src/synth_panel/llm/providers/openrouter.py
@@ -74,6 +74,11 @@ class OpenRouterProvider(LLMProvider):
                 top_p=request.top_p,
             )
         body = build_openai_body(request)
+        # Ask OpenRouter to always return the detailed usage block (including
+        # token counts and native cost). Without this flag, some upstream
+        # providers omit ``usage`` entirely, causing synthpanel to compute
+        # $0 for the whole panel. See sp-2xy.
+        body["usage"] = {"include": True}
         try:
             resp = httpx.post(url, headers=self._headers(), json=body, timeout=120.0)
         except httpx.HTTPError as exc:
@@ -120,6 +125,9 @@ class OpenRouterProvider(LLMProvider):
                 top_p=request.top_p,
             )
         body = build_openai_body(request, stream=True)
+        # Mirror send(): ensure OpenRouter emits usage details in the final
+        # stream chunk so synthpanel can track cost accurately.
+        body["usage"] = {"include": True}
         try:
             with httpx.stream(
                 "POST",

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -471,6 +471,19 @@ def _run_panelist(
             tracker.cumulative_usage.total_tokens,
         )
 
+        # sp-2xy: silent usage-capture failure produces $0 cost for the whole
+        # panel. If we successfully produced responses but tokens are 0, the
+        # upstream provider almost certainly returned an empty ``usage`` block —
+        # warn loudly so this doesn't slip through to JSON again.
+        if tracker.cumulative_usage.total_tokens == 0 and responses and not all(r.get("error") for r in responses):
+            logger.warning(
+                "panelist %s (model=%s) produced %d responses but usage=0 — "
+                "provider likely omitted the usage block; cost will be $0",
+                name,
+                model,
+                len(responses),
+            )
+
         result = PanelistResult(
             persona_name=name,
             responses=responses,

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -990,6 +990,85 @@ class TestOpenRouterProvider:
         headers = provider._headers()
         assert headers["Authorization"] == "Bearer or-test"
 
+    def test_send_requests_detailed_usage(self):
+        """sp-2xy: OpenRouter send() must set ``usage.include=true`` so cost data is reliable.
+
+        Without this flag, some upstream providers omit ``usage`` entirely,
+        which zeros out panelist_cost / total_cost in the panel JSON output.
+        """
+        from synth_panel.llm.providers.openrouter import OpenRouterProvider
+
+        mock_resp = _mock_httpx_response(_openai_json_response("hi"))
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-test"}, clear=False):
+            provider = OpenRouterProvider()
+        with patch("httpx.post", return_value=mock_resp) as mock_post:
+            provider.send(_simple_request("openrouter/meta-llama/llama-3"))
+        body = mock_post.call_args.kwargs["json"]
+        assert body.get("usage") == {"include": True}
+
+    def test_stream_requests_detailed_usage(self):
+        """sp-2xy: streaming requests must also set ``usage.include=true``."""
+        from synth_panel.llm.providers.openrouter import OpenRouterProvider
+
+        # Minimal mock of an httpx streaming context manager
+        mock_stream_cm = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.iter_lines.return_value = iter(["data: [DONE]", ""])
+        mock_stream_cm.__enter__.return_value = mock_resp
+        mock_stream_cm.__exit__.return_value = False
+
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-test"}, clear=False):
+            provider = OpenRouterProvider()
+        with patch("httpx.stream", return_value=mock_stream_cm) as mock_stream:
+            list(provider.stream(_simple_request("openrouter/meta-llama/llama-3")))
+        body = mock_stream.call_args.kwargs["json"]
+        assert body.get("usage") == {"include": True}
+
+    def test_usage_captured_from_response(self):
+        """sp-2xy: usage returned by OpenRouter must propagate into the CompletionResponse."""
+        from synth_panel.llm.providers.openrouter import OpenRouterProvider
+
+        payload = _openai_json_response("hello")
+        payload["usage"] = {"prompt_tokens": 1234, "completion_tokens": 56, "total_tokens": 1290}
+        mock_resp = _mock_httpx_response(payload)
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-test"}, clear=False):
+            provider = OpenRouterProvider()
+        with patch("httpx.post", return_value=mock_resp):
+            result = provider.send(_simple_request("openrouter/anthropic/claude-haiku-4-5"))
+        assert result.usage.input_tokens == 1234
+        assert result.usage.output_tokens == 56
+
+    def test_null_usage_does_not_crash(self):
+        """sp-2xy: some providers return ``"usage": null`` — parser must tolerate it."""
+        from synth_panel.llm.providers.openrouter import OpenRouterProvider
+
+        payload = _openai_json_response("hello")
+        payload["usage"] = None  # Defensive: provider returned null instead of a dict
+        mock_resp = _mock_httpx_response(payload)
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-test"}, clear=False):
+            provider = OpenRouterProvider()
+        with patch("httpx.post", return_value=mock_resp):
+            result = provider.send(_simple_request("openrouter/anthropic/claude-haiku-4-5"))
+        # Zero usage is the correct fallback — no AttributeError, no silent crash.
+        assert result.usage.input_tokens == 0
+        assert result.usage.output_tokens == 0
+        assert result.text == "hello"
+
+    def test_missing_usage_block_does_not_crash(self):
+        """sp-2xy: some providers omit the ``usage`` block entirely."""
+        from synth_panel.llm.providers.openrouter import OpenRouterProvider
+
+        payload = _openai_json_response("hello")
+        payload.pop("usage", None)
+        mock_resp = _mock_httpx_response(payload)
+        with patch.dict(os.environ, {"OPENROUTER_API_KEY": "or-test"}, clear=False):
+            provider = OpenRouterProvider()
+        with patch("httpx.post", return_value=mock_resp):
+            result = provider.send(_simple_request("openrouter/anthropic/claude-haiku-4-5"))
+        assert result.usage.input_tokens == 0
+        assert result.usage.output_tokens == 0
+
 
 # ---------------------------------------------------------------------------
 # Tests: OpenAI-compatible provider — constructor overrides (for local models)


### PR DESCRIPTION
## Summary
- Pass `usage: { include: true }` on OpenRouter requests so we actually receive token counts back
- Tolerate null/missing usage gracefully in the OpenAI-format parser so requests that still skip usage don't crash with a 0-cost regression

## Source
- Polecat: rictus
- Issue: sp-2xy
- MR: sp-wisp-sis
- Branch: polecat/rictus-mo821522

## Test plan
- [ ] CI passes (new coverage in test_providers.py)
- [ ] Live OpenRouter call reports non-zero token counts in cost estimate

🤖 Generated with [Claude Code](https://claude.com/claude-code)