### PR TITLE
fix(ensemble): implement documented per_model_results and cost_breakdown shape (sp-gl9)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -755,7 +755,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     # ── Ensemble mode: run with each model, compare across models ────────
     if ensemble_mode:
-        from synth_panel.ensemble import ensemble_run
+        from synth_panel.ensemble import build_ensemble_output, ensemble_run
 
         ensemble_models = [m for m, _w in model_spec]
         ens_result = ensemble_run(
@@ -771,15 +771,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             top_p=top_p,
         )
         timer.stop()
-        output = {
-            "per_model_results": {
-                mr.model: [{"persona": pr.persona_name, "responses": pr.responses} for pr in mr.panelist_results]
-                for mr in ens_result.model_results
-            },
-            "cost_breakdown": ens_result.per_model_cost,
-            "models": ens_result.models,
-            "total_usage": ens_result.total_usage.to_dict(),
-        }
+        output = build_ensemble_output(ens_result)
         emit(fmt, message="Ensemble complete", extra=output)
         return 0
 

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -158,6 +158,60 @@ def ensemble_run(
     )
 
 
+def build_ensemble_output(
+    ens: EnsembleResult,
+    *,
+    panelist_formatter: Callable[[PanelistResult, str], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Shape an :class:`EnsembleResult` into the public JSON output.
+
+    Produces the shape documented on the ``run_panel`` MCP tool and the CLI
+    ``panel run`` ensemble path:
+
+    ``per_model_results`` is keyed by model and each value is a dict with
+    ``results`` (list of formatted panelist dicts), ``cost`` (formatted
+    USD string), and ``usage`` (token bucket dict). ``cost_breakdown``
+    exposes both the per-model USD breakdown (``by_model``) and the total
+    (``total``).
+
+    ``panelist_formatter`` customises how each :class:`PanelistResult` is
+    rendered; when omitted, a minimal ``{persona, responses, model}`` dict
+    is produced so callers without the full runner context still get a
+    useful payload.
+    """
+
+    def _default_formatter(pr: PanelistResult, model: str) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "persona": pr.persona_name,
+            "responses": pr.responses,
+        }
+        if pr.model or model:
+            out["model"] = pr.model or model
+        if pr.error:
+            out["error"] = pr.error
+        return out
+
+    fmt = panelist_formatter or _default_formatter
+
+    per_model_results: dict[str, dict[str, Any]] = {}
+    for mr in ens.model_results:
+        per_model_results[mr.model] = {
+            "results": [fmt(pr, mr.model) for pr in mr.panelist_results],
+            "cost": mr.cost.format_usd(),
+            "usage": mr.usage.to_dict(),
+        }
+
+    return {
+        "per_model_results": per_model_results,
+        "cost_breakdown": {
+            "by_model": dict(ens.per_model_cost),
+            "total": ens.total_cost.format_usd(),
+        },
+        "models": list(ens.models),
+        "total_usage": ens.total_usage.to_dict(),
+    }
+
+
 # ---------------------------------------------------------------------------
 # Distribution blending
 # ---------------------------------------------------------------------------

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -308,7 +308,7 @@ def _run_ensemble_sync(
     top_p: float | None = None,
 ) -> dict[str, Any]:
     """Run the same panel with each model and return comparative results."""
-    from synth_panel.ensemble import ensemble_run
+    from synth_panel.ensemble import build_ensemble_output, ensemble_run
 
     client = LLMClient()
     ens = ensemble_run(
@@ -323,14 +323,7 @@ def _run_ensemble_sync(
         temperature=temperature,
         top_p=top_p,
     )
-    return {
-        "per_model_results": {
-            mr.model: [_format_panelist_result(pr, mr.model) for pr in mr.panelist_results] for mr in ens.model_results
-        },
-        "cost_breakdown": ens.per_model_cost,
-        "models": ens.models,
-        "total_usage": ens.total_usage.to_dict(),
-    }
+    return build_ensemble_output(ens, panelist_formatter=_format_panelist_result)
 
 
 async def _run_panel_async_instrument(
@@ -786,9 +779,17 @@ async def run_panel(
             free-text responses. Pass a built-in name ("sentiment",
             "themes", "rating") or an inline JSON Schema dict.
         models: List of model names for multi-model ensemble. When
-            provided, the panel is run once per model and results are
-            compared. Returns per_model_results and cost_breakdown.
-            Mutually exclusive with ``model``.
+            provided (length ≥ 2), the panel is run once per model and
+            results are compared. Mutually exclusive with ``model``. The
+            ensemble response replaces the single-model shape with:
+
+            * ``per_model_results`` — ``{model: {results, cost, usage}}``
+              where ``results`` is the formatted panelist list for that
+              model, ``cost`` is a formatted USD string, and ``usage``
+              is the token bucket dict for the model's run.
+            * ``cost_breakdown`` — ``{by_model: {model: "$X"}, total: "$Z"}``.
+            * ``models`` — the input model list.
+            * ``total_usage`` — summed token buckets across all models.
         synthesis_temperature: Sampling temperature for the synthesis step.
             Independent of the panelist temperature.
         variants: Number of persona variants to generate per persona for

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -480,6 +480,126 @@ class TestEnsembleRun:
 
 
 # ---------------------------------------------------------------------------
+# Tests: build_ensemble_output (public JSON shape)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildEnsembleOutput:
+    """build_ensemble_output must emit the documented run_panel shape."""
+
+    def _fixture(self):
+        from synth_panel.cost import CostEstimate, TokenUsage
+        from synth_panel.ensemble import EnsembleResult, ModelRunResult
+
+        haiku_usage = TokenUsage(input_tokens=100, output_tokens=50)
+        sonnet_usage = TokenUsage(input_tokens=200, output_tokens=80)
+        haiku_cost = CostEstimate(input_cost=0.01, output_cost=0.02)
+        sonnet_cost = CostEstimate(input_cost=0.05, output_cost=0.04)
+
+        haiku_mr = ModelRunResult(
+            model="haiku",
+            panelist_results=[
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[{"question": "Q1", "response": "a1", "error": False}],
+                    usage=haiku_usage,
+                    model="haiku",
+                )
+            ],
+            usage=haiku_usage,
+            cost=haiku_cost,
+            sessions={},
+        )
+        sonnet_mr = ModelRunResult(
+            model="sonnet",
+            panelist_results=[
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[{"question": "Q1", "response": "s1", "error": False}],
+                    usage=sonnet_usage,
+                    model="sonnet",
+                )
+            ],
+            usage=sonnet_usage,
+            cost=sonnet_cost,
+            sessions={},
+        )
+        return EnsembleResult(
+            model_results=[haiku_mr, sonnet_mr],
+            models=["haiku", "sonnet"],
+            total_usage=haiku_usage + sonnet_usage,
+            total_cost=haiku_cost + sonnet_cost,
+            per_model_cost={
+                "haiku": haiku_cost.format_usd(),
+                "sonnet": sonnet_cost.format_usd(),
+            },
+            per_model_usage={
+                "haiku": haiku_usage.to_dict(),
+                "sonnet": sonnet_usage.to_dict(),
+            },
+            persona_count=1,
+            question_count=1,
+        )
+
+    def test_top_level_keys(self):
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        assert set(out.keys()) == {"per_model_results", "cost_breakdown", "models", "total_usage"}
+
+    def test_per_model_results_has_results_cost_usage(self):
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        pmr = out["per_model_results"]
+        assert set(pmr.keys()) == {"haiku", "sonnet"}
+        for model in ("haiku", "sonnet"):
+            entry = pmr[model]
+            assert set(entry.keys()) == {"results", "cost", "usage"}
+            assert isinstance(entry["results"], list)
+            assert entry["cost"].startswith("$")
+            assert isinstance(entry["usage"], dict)
+            assert "input_tokens" in entry["usage"]
+
+    def test_cost_breakdown_nested(self):
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        cb = out["cost_breakdown"]
+        assert set(cb.keys()) == {"by_model", "total"}
+        assert set(cb["by_model"].keys()) == {"haiku", "sonnet"}
+        assert cb["total"].startswith("$")
+
+    def test_default_formatter_renders_panelists(self):
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        results = out["per_model_results"]["haiku"]["results"]
+        assert len(results) == 1
+        assert results[0]["persona"] == "Alice"
+        assert results[0]["model"] == "haiku"
+        assert results[0]["responses"][0]["response"] == "a1"
+
+    def test_custom_formatter_used(self):
+        from synth_panel.ensemble import build_ensemble_output
+
+        def fmt(pr, model):
+            return {"n": pr.persona_name, "m": model}
+
+        out = build_ensemble_output(self._fixture(), panelist_formatter=fmt)
+        results = out["per_model_results"]["sonnet"]["results"]
+        assert results == [{"n": "Alice", "m": "sonnet"}]
+
+    def test_total_usage_summed(self):
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        # haiku: 100+50, sonnet: 200+80
+        assert out["total_usage"]["input_tokens"] == 300
+        assert out["total_usage"]["output_tokens"] == 130
+
+
+# ---------------------------------------------------------------------------
 # Tests: CLI parser --models ensemble format
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Make ensemble output match the documented API contract: emit `per_model_results` + `cost_breakdown` keyed by model so consumers can compare models directly

## Source
- Polecat: dag
- Issue: sp-gl9
- MR: sp-wisp-78n
- Branch: polecat/dag-mo837tce

## Test plan
- [ ] CI passes (new coverage in test_ensemble.py)
- [ ] Ensemble JSON output schema matches the documented shape

## Conflict note
Touches src/synth_panel/cli/commands.py and src/synth_panel/mcp/server.py, which overlap with open PRs #186, #187, #190, #191, #192, #193. Rebase likely needed depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)