### PR TITLE
docs(readme): bump docker pin example from 0.9.1 to 0.9.4 (sp-lb4b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ arguments to override. Provider keys are read from environment variables
 (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`/`GEMINI_API_KEY`,
 `XAI_API_KEY`) — pass whichever your model requires.
 
-Pin to a specific version (`:0.9.1`) in production rather than `:latest`.
+Pin to a specific version (`:0.9.4`) in production rather than `:latest`.
 
 ## Use as a Python Library
 


### PR DESCRIPTION
## Summary
- Bump the Docker image pin example in README from `:v0.9.1` to `:v0.9.4` so copy-paste snippets match the shipped image tag

## Source
- Polecat: furiosa
- Issue: sp-lb4b
- MR: sp-wisp-8fk
- Branch: polecat/furiosa-mo83z94u

## Test plan
- [ ] CI passes
- [ ] README pin matches the tag published to GHCR / Docker Hub by PR #183

## Conflict note
README.md is a high-churn file — may need a light rebase against #186 / siblings that also touch README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)