### PR TITLE
fix(site): drop .html from blog og:url + canonical to stop 308 redirect (sp-rn58)

### DIFF
--- a/site/blog/synthpanel-vs-commercial-alternatives.html
+++ b/site/blog/synthpanel-vs-commercial-alternatives.html
@@ -18,7 +18,7 @@
     <meta name="author" content="DataViking" />
     <link
       rel="canonical"
-      href="https://synthpanel.dev/blog/synthpanel-vs-commercial-alternatives.html"
+      href="https://synthpanel.dev/blog/synthpanel-vs-commercial-alternatives"
     />
 
     <meta property="og:type" content="article" />
@@ -32,7 +32,7 @@
     />
     <meta
       property="og:url"
-      content="https://synthpanel.dev/blog/synthpanel-vs-commercial-alternatives.html"
+      content="https://synthpanel.dev/blog/synthpanel-vs-commercial-alternatives"
     />
     <meta property="og:site_name" content="synthpanel" />
     <meta property="og:image" content="https://synthpanel.dev/og-image.png" />


### PR DESCRIPTION
## Summary
- Drop the `.html` extension from the blog post's `og:url` and `<link rel=canonical>` so social share crawlers don't follow the 308 redirect Cloudflare emits on the pretty URL

## Source
- Polecat: nux
- Issue: sp-rn58
- MR: sp-wisp-p05
- Branch: polecat/nux-mo83zswa

## Test plan
- [ ] CI passes
- [ ] Twitter/X + Facebook cache validators show the card resolving in one hop (no redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)