### PR TITLE
fix(mcp): route BYOK detection through credentials store (sp-mkpo)

### DIFF
--- a/src/synth_panel/mcp/sampling.py
+++ b/src/synth_panel/mcp/sampling.py
@@ -27,7 +27,6 @@ Tool handlers call :func:`sample_text` once the decision is made.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -65,6 +64,10 @@ SAMPLING_CRED_ENV_VARS: tuple[str, ...] = (
     "OPENROUTER_API_KEY",
 )
 
+# Importing here (module scope) would create a cycle if credentials ever
+# grew an MCP dependency; the function-local import in
+# :func:`has_byok_credentials` keeps the boundary one-directional.
+
 # First-run hint surfaced on successful sampling runs so users know they
 # can graduate to BYOK for larger panels / ensembles.
 SAMPLING_FIRST_RUN_HINT = (
@@ -94,9 +97,20 @@ class SamplingDecision:
 
 
 def has_byok_credentials(env: dict[str, str] | None = None) -> bool:
-    """Return True when any provider env var is present and non-empty."""
-    source = env if env is not None else os.environ
-    return any(source.get(var, "").strip() for var in SAMPLING_CRED_ENV_VARS)
+    """Return True when any provider credential is available to BYOK.
+
+    Checks both the process environment and the on-disk credential store
+    written by ``synthpanel login`` (sp-1ez / v0.9.4), so an MCP-launched
+    subprocess — which often runs without the invoking shell's env —
+    still recognises keys the CLI can see. When ``env`` is provided
+    (test harness), only that mapping is consulted; the disk store is
+    intentionally skipped so tests stay hermetic.
+    """
+    if env is not None:
+        return any(env.get(var, "").strip() for var in SAMPLING_CRED_ENV_VARS)
+    from synth_panel.credentials import has_credential
+
+    return any(has_credential(var) for var in SAMPLING_CRED_ENV_VARS)
 
 
 def client_supports_sampling(ctx: Any) -> bool:
@@ -145,7 +159,9 @@ def decide_mode(
         use_sampling: Explicit override from the tool caller. ``True``
             forces sampling (error if unsupported), ``False`` forces
             BYOK, ``None`` picks automatically.
-        env: Optional env dict for testing. Defaults to ``os.environ``.
+        env: Optional env dict for testing. When ``None`` both the
+            process environment and the on-disk credential store are
+            consulted via :func:`has_byok_credentials`.
 
     Rules (in order):
         * ``use_sampling=True`` + client supports sampling → sampling.

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
-import os
 from typing import Any
 
 from mcp.server.fastmcp import Context, FastMCP
@@ -142,12 +141,15 @@ def _resolve_mcp_default_model() -> str:
     """Pick a cheap/fast default model based on available provider creds.
 
     Walks :data:`_MCP_DEFAULT_MODEL_PREFERENCE` and returns the first
-    alias whose env var is set. Falls back to :data:`MCP_DEFAULT_MODEL`
-    when nothing is set so the LLM client's missing-credentials error
-    is the one the user sees.
+    alias whose credential is available via env OR the on-disk store
+    written by ``synthpanel login``. Falls back to
+    :data:`MCP_DEFAULT_MODEL` when nothing is set so the LLM client's
+    missing-credentials error is the one the user sees.
     """
+    from synth_panel.credentials import has_credential
+
     for env_var, alias in _MCP_DEFAULT_MODEL_PREFERENCE:
-        if os.environ.get(env_var, "").strip():
+        if has_credential(env_var):
             return alias
     return MCP_DEFAULT_MODEL
 

--- a/tests/test_mcp_sampling.py
+++ b/tests/test_mcp_sampling.py
@@ -84,6 +84,54 @@ class TestHasByokCredentials:
 
         assert has_byok_credentials({"ANTHROPIC_API_KEY": "   "}) is False
 
+    def test_stored_credential_counts_as_byok(self, tmp_path, monkeypatch):
+        """sp-mkpo: ``synthpanel login`` keys must satisfy MCP BYOK.
+
+        A user who persists OPENROUTER_API_KEY via ``synthpanel login``
+        and launches mcp-serve from a client that doesn't inherit the
+        shell env (Claude Desktop bundles, Docker, systemd units) would
+        otherwise see a bogus 'No provider credentials' error even
+        though the CLI finds the same key.
+        """
+        from synth_panel.credentials import save_credential
+        from synth_panel.mcp.sampling import decide_mode, has_byok_credentials
+
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(tmp_path / "creds.json"))
+        save_credential("OPENROUTER_API_KEY", "sk-or-stored")
+
+        # Default path (env=None) must consult both sources.
+        assert has_byok_credentials() is True
+        # Explicit env override stays hermetic — only that dict is consulted.
+        assert has_byok_credentials({}) is False
+
+        ctx = MagicMock()
+        ctx.session.check_client_capability.return_value = False
+        assert decide_mode(ctx).mode == "byok"
+
+    def test_stored_gemini_credential_counts_as_byok(self, tmp_path, monkeypatch):
+        from synth_panel.credentials import save_credential
+        from synth_panel.mcp.sampling import has_byok_credentials
+
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(tmp_path / "creds.json"))
+        save_credential("GEMINI_API_KEY", "g-stored")
+
+        assert has_byok_credentials() is True
+
+    def test_default_model_picks_provider_from_stored_credential(self, tmp_path, monkeypatch):
+        """sp-mkpo: _resolve_mcp_default_model must also see disk creds.
+
+        Without this the default alias stays 'haiku' (Anthropic) even
+        for an OpenRouter-only user, so the LLM client raises a
+        misleading ANTHROPIC_API_KEY error.
+        """
+        from synth_panel.credentials import save_credential
+        from synth_panel.mcp.server import _resolve_mcp_default_model
+
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(tmp_path / "creds.json"))
+        save_credential("OPENROUTER_API_KEY", "sk-or-stored")
+
+        assert _resolve_mcp_default_model() == "openrouter/auto"
+
 
 class TestClientSupportsSampling:
     def test_none_ctx_returns_false(self):


### PR DESCRIPTION
## Summary
- Route MCP BYOK detection through the new credentials store (from PR #178) so keys stashed via `synthpanel login` are recognised by the MCP server, not just env vars

## Source
- Polecat: dag
- Issue: sp-mkpo
- MR: sp-wisp-ok5
- Branch: polecat/dag-mo83ynl2

## Test plan
- [ ] CI passes (updated coverage in test_mcp_sampling.py)
- [ ] MCP `run_panel` with a credentials-store key picks the BYOK path instead of falling back to sampling

## Conflict note
Touches src/synth_panel/mcp/server.py and src/synth_panel/mcp/sampling.py — overlaps with PRs #187 and #196. Rebase likely after siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)