### PR TITLE
fix(metadata): fold resolved --var keys + hashed values into config_hash (sp-ui40)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -903,6 +903,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         persona_count=len(personas),
         question_count=len(questions),
         timer=timer,
+        template_vars=template_vars or None,
     )
 
     # sp-prof: inject profile info into metadata for synthbench

--- a/src/synth_panel/metadata.py
+++ b/src/synth_panel/metadata.py
@@ -38,6 +38,33 @@ def build_config_hash(config: dict[str, Any]) -> str:
     return hashlib.sha256(serialized.encode()).hexdigest()
 
 
+# Truncation length for per-value var hashes. 16 hex chars = 64 bits, enough
+# to distinguish var sets in practice while keeping the fingerprint compact.
+_VAR_VALUE_HASH_LEN = 16
+
+
+def build_template_vars_fingerprint(
+    template_vars: dict[str, str] | None,
+) -> dict[str, str]:
+    """Return ``{key: sha256(value)[:16]}`` for the resolved ``--var`` set.
+
+    Keys from ``template_vars`` are preserved (they are the *names* authors
+    reference in instrument placeholders and must be visible for audit).
+    Values are one-way hashed so the fingerprint can be persisted in
+    metadata without leaking the raw substitution (some vars carry
+    candidate names, URLs, or prices that callers may treat as sensitive).
+
+    Returns an empty dict when ``template_vars`` is ``None`` or empty so
+    callers can unconditionally splice the result into a config-hash input.
+    """
+    if not template_vars:
+        return {}
+    return {
+        key: hashlib.sha256(str(template_vars[key]).encode()).hexdigest()[:_VAR_VALUE_HASH_LEN]
+        for key in sorted(template_vars)
+    }
+
+
 class PanelTimer:
     """Wall-clock timer for panel execution."""
 
@@ -67,6 +94,7 @@ def build_metadata(
     persona_count: int,
     question_count: int,
     timer: PanelTimer | None = None,
+    template_vars: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Build the ``metadata`` dict for synthbench integration.
 
@@ -131,6 +159,11 @@ def build_metadata(
     }
 
     # -- config_hash --
+    # sp-ui40: fold resolved --var keys + hashed values into the hash so
+    # runs that differ only in their var substitution no longer collide.
+    # The fingerprint is only spliced in when a non-empty var set was
+    # provided so runs with no --var keep the same hash they had before.
+    vars_fingerprint = build_template_vars_fingerprint(template_vars)
     config_for_hash: dict[str, Any] = {
         "panelist_model": resolved_panelist,
         "synthesis_model": resolved_synthesis,
@@ -138,8 +171,10 @@ def build_metadata(
         "question_count": question_count,
         "generation_params": generation_params,
     }
+    if vars_fingerprint:
+        config_for_hash["template_vars"] = vars_fingerprint
 
-    return {
+    meta: dict[str, Any] = {
         "generation_params": generation_params,
         "models": models,
         "cost": cost,
@@ -147,3 +182,6 @@ def build_metadata(
         "version": version,
         "config_hash": build_config_hash(config_for_hash),
     }
+    if vars_fingerprint:
+        meta["template_vars_fingerprint"] = vars_fingerprint
+    return meta

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,7 +6,12 @@ import json
 import time
 
 from synth_panel.cost import CostEstimate, TokenUsage, estimate_cost, lookup_pricing
-from synth_panel.metadata import PanelTimer, build_config_hash, build_metadata
+from synth_panel.metadata import (
+    PanelTimer,
+    build_config_hash,
+    build_metadata,
+    build_template_vars_fingerprint,
+)
 
 
 class TestBuildConfigHash:
@@ -29,6 +34,30 @@ class TestBuildConfigHash:
     def test_sha256_length(self):
         h = build_config_hash({"x": 1})
         assert len(h) == 64
+
+
+class TestBuildTemplateVarsFingerprint:
+    def test_none_returns_empty(self):
+        assert build_template_vars_fingerprint(None) == {}
+
+    def test_empty_dict_returns_empty(self):
+        assert build_template_vars_fingerprint({}) == {}
+
+    def test_keys_preserved_values_hashed(self):
+        fp = build_template_vars_fingerprint({"landing_page": "https://example.com"})
+        assert list(fp.keys()) == ["landing_page"]
+        assert fp["landing_page"] != "https://example.com"
+        assert len(fp["landing_page"]) == 16
+
+    def test_deterministic(self):
+        a = build_template_vars_fingerprint({"theme": "pricing", "region": "eu"})
+        b = build_template_vars_fingerprint({"region": "eu", "theme": "pricing"})
+        assert a == b
+
+    def test_different_values_different_hashes(self):
+        a = build_template_vars_fingerprint({"landing_page": "v1"})
+        b = build_template_vars_fingerprint({"landing_page": "v2"})
+        assert a["landing_page"] != b["landing_page"]
 
 
 class TestPanelTimer:
@@ -222,6 +251,98 @@ class TestBuildMetadata:
         m1 = build_metadata(**kwargs)
         m2 = build_metadata(**kwargs)
         assert m1["config_hash"] == m2["config_hash"]
+
+    def test_template_vars_changes_config_hash(self):
+        """sp-ui40: two runs that differ only in --var values must hash differently."""
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        base = dict(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=2,
+            question_count=3,
+        )
+        m_a = build_metadata(**base, template_vars={"landing_page": "v1"})
+        m_b = build_metadata(**base, template_vars={"landing_page": "v2"})
+        assert m_a["config_hash"] != m_b["config_hash"]
+
+    def test_template_vars_different_keys_different_hash(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        base = dict(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        m_a = build_metadata(**base, template_vars={"theme": "pricing"})
+        m_b = build_metadata(**base, template_vars={"channel": "pricing"})
+        assert m_a["config_hash"] != m_b["config_hash"]
+
+    def test_template_vars_stable_across_key_order(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        base = dict(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        m_a = build_metadata(**base, template_vars={"a": "1", "b": "2"})
+        m_b = build_metadata(**base, template_vars={"b": "2", "a": "1"})
+        assert m_a["config_hash"] == m_b["config_hash"]
+
+    def test_template_vars_none_preserves_legacy_hash(self):
+        """Runs without --var must produce the same hash as before sp-ui40."""
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        base = dict(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+        )
+        m_none = build_metadata(**base)
+        m_empty = build_metadata(**base, template_vars={})
+        m_explicit_none = build_metadata(**base, template_vars=None)
+        assert m_none["config_hash"] == m_empty["config_hash"]
+        assert m_none["config_hash"] == m_explicit_none["config_hash"]
+        assert "template_vars_fingerprint" not in m_none
+        assert "template_vars_fingerprint" not in m_empty
+
+    def test_template_vars_fingerprint_exposed(self):
+        usage = self._make_usage()
+        cost = self._make_cost(usage)
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=usage,
+            panelist_cost=cost,
+            total_usage=usage,
+            total_cost=cost,
+            persona_count=1,
+            question_count=1,
+            template_vars={"theme": "pricing", "audience": "smb"},
+        )
+        fp = meta["template_vars_fingerprint"]
+        assert set(fp.keys()) == {"audience", "theme"}
+        # Each value is a truncated SHA256 hex digest
+        for v in fp.values():
+            assert len(v) == 16
+            int(v, 16)  # raises if non-hex
+        # Keys survive as cleartext; values are hashed
+        assert "pricing" not in fp.values()
 
     def test_json_serializable(self):
         usage = self._make_usage()


### PR DESCRIPTION
## Summary
- Fold resolved `--var` keys and hashed values into `config_hash` so two runs with different substituted variables produce different hashes (they currently collide)
- Prevents cache reuse between logically distinct runs

## Source
- Polecat: nux
- Issue: sp-ui40
- MR: sp-wisp-wf0
- Branch: polecat/nux-mo8n3kvr

## Test plan
- [ ] CI passes (new coverage in test_metadata.py)
- [ ] Two runs with different `--var` values yield different `config_hash`

## Conflict note
Touches src/synth_panel/cli/commands.py — overlaps with the open CLI stack (#190, #192, #193, #195, #196, #197, #198, #202). Rebase likely needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)