### PR TITLE
feat(cli): flag run_invalid when >=50% of panelists report missing input (sp-bjt4)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -850,6 +851,19 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     run_invalid = failure_stats["total_pairs"] > 0 and failure_stats["failure_rate"] > threshold
     strict_violation = strict and failure_stats["errored_pairs"] > 0
 
+    # sp-bjt4: detect the "polite refusal" failure mode — panelists returned
+    # clean responses but uniformly flagged the question as unanswerable
+    # because the source material never made it into the prompt. Without
+    # this check, ``run_invalid`` stays False and the failure is only
+    # narrated in the synthesis ``surprises`` field, so CI gates (which
+    # key on ``run_invalid``) miss it silently.
+    missing_input_stats = _detect_missing_input_refusals(panelist_results)
+    missing_input_invalid = (
+        missing_input_stats["considered"] > 0 and missing_input_stats["refusal_rate"] >= _MISSING_INPUT_THRESHOLD
+    )
+    if missing_input_invalid:
+        run_invalid = True
+
     # Compute panelist costs (needed before synthesis for cost estimate)
     pricing, is_estimated = lookup_pricing(model)
     panelist_cost_est = estimate_cost(panelist_usage, pricing)
@@ -911,7 +925,14 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         metadata["profile_hash"] = profile.config_hash()
 
     # Output results
-    banner = _build_invalid_banner(failure_stats, threshold, strict=strict, strict_violation=strict_violation)
+    banner = _build_invalid_banner(
+        failure_stats,
+        threshold,
+        strict=strict,
+        strict_violation=strict_violation,
+        missing_input_stats=missing_input_stats,
+        missing_input_invalid=missing_input_invalid,
+    )
 
     if fmt is OutputFormat.TEXT:
         if banner:
@@ -1017,7 +1038,20 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # Surface failure stats + run validity in structured output so
         # downstream consumers (MCP, CI) can gate on it without parsing text.
         extra["failure_stats"] = failure_stats
+        extra["missing_input_stats"] = missing_input_stats
         extra["run_invalid"] = bool(run_invalid or strict_violation)
+        if missing_input_invalid:
+            # sp-bjt4: surface as a top-level warning so MCP / CI consumers
+            # see the condition even if they don't special-case
+            # missing_input_stats.
+            warnings_list = extra.setdefault("warnings", [])
+            if isinstance(warnings_list, list):
+                warnings_list.append(
+                    "missing_input_refusals: "
+                    f"{missing_input_stats['refusing']}/{missing_input_stats['considered']}"
+                    f" panelists reported missing or unavailable input"
+                    f" ({missing_input_stats['refusal_rate']:.0%})"
+                )
         # Include blend distributions when --blend is active
         if blend_result:
             extra["blend"] = {
@@ -1144,12 +1178,116 @@ def _analyze_failures(
     }
 
 
+# sp-bjt4: patterns that signal a panelist is refusing because the prompt
+# arrived with empty/malformed source material (e.g. a landing-page audit
+# rendered with a blank {page_html} section). These fire *after* a clean
+# panelist run, so they cannot be caught by _analyze_failures — the model
+# replied politely with "I don't see…" and no error flag was set. Kept as
+# ordered tuples of (pattern, description) to keep the list auditable.
+_MISSING_INPUT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"\b(?:don't|do not|can't|cannot|can not|don't actually|do not actually)\s+(?:see|find|have)\s+"
+        r"(?:the|any|a|an)\s+(?:actual\s+)?"
+        r"(?:content|text|page|document|article|example|examples|material|information|"
+        r"details|data|image|screenshot|section|excerpt|passage|transcript|copy)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bno\s+(?:actual\s+)?"
+        r"(?:content|text|input|page|document|material|information|article|copy|examples?|excerpt|passage|transcript)\s+"
+        r"(?:was|has\s+been|is|to)\s+"
+        r"(?:provided|shared|given|included|attached|review|analyze|evaluate)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:haven't|have not|hasn't|has not|wasn't|was not)\s+(?:been\s+|actually\s+)?"
+        r"(?:shared|provided|given|included|attached|pasted)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\bnothing\s+(?:here\s+)?to\s+"
+        r"(?:review|analyze|evaluate|assess|comment\s+on|respond\s+to|discuss|work\s+with|go\s+on)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:the\s+)?(?:content|text|page|document|material|copy|excerpt|passage)\s+"
+        r"(?:you|that|which)\s+"
+        r"(?:mentioned|referenced|described|referred\s+to|linked|pointed\s+to)",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\b(?:missing|absent|empty|blank)\s+"
+        r"(?:content|input|text|page|document|material|information|body|section)",
+        re.IGNORECASE,
+    ),
+)
+
+# Threshold is a module constant rather than a CLI flag — the bead specifies
+# ≥50% as the heuristic and adding a flag would invite misuse (set to 100%
+# and the signal disappears). Tune here if real-world data demands it.
+_MISSING_INPUT_THRESHOLD: float = 0.5
+
+
+def _response_flags_missing_input(text: str) -> bool:
+    """Return True iff *text* matches any missing-input refusal pattern."""
+    if not text:
+        return False
+    return any(p.search(text) for p in _MISSING_INPUT_PATTERNS)
+
+
+def _detect_missing_input_refusals(
+    panelist_results: list[Any],
+) -> dict[str, Any]:
+    """Count panelists whose primary responses flag missing/unavailable input.
+
+    A panelist is counted as *refusing* if at least one primary (non-follow-up)
+    response matches a missing-input pattern. Wholesale-errored panelists are
+    excluded from the denominator — their failure is already captured by
+    ``_analyze_failures`` and double-counting would muddy the rate.
+
+    Returns a dict with ``considered`` (panelists included in denominator),
+    ``refusing`` (panelists with at least one flagged response),
+    ``refusal_rate`` (0-1), and ``refusing_personas`` (sorted names).
+    """
+    considered = 0
+    refusing = 0
+    refusing_personas: set[str] = set()
+
+    for pr in panelist_results:
+        if getattr(pr, "error", None):
+            continue
+        responses = getattr(pr, "responses", []) or []
+        if not responses:
+            continue
+        considered += 1
+        for resp in responses:
+            if not isinstance(resp, dict) or resp.get("follow_up"):
+                continue
+            answer = resp.get("response", "")
+            if isinstance(answer, dict):
+                answer = json.dumps(answer)
+            if _response_flags_missing_input(str(answer)):
+                refusing += 1
+                refusing_personas.add(getattr(pr, "persona_name", "unknown"))
+                break
+
+    rate = (refusing / considered) if considered > 0 else 0.0
+    return {
+        "considered": considered,
+        "refusing": refusing,
+        "refusal_rate": rate,
+        "refusing_personas": sorted(refusing_personas),
+    }
+
+
 def _build_invalid_banner(
     stats: dict[str, Any],
     threshold: float,
     *,
     strict: bool,
     strict_violation: bool,
+    missing_input_stats: dict[str, Any] | None = None,
+    missing_input_invalid: bool = False,
 ) -> str:
     """Render the fatal banner printed to stderr on an invalid run.
 
@@ -1160,21 +1298,31 @@ def _build_invalid_banner(
     """
     total = stats["total_pairs"]
     errored = stats["errored_pairs"]
-    if total == 0:
-        return ""
-    rate = stats["failure_rate"]
-    over_threshold = rate > threshold
-    if not (over_threshold or strict_violation):
+    rate = stats["failure_rate"] if total > 0 else 0.0
+    over_threshold = total > 0 and rate > threshold
+    if not (over_threshold or strict_violation or missing_input_invalid):
         return ""
 
     bar = "!" * 70
     lines = [bar]
-    if strict_violation and not over_threshold:
-        lines.append(f"PANEL RUN INVALID (--strict): {errored}/{total} panelist-question pairs errored.")
-    else:
+    if over_threshold:
         lines.append(
             f"PANEL RUN INVALID: {errored}/{total} panelist-question pairs"
             f" errored ({rate:.0%} > threshold {threshold:.0%})."
+        )
+    elif strict_violation:
+        lines.append(f"PANEL RUN INVALID (--strict): {errored}/{total} panelist-question pairs errored.")
+    elif missing_input_invalid and missing_input_stats:
+        considered = missing_input_stats["considered"]
+        refusing = missing_input_stats["refusing"]
+        mi_rate = missing_input_stats["refusal_rate"]
+        lines.append(
+            f"PANEL RUN INVALID: {refusing}/{considered} panelist(s) reported"
+            f" missing or unavailable input ({mi_rate:.0%} >= threshold"
+            f" {_MISSING_INPUT_THRESHOLD:.0%})."
+        )
+        lines.append(
+            "The prompt likely arrived with an empty or malformed section (e.g. an unrendered template fragment)."
         )
     lines.append("No synthesis was performed — the run produced no usable data.")
     if stats.get("failed_panelists"):
@@ -1185,8 +1333,18 @@ def _build_invalid_banner(
         if extra > 0:
             shown += f", +{extra} more"
         lines.append(f"  Affected personas: {shown}")
-    lines.append("Check provider status (e.g. rate-limit / 503), run with a different")
-    lines.append("--model, or re-run once the upstream provider is healthy.")
+    if missing_input_invalid and missing_input_stats and missing_input_stats.get("refusing_personas"):
+        shown = ", ".join(missing_input_stats["refusing_personas"][:4])
+        extra = len(missing_input_stats["refusing_personas"]) - 4
+        if extra > 0:
+            shown += f", +{extra} more"
+        lines.append(f"  Personas reporting missing input: {shown}")
+    if missing_input_invalid and not (over_threshold or strict_violation):
+        lines.append("Check that every --var / {placeholder} rendered with real content,")
+        lines.append("then re-run once the prompt is whole.")
+    else:
+        lines.append("Check provider status (e.g. rate-limit / 503), run with a different")
+        lines.append("--model, or re-run once the upstream provider is healthy.")
     lines.append(bar)
     return "\n".join(lines)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -900,6 +900,234 @@ class TestPanelRun:
         mock_synth.assert_not_called()
 
 
+# --- sp-bjt4: missing-input refusal detection -----------------------------
+
+
+class TestMissingInputDetection:
+    """Polite refusals ("I don't see the content you mentioned") don't trip
+    _analyze_failures because the panelist returned a clean response. This
+    suite exercises the secondary heuristic that gates run_invalid on
+    ≥50% of panelists reporting missing/unavailable input."""
+
+    def test_detector_flags_above_threshold(self):
+        from synth_panel.cli.commands import _detect_missing_input_refusals
+        from synth_panel.orchestrator import PanelistResult
+
+        results = [
+            PanelistResult(
+                persona_name="Alice",
+                responses=[
+                    {"question": "Summarize the page", "response": "I don't see the page content you mentioned."},
+                ],
+                usage=ZERO_USAGE,
+            ),
+            PanelistResult(
+                persona_name="Bob",
+                responses=[
+                    {"question": "Summarize the page", "response": "No content was provided for me to analyze."},
+                ],
+                usage=ZERO_USAGE,
+            ),
+            PanelistResult(
+                persona_name="Carol",
+                responses=[
+                    {"question": "Summarize the page", "response": "The copy here reads clearly and I think it works."},
+                ],
+                usage=ZERO_USAGE,
+            ),
+        ]
+
+        stats = _detect_missing_input_refusals(results)
+        assert stats["considered"] == 3
+        assert stats["refusing"] == 2
+        assert stats["refusal_rate"] == pytest.approx(2 / 3)
+        assert stats["refusing_personas"] == ["Alice", "Bob"]
+
+    def test_detector_ignores_follow_ups(self):
+        """Primary-response refusals count; follow-ups piggyback and are skipped
+        so we don't double-count a single refusal."""
+        from synth_panel.cli.commands import _detect_missing_input_refusals
+        from synth_panel.orchestrator import PanelistResult
+
+        results = [
+            PanelistResult(
+                persona_name="Alice",
+                responses=[
+                    {"question": "Primary Q", "response": "Sounds great, I'd pay $10/mo."},
+                    {
+                        "question": "Follow-up",
+                        "response": "I haven't been provided with more details.",
+                        "follow_up": True,
+                    },
+                ],
+                usage=ZERO_USAGE,
+            ),
+        ]
+        stats = _detect_missing_input_refusals(results)
+        assert stats["considered"] == 1
+        assert stats["refusing"] == 0
+        assert stats["refusal_rate"] == 0.0
+
+    def test_detector_excludes_errored_panelists(self):
+        """A wholesale panelist failure is already flagged by _analyze_failures;
+        including it here would double-count and distort the rate."""
+        from synth_panel.cli.commands import _detect_missing_input_refusals
+        from synth_panel.orchestrator import PanelistResult
+
+        results = [
+            PanelistResult(
+                persona_name="Alice",
+                responses=[],
+                usage=ZERO_USAGE,
+                error="provider 503",
+            ),
+            PanelistResult(
+                persona_name="Bob",
+                responses=[
+                    {"question": "Q", "response": "I don't see the content you mentioned."},
+                ],
+                usage=ZERO_USAGE,
+            ),
+        ]
+        stats = _detect_missing_input_refusals(results)
+        assert stats["considered"] == 1
+        assert stats["refusing"] == 1
+        assert stats["refusal_rate"] == 1.0
+
+    def test_detector_returns_zero_rate_when_empty(self):
+        from synth_panel.cli.commands import _detect_missing_input_refusals
+
+        stats = _detect_missing_input_refusals([])
+        assert stats["considered"] == 0
+        assert stats["refusing"] == 0
+        assert stats["refusal_rate"] == 0.0
+        assert stats["refusing_personas"] == []
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_sets_run_invalid_on_majority_missing_input(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """End-to-end: three clean panelists, two refuse for missing input
+        → run_invalid=True, warning surfaced, synthesis skipped."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[
+                        {"question": "Review the page", "response": "I don't see the page content you mentioned."},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Bob",
+                    responses=[
+                        {"question": "Review the page", "response": "No content was provided to analyze."},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Carol",
+                    responses=[
+                        {"question": "Review the page", "response": "It's a solid value prop overall."},
+                    ],
+                    usage=ZERO_USAGE,
+                ),
+            ],
+            registry,
+            {},
+        )
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n  - name: Carol\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Review the page\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+            ]
+        )
+        assert code == 2
+        data = json.loads(capsys.readouterr().out)
+        assert data["run_invalid"] is True
+        assert data["missing_input_stats"]["refusing"] == 2
+        assert data["missing_input_stats"]["considered"] == 3
+        assert data["missing_input_stats"]["refusal_rate"] == pytest.approx(2 / 3)
+        assert sorted(data["missing_input_stats"]["refusing_personas"]) == ["Alice", "Bob"]
+        # Top-level warning is what CI gates key on when they don't parse stats.
+        assert any("missing_input_refusals" in w for w in data["warnings"])
+        mock_synth.assert_not_called()
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_stays_valid_below_threshold(self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path):
+        """One refusal out of three (~33%) is below the 50% threshold — the
+        run is still valid and synthesis proceeds."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[{"question": "Q", "response": "I don't see the content you mentioned."}],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Bob",
+                    responses=[{"question": "Q", "response": "Reasonably priced."}],
+                    usage=ZERO_USAGE,
+                ),
+                PanelistResult(
+                    persona_name="Carol",
+                    responses=[{"question": "Q", "response": "Great value."}],
+                    usage=ZERO_USAGE,
+                ),
+            ],
+            registry,
+            {},
+        )
+        mock_synth.return_value = _mock_synthesis_result()
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n  - name: Carol\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["run_invalid"] is False
+        assert data["missing_input_stats"]["refusing"] == 1
+        assert data["missing_input_stats"]["considered"] == 3
+        assert not any("missing_input_refusals" in w for w in data.get("warnings", []))
+        mock_synth.assert_called_once()
+
+
 # --- sp-7vp: --save flag --------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Set `run_invalid = true` in the output metadata when ≥50% of panelists report they couldn't answer because of missing input, so downstream consumers don't treat a compromised run as valid signal

## Source
- Polecat: furiosa
- Issue: sp-bjt4
- MR: sp-wisp-i50
- Branch: polecat/furiosa-mo8n32l8

## Test plan
- [ ] CI passes (new coverage in test_cli.py)
- [ ] Runs with majority "missing input" panelists emit `run_invalid: true`

## Conflict note
Touches src/synth_panel/cli/commands.py and tests/test_cli.py — overlaps with the open CLI stack (#190, #192, #193, #195-#198, #202, #203). Rebase near-certain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)