### PR TITLE
fix(panel): emit per_model_results + cost_breakdown on non-ensemble runs (sp-0h9x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Fixed
+- (sp-0h9x) Panel results: `per_model_results` and `cost_breakdown` are now populated on every non-ensemble `panel run` (CLI + MCP), not just `models=[...]` ensemble runs. Mixed-model panels via `persona_models` surface one rollup entry per distinct model; single-model panels surface a one-entry dict. sp-gl9 only wired these fields in the ensemble path, so mayor's audits and other consumers reading the flat panel shape still saw `None`.
+
 ## [0.9.5] - 2026-04-21
 
 ### Added

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -21,7 +21,7 @@ from synth_panel.credentials import has_credential
 from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
 from synth_panel.metadata import PanelTimer, build_metadata
-from synth_panel.orchestrator import run_panel_parallel
+from synth_panel.orchestrator import PanelistResult, run_panel_parallel
 from synth_panel.persistence import Session
 from synth_panel.perturbation import generate_panel_variants
 from synth_panel.prompts import (
@@ -1023,6 +1023,34 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             # surfaces it — this is the critical fix for sp-2hg.
             print(banner, file=sys.stderr)
     else:
+        # sp-0h9x: always populate per_model_results + cost_breakdown, even
+        # for single-model panels. mayor's ensemble audits use persona_models
+        # (mixed-model mode) rather than the ``models=[...]`` ensemble path,
+        # so these fields were silently None in 0.9.5 despite sp-gl9 claiming
+        # to ship them. A single-entry rollup still eliminates the
+        # None-vs-dict branch for consumers.
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        def _cli_panelist_formatter(pr: PanelistResult, panel_model: str) -> dict[str, Any]:
+            pr_pricing, _ = lookup_pricing(pr.model or panel_model)
+            pr_cost = estimate_cost(pr.usage, pr_pricing)
+            out: dict[str, Any] = {
+                "persona": pr.persona_name,
+                "responses": pr.responses,
+                "usage": pr.usage.to_dict(),
+                "cost": pr_cost.format_usd(),
+                "error": pr.error,
+            }
+            if pr.model:
+                out["model"] = pr.model
+            return out
+
+        per_model_results, cost_breakdown = build_mixed_model_rollup(
+            panelist_results,
+            default_model=model,
+            panelist_formatter=_cli_panelist_formatter,
+        )
+
         extra: dict[str, Any] = _build_rounds_shape(
             instrument=instrument,
             results=results,
@@ -1035,6 +1063,8 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             persona_count=len(personas),
             question_count=len(questions),
             metadata=metadata,
+            per_model_results=per_model_results,
+            cost_breakdown=cost_breakdown,
         )
         extra["parameters"] = _build_params_metadata(args, temperature, top_p)
         # Surface failure stats + run validity in structured output so
@@ -1364,6 +1394,8 @@ def _build_rounds_shape(
     question_count: int,
     panelist_usage: TokenUsage | None = None,
     metadata: dict[str, Any] | None = None,
+    per_model_results: dict[str, Any] | None = None,
+    cost_breakdown: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the rounds-shaped panel output payload.
 
@@ -1372,6 +1404,11 @@ def _build_rounds_shape(
     runs use this same shape with one entry per executed round; that
     wiring lives in F3-A. Per-round ``synthesis`` is ``null`` for the
     single-round case — the final synthesis goes at the top level.
+
+    ``per_model_results`` and ``cost_breakdown``, when provided, surface
+    the sp-0h9x rollup shape alongside the primary ``model`` field — a
+    superset of the mixed-model artifact that mayor's ensemble audits
+    previously had to reconstruct by iterating ``rounds[].results[]``.
     """
     round_name = instrument.rounds[0].name if instrument.rounds else "default"
     result: dict[str, Any] = {
@@ -1392,6 +1429,8 @@ def _build_rounds_shape(
         "model": model,
         "persona_count": persona_count,
         "question_count": question_count,
+        "per_model_results": per_model_results,
+        "cost_breakdown": cost_breakdown,
     }
     if metadata is not None:
         result["metadata"] = metadata

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -158,6 +158,19 @@ def ensemble_run(
     )
 
 
+def _default_panelist_formatter(pr: PanelistResult, model: str) -> dict[str, Any]:
+    """Minimal panelist dict shared by ensemble + mixed-model rollups."""
+    out: dict[str, Any] = {
+        "persona": pr.persona_name,
+        "responses": pr.responses,
+    }
+    if pr.model or model:
+        out["model"] = pr.model or model
+    if pr.error:
+        out["error"] = pr.error
+    return out
+
+
 def build_ensemble_output(
     ens: EnsembleResult,
     *,
@@ -180,18 +193,7 @@ def build_ensemble_output(
     useful payload.
     """
 
-    def _default_formatter(pr: PanelistResult, model: str) -> dict[str, Any]:
-        out: dict[str, Any] = {
-            "persona": pr.persona_name,
-            "responses": pr.responses,
-        }
-        if pr.model or model:
-            out["model"] = pr.model or model
-        if pr.error:
-            out["error"] = pr.error
-        return out
-
-    fmt = panelist_formatter or _default_formatter
+    fmt = panelist_formatter or _default_panelist_formatter
 
     per_model_results: dict[str, dict[str, Any]] = {}
     for mr in ens.model_results:
@@ -210,6 +212,76 @@ def build_ensemble_output(
         "models": list(ens.models),
         "total_usage": ens.total_usage.to_dict(),
     }
+
+
+def build_mixed_model_rollup(
+    panelist_results: list[PanelistResult],
+    default_model: str,
+    *,
+    panelist_formatter: Callable[[PanelistResult, str], dict[str, Any]] | None = None,
+) -> tuple[dict[str, dict[str, Any]], dict[str, Any]]:
+    """Group panelist results by model and produce ``per_model_results`` + ``cost_breakdown``.
+
+    Unlike :func:`build_ensemble_output`, this operates on the output of a
+    single :func:`run_panel_parallel` call where panelists may have run on
+    different models via ``persona_models``. The returned shape matches the
+    ensemble path so downstream consumers (dashboards, CI gates, cost
+    comparators) see the same keys regardless of how the mix arose.
+
+    Single-model panels still produce a one-entry ``per_model_results`` dict
+    rather than ``None`` — "only one model ran" is a valid rollup, and
+    keeping the field populated eliminates a None-vs-dict branch for
+    consumers.
+
+    Args:
+        panelist_results: Flat list of :class:`PanelistResult` objects from
+            a single panel run. Each result's ``model`` attribute is used
+            to key the rollup; untagged results fall back to ``default_model``.
+        default_model: Model to use for results whose ``model`` attribute
+            is ``None`` (e.g. pre-multi-model panels).
+        panelist_formatter: Callable returning the per-panelist dict shape.
+            Defaults to a minimal ``{persona, responses, model}`` dict; CLI
+            callers override this to emit the full ``cost`` + ``usage``
+            shape already used in ``results[]``.
+
+    Returns:
+        ``(per_model_results, cost_breakdown)`` where:
+
+        * ``per_model_results`` is ``{model: {results, cost, usage}}``
+        * ``cost_breakdown`` is ``{by_model: {model: "$X"}, total: "$Y"}``
+
+        Both are empty when ``panelist_results`` is empty.
+    """
+    fmt = panelist_formatter or _default_panelist_formatter
+
+    by_model: dict[str, list[PanelistResult]] = {}
+    for pr in panelist_results:
+        key = pr.model or default_model
+        by_model.setdefault(key, []).append(pr)
+
+    per_model_results: dict[str, dict[str, Any]] = {}
+    by_model_cost: dict[str, str] = {}
+    total_cost = CostEstimate()
+
+    for model_name, prs in by_model.items():
+        model_usage = ZERO_USAGE
+        for pr in prs:
+            model_usage = model_usage + pr.usage
+        pricing, _ = lookup_pricing(model_name)
+        model_cost = estimate_cost(model_usage, pricing)
+        per_model_results[model_name] = {
+            "results": [fmt(pr, model_name) for pr in prs],
+            "cost": model_cost.format_usd(),
+            "usage": model_usage.to_dict(),
+        }
+        by_model_cost[model_name] = model_cost.format_usd()
+        total_cost = total_cost + model_cost
+
+    cost_breakdown: dict[str, Any] = {
+        "by_model": by_model_cost,
+        "total": total_cost.format_usd(),
+    }
+    return per_model_results, cost_breakdown
 
 
 # ---------------------------------------------------------------------------

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -438,6 +438,19 @@ async def _run_panel_async_instrument(
         question_count=total_question_count,
     )
 
+    # sp-0h9x: mirror the ensemble path's per-model rollup onto every
+    # non-ensemble panel result. The terminal round's panelist list is the
+    # canonical "one row per persona" view, so grouping those by model
+    # matches the flat ``results`` field that back-compat consumers read.
+    from synth_panel.ensemble import build_mixed_model_rollup
+
+    terminal_prs = mr.rounds[-1].panelist_results if mr.rounds else []
+    per_model_results, cost_breakdown = build_mixed_model_rollup(
+        terminal_prs,
+        default_model=model,
+        panelist_formatter=lambda pr, m: _format_panelist_result(pr, m),
+    )
+
     return {
         "result_id": result_id,
         "model": model,
@@ -453,6 +466,8 @@ async def _run_panel_async_instrument(
         # Back-compat: ``results`` mirrors the terminal round's flat panelist
         # list so v1/v2 callers see the same shape they did pre-0.5.0.
         "results": flat_results,
+        "per_model_results": per_model_results,
+        "cost_breakdown": cost_breakdown,
         "metadata": inst_metadata,
     }
 
@@ -549,6 +564,17 @@ async def _run_panel_async(
         variant_count=variant_count,
     )
 
+    # sp-0h9x: emit per_model_results + cost_breakdown so downstream
+    # consumers see the same rollup shape as the ensemble path, even on
+    # single-model and mixed-model (persona_models) panels.
+    from synth_panel.ensemble import build_mixed_model_rollup
+
+    per_model_results, cost_breakdown = build_mixed_model_rollup(
+        _panelist_results,
+        default_model=model,
+        panelist_formatter=lambda pr, m: _format_panelist_result(pr, m),
+    )
+
     result: dict[str, Any] = {
         "result_id": result_id,
         "model": model,
@@ -567,6 +593,8 @@ async def _run_panel_async(
         ],
         "path": [],
         "warnings": [],
+        "per_model_results": per_model_results,
+        "cost_breakdown": cost_breakdown,
         "metadata": metadata,
     }
 
@@ -721,6 +749,14 @@ async def run_panel(
     raw ``questions`` input, ``path`` has length 1 or N (linear) and
     ``warnings`` is empty in the typical case — the shape is uniform
     across versions so callers don't need to special-case.
+
+    Every non-ensemble run also includes ``per_model_results``
+    (``{model: {results, cost, usage}}``) and ``cost_breakdown``
+    (``{by_model, total}``) — the same shape the ``models=[...]``
+    ensemble path returns. Single-model panels produce a one-entry
+    dict; ``persona_models`` runs produce one entry per distinct
+    model. Consumers can read the rollup unconditionally instead of
+    iterating ``rounds[].results[]`` themselves.
 
     Args:
         questions: Flat list of question dicts (v1-equivalent). Each

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -600,6 +600,110 @@ class TestBuildEnsembleOutput:
 
 
 # ---------------------------------------------------------------------------
+# Tests: build_mixed_model_rollup (sp-0h9x)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMixedModelRollup:
+    """Non-ensemble panels should still emit per_model_results + cost_breakdown.
+
+    sp-0h9x: sp-gl9 only populated these fields in the ensemble path. Mixed-
+    model panels (via ``persona_models``) and even single-model panels must
+    get the same rollup shape so downstream consumers (dashboards, CI gates)
+    don't have to reconstruct it from ``rounds[].results[]``.
+    """
+
+    def _pr(self, name: str, model: str | None, inp: int = 100, out: int = 50) -> PanelistResult:
+        from synth_panel.cost import TokenUsage
+
+        return PanelistResult(
+            persona_name=name,
+            responses=[{"question": "Q1", "response": f"{name}-a", "error": False}],
+            usage=TokenUsage(input_tokens=inp, output_tokens=out),
+            model=model,
+        )
+
+    def test_single_model_one_entry(self):
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        prs = [self._pr("Alice", "haiku"), self._pr("Bob", "haiku")]
+        pmr, cb = build_mixed_model_rollup(prs, default_model="haiku")
+        assert list(pmr.keys()) == ["haiku"]
+        assert len(pmr["haiku"]["results"]) == 2
+        assert pmr["haiku"]["usage"]["input_tokens"] == 200
+        assert pmr["haiku"]["usage"]["output_tokens"] == 100
+        assert pmr["haiku"]["cost"].startswith("$")
+        assert set(cb.keys()) == {"by_model", "total"}
+        assert list(cb["by_model"].keys()) == ["haiku"]
+        assert cb["total"].startswith("$")
+
+    def test_mixed_model_groups_by_pr_model(self):
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        prs = [
+            self._pr("Alice", "haiku", inp=100, out=50),
+            self._pr("Bob", "sonnet", inp=200, out=80),
+            self._pr("Carol", "haiku", inp=50, out=20),
+        ]
+        pmr, cb = build_mixed_model_rollup(prs, default_model="haiku")
+        assert set(pmr.keys()) == {"haiku", "sonnet"}
+        # Haiku gets Alice + Carol aggregated
+        assert pmr["haiku"]["usage"]["input_tokens"] == 150
+        assert pmr["haiku"]["usage"]["output_tokens"] == 70
+        haiku_personas = [r["persona"] for r in pmr["haiku"]["results"]]
+        assert haiku_personas == ["Alice", "Carol"]
+        # Sonnet gets Bob only
+        assert pmr["sonnet"]["usage"]["input_tokens"] == 200
+        assert [r["persona"] for r in pmr["sonnet"]["results"]] == ["Bob"]
+        # Breakdown covers both models
+        assert set(cb["by_model"].keys()) == {"haiku", "sonnet"}
+
+    def test_untagged_pr_falls_back_to_default_model(self):
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        prs = [self._pr("Alice", None), self._pr("Bob", None)]
+        pmr, _cb = build_mixed_model_rollup(prs, default_model="haiku")
+        assert list(pmr.keys()) == ["haiku"]
+        assert len(pmr["haiku"]["results"]) == 2
+
+    def test_empty_results(self):
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        pmr, cb = build_mixed_model_rollup([], default_model="haiku")
+        assert pmr == {}
+        assert cb == {"by_model": {}, "total": "$0.0000"}
+
+    def test_custom_formatter(self):
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        def fmt(pr, model):
+            return {"n": pr.persona_name, "m": model}
+
+        prs = [self._pr("Alice", "haiku"), self._pr("Bob", "sonnet")]
+        pmr, _cb = build_mixed_model_rollup(prs, default_model="haiku", panelist_formatter=fmt)
+        assert pmr["haiku"]["results"] == [{"n": "Alice", "m": "haiku"}]
+        assert pmr["sonnet"]["results"] == [{"n": "Bob", "m": "sonnet"}]
+
+    def test_total_equals_sum_of_by_model(self):
+        """cost_breakdown.total must equal the sum of by_model values."""
+        from synth_panel.cost import CostEstimate, estimate_cost, lookup_pricing
+        from synth_panel.ensemble import build_mixed_model_rollup
+
+        prs = [
+            self._pr("Alice", "haiku", inp=100, out=50),
+            self._pr("Bob", "sonnet", inp=200, out=80),
+        ]
+        _pmr, cb = build_mixed_model_rollup(prs, default_model="haiku")
+
+        # Re-derive expected total from pricing to confirm it aggregates
+        expected = CostEstimate()
+        for pr in prs:
+            pricing, _ = lookup_pricing(pr.model)
+            expected = expected + estimate_cost(pr.usage, pricing)
+        assert cb["total"] == expected.format_usd()
+
+
+# ---------------------------------------------------------------------------
 # Tests: CLI parser --models ensemble format
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Emit `per_model_results` + `cost_breakdown` shape uniformly — including on single-model (non-ensemble) runs — so downstream consumers don't need to branch on ensemble-vs-solo output

## Source
- Polecat: nux
- Issue: sp-0h9x
- MR: sp-wisp-5sd
- Branch: polecat/nux-mo8sk0cq

## Test plan
- [ ] CI passes (updated coverage in test_ensemble.py)
- [ ] Non-ensemble `panel run` JSON output carries per_model_results + cost_breakdown

## Conflict note
Touches cli/commands.py, ensemble.py, mcp/server.py, CHANGELOG.md, test_ensemble.py — heavy overlap with the open CLI/ensemble stack (#187, #190, #192, #193, #195-#198, #201-#204). Rebase near-certain after any of those lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)