### PR TITLE
fix(ensemble): bucket cost per-model so multi-model runs report real spend (sp-atvc)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -16,7 +16,15 @@ from typing import Any
 import yaml
 
 from synth_panel.cli.output import OutputFormat, emit
-from synth_panel.cost import ZERO_USAGE, TokenUsage, estimate_cost, format_summary, lookup_pricing
+from synth_panel.cost import (
+    ZERO_USAGE,
+    CostEstimate,
+    TokenUsage,
+    aggregate_per_model,
+    estimate_cost,
+    format_summary,
+    lookup_pricing,
+)
 from synth_panel.credentials import has_credential
 from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
@@ -774,6 +782,21 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         )
         timer.stop()
         output = build_ensemble_output(ens_result)
+        # sp-atvc: attach a metadata bundle whose cost.per_model covers
+        # every ensemble model, not just the first in the spec.
+        ens_per_model_meta = {mr.model: (mr.usage, mr.cost) for mr in ens_result.model_results}
+        output["metadata"] = build_metadata(
+            panelist_model=ensemble_models[0],
+            panelist_usage=ens_result.total_usage,
+            panelist_cost=ens_result.total_cost,
+            total_usage=ens_result.total_usage,
+            total_cost=ens_result.total_cost,
+            persona_count=ens_result.persona_count,
+            question_count=ens_result.question_count,
+            timer=timer,
+            template_vars=template_vars or None,
+            panelist_per_model=ens_per_model_meta,
+        )
         emit(fmt, message="Ensemble complete", extra=output)
         return 0
 
@@ -838,6 +861,13 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         results.append(result_dict)
         panelist_usage = panelist_usage + pr.usage
 
+    # sp-atvc: bucket panelist usage/cost by actual model so multi-model
+    # runs (persona_models routing, --blend, ensemble) price each token
+    # at the rate its provider charged, instead of applying the primary
+    # model's rate to every bucket.
+    panelist_per_model_usage, panelist_per_model_cost = aggregate_per_model(panelist_results, model)
+    multi_model_run = len(panelist_per_model_usage) > 1
+
     # ── Failure analysis (sp-2hg) ──────────────────────────────────────
     # Count panelist-question pairs and determine how many errored. A pair
     # is considered errored if its response dict is flagged ``error: True``
@@ -865,9 +895,16 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     if missing_input_invalid:
         run_invalid = True
 
-    # Compute panelist costs (needed before synthesis for cost estimate)
+    # Compute panelist costs (needed before synthesis for cost estimate).
+    # For multi-model runs, sum the per-model costs so the total reflects
+    # each provider's real rate; single-model runs keep the legacy path.
     pricing, is_estimated = lookup_pricing(model)
-    panelist_cost_est = estimate_cost(panelist_usage, pricing)
+    if multi_model_run:
+        panelist_cost_est = CostEstimate()
+        for _m, _c in panelist_per_model_cost.items():
+            panelist_cost_est = panelist_cost_est + _c
+    else:
+        panelist_cost_est = estimate_cost(panelist_usage, pricing)
 
     # Synthesis step (unless --no-synthesis)
     skip_synthesis = getattr(args, "no_synthesis", False)
@@ -906,6 +943,12 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     timer.stop()
     synthesis_dict = synthesis_result.to_dict() if synthesis_result else None
 
+    panelist_per_model_meta: dict[str, tuple[TokenUsage, CostEstimate]] | None = None
+    if multi_model_run:
+        panelist_per_model_meta = {
+            _m: (panelist_per_model_usage[_m], panelist_per_model_cost[_m]) for _m in panelist_per_model_usage
+        }
+
     metadata = build_metadata(
         panelist_model=model,
         synthesis_model=getattr(args, "synthesis_model", None),
@@ -919,6 +962,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         question_count=len(questions),
         timer=timer,
         template_vars=template_vars or None,
+        panelist_per_model=panelist_per_model_meta,
     )
 
     # sp-prof: inject profile info into metadata for synthbench

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -231,6 +231,34 @@ def estimate_cost(
     )
 
 
+def aggregate_per_model(
+    panelist_results,  # Iterable[PanelistResult]; untyped to avoid circular import
+    default_model: str,
+) -> tuple[dict[str, TokenUsage], dict[str, CostEstimate]]:
+    """Bucket panelist usage/cost by each result's ``.model`` attribute.
+
+    Each panelist's ``.model`` (falling back to *default_model* when unset)
+    is used to look up that provider's pricing, so multi-model runs
+    (``--models haiku:0.5,gemini:0.5`` routing, ``ensemble_run``, or
+    ``--blend`` mode) get per-model cost that reflects the actual rate
+    the provider charged — not a uniform rate applied across all tokens.
+
+    Returns ``(per_model_usage, per_model_cost)``. Keys are the model
+    identifiers as recorded on panelist results (alias resolution happens
+    later in ``build_metadata`` when producing the public payload).
+    """
+    per_usage: dict[str, TokenUsage] = {}
+    for pr in panelist_results:
+        m = getattr(pr, "model", None) or default_model
+        per_usage[m] = per_usage.get(m, ZERO_USAGE) + pr.usage
+
+    per_cost: dict[str, CostEstimate] = {}
+    for m, usage in per_usage.items():
+        pricing, _ = lookup_pricing(m)
+        per_cost[m] = estimate_cost(usage, pricing)
+    return per_usage, per_cost
+
+
 def format_summary(
     label: str,
     usage: TokenUsage,

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -174,11 +174,17 @@ def build_ensemble_output(
     exposes both the per-model USD breakdown (``by_model``) and the total
     (``total``).
 
+    ``metadata`` carries the synthbench-shaped ``cost.per_model`` bundle
+    populated from every model in the ensemble (sp-atvc). Without this,
+    downstream audits that read ``metadata.cost.per_model`` only saw the
+    first model and undercounted multi-model ensemble spend.
+
     ``panelist_formatter`` customises how each :class:`PanelistResult` is
     rendered; when omitted, a minimal ``{persona, responses, model}`` dict
     is produced so callers without the full runner context still get a
     useful payload.
     """
+    from synth_panel.metadata import build_metadata
 
     def _default_formatter(pr: PanelistResult, model: str) -> dict[str, Any]:
         out: dict[str, Any] = {
@@ -201,6 +207,21 @@ def build_ensemble_output(
             "usage": mr.usage.to_dict(),
         }
 
+    # sp-atvc: build a metadata bundle whose cost.per_model covers every
+    # ensemble model so downstream audits see real per-provider spend.
+    primary_model = ens.models[0] if ens.models else ""
+    panelist_per_model = {mr.model: (mr.usage, mr.cost) for mr in ens.model_results}
+    ens_metadata = build_metadata(
+        panelist_model=primary_model,
+        panelist_usage=ens.total_usage,
+        panelist_cost=ens.total_cost,
+        total_usage=ens.total_usage,
+        total_cost=ens.total_cost,
+        persona_count=ens.persona_count,
+        question_count=ens.question_count,
+        panelist_per_model=panelist_per_model,
+    )
+
     return {
         "per_model_results": per_model_results,
         "cost_breakdown": {
@@ -209,6 +230,7 @@ def build_ensemble_output(
         },
         "models": list(ens.models),
         "total_usage": ens.total_usage.to_dict(),
+        "metadata": ens_metadata,
     }
 
 

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -60,7 +60,13 @@ from synth_panel._runners import (
 from synth_panel._runners import (
     run_panel_sync as _run_panel_sync,
 )
-from synth_panel.cost import ZERO_USAGE, estimate_cost, lookup_pricing
+from synth_panel.cost import (
+    ZERO_USAGE,
+    CostEstimate,
+    aggregate_per_model,
+    estimate_cost,
+    lookup_pricing,
+)
 from synth_panel.cost import TokenUsage as CostTokenUsage
 from synth_panel.instrument import Instrument, parse_instrument
 from synth_panel.llm.client import LLMClient
@@ -390,7 +396,6 @@ async def _run_panel_async_instrument(
         flat_results = round_dict_results
 
     pricing, _ = lookup_pricing(model)
-    total_cost = estimate_cost(mr.usage, pricing)
 
     timer.stop()
 
@@ -400,12 +405,24 @@ async def _run_panel_async_instrument(
         else None
     )
 
-    # Compute per-model cost breakdown for metadata
+    # sp-atvc: aggregate panelist usage/cost per actual model across all
+    # rounds so multi-model instrument runs get accurate per-model cost
+    # instead of pricing every bucket at the default model's rate.
+    all_panelist_results: list[Any] = [pr for rr in mr.rounds for pr in rr.panelist_results]
+    per_model_usage, per_model_cost = aggregate_per_model(all_panelist_results, model)
+    multi_model_run = len(per_model_usage) > 1
+
     panelist_usage = ZERO_USAGE
     for rr in mr.rounds:
         for pr in rr.panelist_results:
             panelist_usage = panelist_usage + pr.usage
-    panelist_cost_est = estimate_cost(panelist_usage, pricing)
+
+    if multi_model_run:
+        panelist_cost_est = CostEstimate()
+        for _c in per_model_cost.values():
+            panelist_cost_est = panelist_cost_est + _c
+    else:
+        panelist_cost_est = estimate_cost(panelist_usage, pricing)
 
     synthesis_usage_for_meta: CostTokenUsage | None = None
     synthesis_cost_for_meta = None
@@ -415,6 +432,13 @@ async def _run_panel_async_instrument(
         synth_pricing, _ = lookup_pricing(synth_model)
         synthesis_cost_for_meta = estimate_cost(synthesis_usage_for_meta, synth_pricing)
 
+    # Derive the run's reported total_cost from the accurate components
+    # instead of the single-model rollup that mr.usage assumes.
+    total_cost = panelist_cost_est + (synthesis_cost_for_meta or CostEstimate())
+
+    panelist_per_model_meta = (
+        {_m: (per_model_usage[_m], per_model_cost[_m]) for _m in per_model_usage} if multi_model_run else None
+    )
     inst_metadata = build_metadata(
         panelist_model=model,
         synthesis_model=getattr(mr.final_synthesis, "model", None) if mr.final_synthesis else None,
@@ -427,6 +451,7 @@ async def _run_panel_async_instrument(
         persona_count=len(personas),
         question_count=total_question_count,
         timer=timer,
+        panelist_per_model=panelist_per_model_meta,
     )
 
     result_id = save_panel_result(
@@ -481,7 +506,7 @@ async def _run_panel_async(
 
     # Run the blocking panel execution in a thread
     (
-        _panelist_results,
+        panelist_results_full,
         result_dicts,
         panelist_usage,
         panelist_cost,
@@ -509,6 +534,17 @@ async def _run_panel_async(
 
     await ctx.report_progress(total, total)
 
+    # sp-atvc: re-price panelist usage per actual model when panelists
+    # were dispatched across multiple providers (persona_models routing).
+    # Without this, total_cost prices every token at the default model's
+    # rate and metadata.cost.per_model hides the cheaper/dearer providers.
+    per_model_usage, per_model_cost = aggregate_per_model(panelist_results_full, model)
+    multi_model_run = len(per_model_usage) > 1
+    if multi_model_run:
+        panelist_cost = CostEstimate()
+        for _c in per_model_cost.values():
+            panelist_cost = panelist_cost + _c
+
     # Compute total cost (panelist + synthesis)
     synthesis_usage_obj: CostTokenUsage | None = None
     synthesis_cost_obj = None
@@ -523,6 +559,9 @@ async def _run_panel_async(
         total_cost = panelist_cost
 
     timer.stop()
+    panelist_per_model_meta = (
+        {_m: (per_model_usage[_m], per_model_cost[_m]) for _m in per_model_usage} if multi_model_run else None
+    )
     metadata = build_metadata(
         panelist_model=model,
         synthesis_model=synthesis_dict.get("model") if synthesis_dict else None,
@@ -535,6 +574,7 @@ async def _run_panel_async(
         persona_count=len(personas),
         question_count=len(questions),
         timer=timer,
+        panelist_per_model=panelist_per_model_meta,
     )
 
     # Save result

--- a/src/synth_panel/metadata.py
+++ b/src/synth_panel/metadata.py
@@ -12,7 +12,7 @@ import platform
 import time
 from typing import Any
 
-from synth_panel.cost import CostEstimate, TokenUsage, lookup_pricing
+from synth_panel.cost import CostEstimate, TokenUsage
 from synth_panel.llm.aliases import resolve_alias
 
 
@@ -95,12 +95,22 @@ def build_metadata(
     question_count: int,
     timer: PanelTimer | None = None,
     template_vars: dict[str, str] | None = None,
+    panelist_per_model: dict[str, tuple[TokenUsage, CostEstimate]] | None = None,
 ) -> dict[str, Any]:
     """Build the ``metadata`` dict for synthbench integration.
 
     Parameters correspond to data already available at the call site in
     both CLI and MCP output paths — no new tracking infrastructure is
     required.
+
+    ``panelist_per_model`` is an optional ``{model: (usage, cost)}`` map
+    that replaces the default single-model panelist bucket. Used by
+    ensemble, ``--blend``, and weighted ``persona_models`` runs where
+    panelists were dispatched across multiple providers; each bucket
+    carries the tokens actually billed to that model so
+    ``metadata.cost.per_model`` reflects real spend instead of pricing
+    every token at the default model's rate. When ``None``, the legacy
+    single-model (+ optional synthesis) shape is produced.
     """
     resolved_panelist = resolve_alias(panelist_model)
     resolved_synthesis = resolve_alias(synthesis_model) if synthesis_model else resolved_panelist
@@ -119,23 +129,36 @@ def build_metadata(
     }
 
     # -- cost --
-    _panelist_pricing, _ = lookup_pricing(panelist_model)
-    per_model: dict[str, Any] = {
-        resolved_panelist: {
+    per_model: dict[str, Any] = {}
+    if panelist_per_model:
+        for m, (u, c) in panelist_per_model.items():
+            key = resolve_alias(m)
+            existing = per_model.get(key)
+            if existing is None:
+                per_model[key] = {
+                    "tokens": u.total_tokens,
+                    "cost_usd": round(c.total_cost, 6),
+                }
+            else:
+                # Two aliases resolve to the same canonical id — merge.
+                existing["tokens"] += u.total_tokens
+                existing["cost_usd"] = round(existing["cost_usd"] + c.total_cost, 6)
+    else:
+        per_model[resolved_panelist] = {
             "tokens": panelist_usage.total_tokens,
             "cost_usd": round(panelist_cost.total_cost, 6),
-        },
-    }
-    if synthesis_usage is not None and synthesis_cost is not None and resolved_synthesis != resolved_panelist:
-        per_model[resolved_synthesis] = {
-            "tokens": synthesis_usage.total_tokens,
-            "cost_usd": round(synthesis_cost.total_cost, 6),
         }
-    elif synthesis_usage is not None and synthesis_cost is not None:
-        # Same model — merge into existing entry
-        existing = per_model[resolved_panelist]
-        existing["tokens"] += synthesis_usage.total_tokens
-        existing["cost_usd"] = round(existing["cost_usd"] + synthesis_cost.total_cost, 6)
+
+    if synthesis_usage is not None and synthesis_cost is not None:
+        existing = per_model.get(resolved_synthesis)
+        if existing is None:
+            per_model[resolved_synthesis] = {
+                "tokens": synthesis_usage.total_tokens,
+                "cost_usd": round(synthesis_cost.total_cost, 6),
+            }
+        else:
+            existing["tokens"] += synthesis_usage.total_tokens
+            existing["cost_usd"] = round(existing["cost_usd"] + synthesis_cost.total_cost, 6)
 
     cost: dict[str, Any] = {
         "total_tokens": total_usage.total_tokens,

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -41,6 +41,8 @@ from synth_panel._runners import (
 )
 from synth_panel.cost import (
     ZERO_USAGE,
+    CostEstimate,
+    aggregate_per_model,
     estimate_cost,
     lookup_pricing,
 )
@@ -525,7 +527,7 @@ def quick_poll(
     client = _get_client()
     timer = PanelTimer()
     (
-        _panelist_results,
+        panelist_results_full,
         result_dicts,
         panelist_usage,
         panelist_cost,
@@ -543,6 +545,15 @@ def quick_poll(
         top_p=top_p,
     )
 
+    # sp-atvc: re-price per actual model when panelists ran across
+    # providers so the PollResult surfaces real spend.
+    per_model_usage, per_model_cost = aggregate_per_model(panelist_results_full, model)
+    multi_model_run = len(per_model_usage) > 1
+    if multi_model_run:
+        panelist_cost = CostEstimate()
+        for _c in per_model_cost.values():
+            panelist_cost = panelist_cost + _c
+
     synthesis_usage_obj: CostTokenUsage | None = None
     synthesis_cost_obj = None
     if synthesis_dict and "usage" in synthesis_dict:
@@ -556,6 +567,9 @@ def quick_poll(
         total_cost = panelist_cost
 
     timer.stop()
+    panelist_per_model_meta = (
+        {_m: (per_model_usage[_m], per_model_cost[_m]) for _m in per_model_usage} if multi_model_run else None
+    )
     metadata = build_metadata(
         panelist_model=model,
         synthesis_model=synthesis_dict.get("model") if synthesis_dict else None,
@@ -568,6 +582,7 @@ def quick_poll(
         persona_count=len(merged),
         question_count=1,
         timer=timer,
+        panelist_per_model=panelist_per_model_meta,
     )
 
     result_id = save_panel_result(
@@ -699,12 +714,22 @@ def run_panel(
             synthesis_temperature=synthesis_temperature,
         )
         pricing, _ = lookup_pricing(model)
-        total_cost = estimate_cost(mr.usage, pricing)
         panelist_usage = ZERO_USAGE
         for rr in mr.rounds:
             for pr in rr.panelist_results:
                 panelist_usage = panelist_usage + pr.usage
-        panelist_cost_est = estimate_cost(panelist_usage, pricing)
+
+        # sp-atvc: accurate per-model cost across rounds when panelists
+        # ran on different providers (persona_models routing).
+        all_pr = [pr for rr in mr.rounds for pr in rr.panelist_results]
+        per_model_usage, per_model_cost = aggregate_per_model(all_pr, model)
+        multi_model_run = len(per_model_usage) > 1
+        if multi_model_run:
+            panelist_cost_est = CostEstimate()
+            for _c in per_model_cost.values():
+                panelist_cost_est = panelist_cost_est + _c
+        else:
+            panelist_cost_est = estimate_cost(panelist_usage, pricing)
 
         synthesis_usage_for_meta: CostTokenUsage | None = None
         synthesis_cost_for_meta = None
@@ -715,8 +740,13 @@ def run_panel(
             synthesis_cost_for_meta = estimate_cost(synthesis_usage_for_meta, synth_pricing)
         timer.stop()
 
+        total_cost = panelist_cost_est + (synthesis_cost_for_meta or CostEstimate())
+
         total_question_count = sum(
             len(next((r.questions for r in instrument_obj.rounds if r.name == rr.name), [])) for rr in mr.rounds
+        )
+        panelist_per_model_meta = (
+            {_m: (per_model_usage[_m], per_model_cost[_m]) for _m in per_model_usage} if multi_model_run else None
         )
         metadata = build_metadata(
             panelist_model=model,
@@ -730,6 +760,7 @@ def run_panel(
             persona_count=len(merged),
             question_count=total_question_count,
             timer=timer,
+            panelist_per_model=panelist_per_model_meta,
         )
 
         # Flat results for persistence — take the terminal round's panelist list.
@@ -762,7 +793,7 @@ def run_panel(
 
     timer = PanelTimer()
     (
-        _panelist_results,
+        panelist_results_full,
         result_dicts,
         panelist_usage,
         panelist_cost,
@@ -785,6 +816,14 @@ def run_panel(
         variants=variants,
     )
 
+    # sp-atvc: per-model accounting for multi-provider panelist routing.
+    per_model_usage, per_model_cost = aggregate_per_model(panelist_results_full, model)
+    multi_model_run = len(per_model_usage) > 1
+    if multi_model_run:
+        panelist_cost = CostEstimate()
+        for _c in per_model_cost.values():
+            panelist_cost = panelist_cost + _c
+
     synthesis_usage_obj: CostTokenUsage | None = None
     synthesis_cost_obj = None
     if synthesis_dict and "usage" in synthesis_dict:
@@ -798,6 +837,9 @@ def run_panel(
         total_cost = panelist_cost
 
     timer.stop()
+    panelist_per_model_meta = (
+        {_m: (per_model_usage[_m], per_model_cost[_m]) for _m in per_model_usage} if multi_model_run else None
+    )
     metadata = build_metadata(
         panelist_model=model,
         synthesis_model=synthesis_dict.get("model") if synthesis_dict else None,
@@ -810,6 +852,7 @@ def run_panel(
         persona_count=len(merged),
         question_count=len(normalised_questions),
         timer=timer,
+        panelist_per_model=panelist_per_model_meta,
     )
 
     variant_count = variant_data["variant_count"] if variant_data else 0

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -16,6 +16,7 @@ from synth_panel.cost import (
     CostEstimate,
     TokenUsage,
     UsageTracker,
+    aggregate_per_model,
     estimate_cost,
     format_summary,
     lookup_pricing,
@@ -179,6 +180,87 @@ class TestEstimateCost:
         cost = estimate_cost(usage, HAIKU_PRICING)
         assert cost.cache_creation_cost == pytest.approx(1.25)
         assert cost.cache_read_cost == pytest.approx(0.10)
+
+
+# --- aggregate_per_model --------------------------------------------------
+
+
+class _FakePanelist:
+    """Minimal stand-in for PanelistResult — only model + usage matter."""
+
+    def __init__(self, model: str | None, usage: TokenUsage):
+        self.model = model
+        self.usage = usage
+
+
+class TestAggregatePerModel:
+    """sp-atvc: verify multi-model panelist usage gets bucketed correctly."""
+
+    def test_single_model_single_bucket(self):
+        prs = [
+            _FakePanelist("haiku", TokenUsage(input_tokens=100, output_tokens=50)),
+            _FakePanelist("haiku", TokenUsage(input_tokens=200, output_tokens=80)),
+        ]
+        per_usage, per_cost = aggregate_per_model(prs, "haiku")
+        assert set(per_usage.keys()) == {"haiku"}
+        assert per_usage["haiku"].input_tokens == 300
+        assert per_usage["haiku"].output_tokens == 130
+        assert per_cost["haiku"].total_cost > 0
+
+    def test_multi_model_separate_buckets(self):
+        """Panelists routed to different providers populate one bucket each."""
+        prs = [
+            _FakePanelist("haiku", TokenUsage(input_tokens=100, output_tokens=50)),
+            _FakePanelist("gemini-2.5-flash", TokenUsage(input_tokens=100, output_tokens=50)),
+            _FakePanelist("gpt-4o-mini", TokenUsage(input_tokens=100, output_tokens=50)),
+        ]
+        per_usage, _per_cost = aggregate_per_model(prs, "haiku")
+        assert set(per_usage.keys()) == {"haiku", "gemini-2.5-flash", "gpt-4o-mini"}
+        # Each bucket carries only its own tokens — NOT the summed total.
+        for m in per_usage:
+            assert per_usage[m].input_tokens == 100
+            assert per_usage[m].output_tokens == 50
+
+    def test_unset_model_falls_back_to_default(self):
+        prs = [
+            _FakePanelist(None, TokenUsage(input_tokens=10, output_tokens=5)),
+            _FakePanelist("haiku", TokenUsage(input_tokens=10, output_tokens=5)),
+        ]
+        per_usage, _ = aggregate_per_model(prs, "haiku")
+        # Both collapse into the default model bucket.
+        assert set(per_usage.keys()) == {"haiku"}
+        assert per_usage["haiku"].input_tokens == 20
+
+    def test_per_model_cost_uses_each_providers_pricing(self):
+        """Bug repro: aggregated cost must price each bucket separately.
+
+        Before sp-atvc the caller summed all usage then priced at the default
+        model's rate, which under-reported total cost when cheap models
+        (gemini-flash, gpt-mini) carried traffic routed away from a pricier
+        default.
+        """
+        # All three get 1M input tokens. With correct per-model pricing the
+        # total cost equals the sum of each provider's input-per-million rate.
+        big = TokenUsage(input_tokens=1_000_000)
+        prs = [
+            _FakePanelist("haiku", big),
+            _FakePanelist("gemini-2.5-flash", big),
+            _FakePanelist("gpt-4o-mini", big),
+        ]
+        _usage, per_cost = aggregate_per_model(prs, "haiku")
+        total_per_model = sum(c.total_cost for c in per_cost.values())
+        # Reference: the wrong way — price 3M tokens at haiku rate only.
+        wrong_single_rate = estimate_cost(TokenUsage(input_tokens=3_000_000), HAIKU_PRICING).total_cost
+        # The correct sum must differ from the single-rate estimate (the bug).
+        assert total_per_model != pytest.approx(wrong_single_rate)
+        # And each bucket must be individually non-zero.
+        for m in per_cost:
+            assert per_cost[m].total_cost > 0
+
+    def test_empty_iterable(self):
+        per_usage, per_cost = aggregate_per_model([], "haiku")
+        assert per_usage == {}
+        assert per_cost == {}
 
 
 # --- format_summary -------------------------------------------------------

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -545,7 +545,7 @@ class TestBuildEnsembleOutput:
         from synth_panel.ensemble import build_ensemble_output
 
         out = build_ensemble_output(self._fixture())
-        assert set(out.keys()) == {"per_model_results", "cost_breakdown", "models", "total_usage"}
+        assert set(out.keys()) == {"per_model_results", "cost_breakdown", "models", "total_usage", "metadata"}
 
     def test_per_model_results_has_results_cost_usage(self):
         from synth_panel.ensemble import build_ensemble_output
@@ -597,6 +597,35 @@ class TestBuildEnsembleOutput:
         # haiku: 100+50, sonnet: 200+80
         assert out["total_usage"]["input_tokens"] == 300
         assert out["total_usage"]["output_tokens"] == 130
+
+    def test_metadata_per_model_covers_all_ensemble_models(self):
+        """sp-atvc: metadata.cost.per_model must list every ensemble model.
+
+        Regression guard for the mayor audit where a 3-model ensemble
+        reported only the first model in metadata.cost.per_model, hiding
+        ~6x of the real spend.
+        """
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        per_model = out["metadata"]["cost"]["per_model"]
+        # Both ensemble models must have their own bucket.
+        assert len(per_model) == 2
+        # Each entry carries tokens + cost_usd.
+        for entry in per_model.values():
+            assert "tokens" in entry
+            assert "cost_usd" in entry
+            assert entry["tokens"] > 0
+            assert entry["cost_usd"] > 0
+
+    def test_metadata_total_cost_matches_ensemble(self):
+        """metadata.cost.total_cost_usd must equal the summed per-model cost."""
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        meta_cost = out["metadata"]["cost"]
+        summed = sum(e["cost_usd"] for e in meta_cost["per_model"].values())
+        assert summed == pytest.approx(meta_cost["total_cost_usd"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import time
 
+import pytest
+
 from synth_panel.cost import CostEstimate, TokenUsage, estimate_cost, lookup_pricing
 from synth_panel.metadata import (
     PanelTimer,
@@ -364,3 +366,133 @@ class TestBuildMetadata:
         serialized = json.dumps(meta)
         parsed = json.loads(serialized)
         assert parsed["models"]["panelist"] == meta["models"]["panelist"]
+
+
+class TestBuildMetadataPerModelOverride:
+    """sp-atvc: multi-model ensemble runs must surface every model in
+    ``metadata.cost.per_model`` with its real tokens and cost — not collapse
+    into a single bucket for the default model.
+    """
+
+    def _usage(self, inp: int, out: int) -> TokenUsage:
+        return TokenUsage(input_tokens=inp, output_tokens=out)
+
+    def _cost(self, usage: TokenUsage, model: str) -> CostEstimate:
+        pricing, _ = lookup_pricing(model)
+        return estimate_cost(usage, pricing)
+
+    def test_three_model_ensemble_records_all_three(self):
+        """The bug repro: 3-model ensemble must produce 3 per_model entries."""
+        haiku_u = self._usage(10_000, 5_000)
+        gpt_u = self._usage(12_000, 4_000)
+        gem_u = self._usage(15_000, 6_000)
+        haiku_c = self._cost(haiku_u, "haiku")
+        gpt_c = self._cost(gpt_u, "gpt-4o-mini")
+        gem_c = self._cost(gem_u, "gemini-2.5-flash")
+        total_u = haiku_u + gpt_u + gem_u
+        total_c = haiku_c + gpt_c + gem_c
+
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=total_u,
+            panelist_cost=total_c,
+            total_usage=total_u,
+            total_cost=total_c,
+            persona_count=6,
+            question_count=4,
+            panelist_per_model={
+                "haiku": (haiku_u, haiku_c),
+                "gpt-4o-mini": (gpt_u, gpt_c),
+                "gemini-2.5-flash": (gem_u, gem_c),
+            },
+        )
+
+        per_model = meta["cost"]["per_model"]
+        # All three providers must appear — regression guard for the
+        # audited "only openrouter/anthropic/claude-haiku-4.5 present" bug.
+        assert len(per_model) == 3
+        # Every bucket carries its own tokens, not the total.
+        for entry in per_model.values():
+            assert entry["tokens"] < total_u.total_tokens
+            assert entry["cost_usd"] > 0
+        # Sum of per_model cost ≈ reported total cost.
+        summed = sum(e["cost_usd"] for e in per_model.values())
+        assert summed == pytest.approx(meta["cost"]["total_cost_usd"])
+
+    def test_override_plus_synthesis_different_model(self):
+        """Synthesis model gets its own bucket on top of ensemble panelists."""
+        haiku_u = self._usage(100, 50)
+        gpt_u = self._usage(100, 50)
+        haiku_c = self._cost(haiku_u, "haiku")
+        gpt_c = self._cost(gpt_u, "gpt-4o-mini")
+        synth_u = self._usage(200, 100)
+        synth_c = self._cost(synth_u, "sonnet")
+
+        meta = build_metadata(
+            panelist_model="haiku",
+            synthesis_model="sonnet",
+            panelist_usage=haiku_u + gpt_u,
+            panelist_cost=haiku_c + gpt_c,
+            synthesis_usage=synth_u,
+            synthesis_cost=synth_c,
+            total_usage=haiku_u + gpt_u + synth_u,
+            total_cost=haiku_c + gpt_c + synth_c,
+            persona_count=2,
+            question_count=1,
+            panelist_per_model={
+                "haiku": (haiku_u, haiku_c),
+                "gpt-4o-mini": (gpt_u, gpt_c),
+            },
+        )
+
+        per_model = meta["cost"]["per_model"]
+        # Three distinct buckets: haiku + gpt-mini + synthesis model.
+        assert len(per_model) == 3
+
+    def test_override_merges_when_synthesis_shares_model(self):
+        """Synthesis sharing a panelist model merges into that bucket."""
+        haiku_u = self._usage(100, 50)
+        gpt_u = self._usage(100, 50)
+        haiku_c = self._cost(haiku_u, "haiku")
+        gpt_c = self._cost(gpt_u, "gpt-4o-mini")
+        synth_u = self._usage(200, 100)
+        synth_c = self._cost(synth_u, "haiku")
+
+        meta = build_metadata(
+            panelist_model="haiku",
+            synthesis_model="haiku",
+            panelist_usage=haiku_u + gpt_u,
+            panelist_cost=haiku_c + gpt_c,
+            synthesis_usage=synth_u,
+            synthesis_cost=synth_c,
+            total_usage=haiku_u + gpt_u + synth_u,
+            total_cost=haiku_c + gpt_c + synth_c,
+            persona_count=2,
+            question_count=1,
+            panelist_per_model={
+                "haiku": (haiku_u, haiku_c),
+                "gpt-4o-mini": (gpt_u, gpt_c),
+            },
+        )
+
+        per_model = meta["cost"]["per_model"]
+        assert len(per_model) == 2
+        # haiku bucket should reflect panelist + synthesis tokens.
+        haiku_key = next(k for k in per_model if "haiku" in k)
+        assert per_model[haiku_key]["tokens"] == (haiku_u + synth_u).total_tokens
+
+    def test_legacy_single_model_path_unchanged(self):
+        """Omitting panelist_per_model preserves the original shape."""
+        u = self._usage(100, 50)
+        c = self._cost(u, "haiku")
+        meta = build_metadata(
+            panelist_model="haiku",
+            panelist_usage=u,
+            panelist_cost=c,
+            total_usage=u,
+            total_cost=c,
+            persona_count=1,
+            question_count=1,
+        )
+        per_model = meta["cost"]["per_model"]
+        assert len(per_model) == 1


### PR DESCRIPTION
## Summary
- Track cost per model (not summed into one bucket) during ensemble runs so the reported spend actually matches what each provider billed

## Source
- Polecat: furiosa
- Issue: sp-atvc
- MR: sp-wisp-488
- Branch: polecat/furiosa-mo8sjh0s

## Test plan
- [ ] CI passes (updated coverage in test_cost.py, test_ensemble.py, test_metadata.py)
- [ ] Ensemble JSON cost block matches sum of per-provider invoices in a live multi-model run

## Conflict note
Wide surface: cli/commands.py, ensemble.py, cost.py, mcp/server.py, metadata.py, sdk.py, tests. Heavy overlap with practically every open PR in the CLI/ensemble/cost stack (#190-#207). Rebase required after almost any merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)