### PR TITLE
fix(cost): correct SONNET_PRICING to Sonnet 4.5 rates, not Opus-3 (sp-cxyb)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -488,7 +488,7 @@ Operations:
 | Model Family | Input | Output | Cache Write | Cache Read |
 |-------------|-------|--------|-------------|------------|
 | Haiku tier | $1.00 | $5.00 | $1.25 | $0.10 |
-| Sonnet tier (default) | $15.00 | $75.00 | $18.75 | $1.50 |
+| Sonnet tier (default) | $3.00 | $15.00 | $3.75 | $0.30 |
 | Opus tier | $15.00 | $75.00 | $18.75 | $1.50 |
 
 When a model does not match any known tier, the default (Sonnet) pricing is used and the output is annotated with "pricing=estimated-default".

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -66,7 +66,7 @@ class ModelPricing:
 
 
 # Known pricing tiers from SPEC.md §7.
-# pricing snapshot_date: 2026-04-14
+# pricing snapshot_date: 2026-04-21
 HAIKU_PRICING = ModelPricing(
     input_cost_per_million=1.00,
     output_cost_per_million=5.00,
@@ -74,11 +74,15 @@ HAIKU_PRICING = ModelPricing(
     cache_read_cost_per_million=0.10,
 )
 
+# Sonnet 4.5 published rates (per Anthropic price list): $3/M in, $15/M out,
+# $3.75/M 5-min cache write, $0.30/M cache read. Prior to sp-cxyb this table
+# carried legacy Opus-3 rates ($15/$75/$18.75/$1.50), which also leaked into
+# DEFAULT_PRICING and over-billed every unknown model by ~5x.
 SONNET_PRICING = ModelPricing(
-    input_cost_per_million=15.00,
-    output_cost_per_million=75.00,
-    cache_creation_cost_per_million=18.75,
-    cache_read_cost_per_million=1.50,
+    input_cost_per_million=3.00,
+    output_cost_per_million=15.00,
+    cache_creation_cost_per_million=3.75,
+    cache_read_cost_per_million=0.30,
 )
 
 OPUS_PRICING = ModelPricing(

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -187,10 +187,11 @@ class TestCostEstimate:
 
 class TestEstimateCost:
     def test_sonnet_pricing(self):
+        # sp-cxyb: Sonnet 4.5 rates are $3/M input, $15/M output.
         usage = TokenUsage(input_tokens=1_000_000, output_tokens=1_000_000)
         cost = estimate_cost(usage, SONNET_PRICING)
-        assert cost.input_cost == pytest.approx(15.0)
-        assert cost.output_cost == pytest.approx(75.0)
+        assert cost.input_cost == pytest.approx(3.0)
+        assert cost.output_cost == pytest.approx(15.0)
 
     def test_zero_usage(self):
         cost = estimate_cost(ZERO_USAGE)


### PR DESCRIPTION
## Summary
- Correct `SONNET_PRICING` constants — they were carrying Opus-3 rates, materially inflating every Sonnet cost estimate
- SPEC updated to reflect the canonical Sonnet 4.5 pricing

## Source
- Polecat: furiosa
- Issue: sp-cxyb
- MR: sp-wisp-1su
- Branch: polecat/furiosa-mo8x0mxv

## Test plan
- [ ] CI passes (updated coverage in test_cost.py)
- [ ] Sonnet cost estimate matches Anthropic's published pricing for a known run

🤖 Generated with [Claude Code](https://claude.com/claude-code)