### PR TITLE
fix(cost): add pricing for common OpenRouter models (sp-5ggf)

### DIFF
--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -113,10 +113,76 @@ GPT_5_MINI_PRICING = ModelPricing(
     cache_read_cost_per_million=0.025,
 )
 
+# OpenAI gpt-4o-mini (OpenRouter: ``openai/gpt-4o-mini``).
+# Published rates: $0.15/M input, $0.60/M output, $0.075/M cached input.
+GPT_4O_MINI_PRICING = ModelPricing(
+    input_cost_per_million=0.15,
+    output_cost_per_million=0.60,
+    cache_creation_cost_per_million=0.15,
+    cache_read_cost_per_million=0.075,
+)
+
+# OpenAI gpt-4o (OpenRouter: ``openai/gpt-4o``).
+# Published rates: $2.50/M input, $10.00/M output, $1.25/M cached input.
+GPT_4O_PRICING = ModelPricing(
+    input_cost_per_million=2.50,
+    output_cost_per_million=10.00,
+    cache_creation_cost_per_million=2.50,
+    cache_read_cost_per_million=1.25,
+)
+
+# OpenAI gpt-4.1-mini (OpenRouter: ``openai/gpt-4.1-mini``).
+# Published rates: $0.40/M input, $1.60/M output, $0.10/M cached input.
+GPT_4_1_MINI_PRICING = ModelPricing(
+    input_cost_per_million=0.40,
+    output_cost_per_million=1.60,
+    cache_creation_cost_per_million=0.40,
+    cache_read_cost_per_million=0.10,
+)
+
+# DeepSeek Chat V3 (OpenRouter: ``deepseek/deepseek-chat-v3``, ``deepseek-chat-v3.1``).
+# OpenRouter rates: $0.27/M input, $1.10/M output, $0.07/M cache read.
+# Covers the v3 family via the ``deepseek-chat`` substring; R1 is priced separately
+# (not included here — different product tier).
+DEEPSEEK_CHAT_PRICING = ModelPricing(
+    input_cost_per_million=0.27,
+    output_cost_per_million=1.10,
+    cache_creation_cost_per_million=0.27,
+    cache_read_cost_per_million=0.07,
+)
+
+# Qwen3 Plus (OpenRouter: ``qwen/qwen3-plus``, Alibaba DashScope rate).
+# Published rates: $0.33/M input, $1.95/M output. Cache rates not published —
+# defaulted to input rate (no-savings baseline).
+QWEN3_PLUS_PRICING = ModelPricing(
+    input_cost_per_million=0.33,
+    output_cost_per_million=1.95,
+    cache_creation_cost_per_million=0.33,
+    cache_read_cost_per_million=0.33,
+)
+
+# Mistral Medium 3 (OpenRouter: ``mistralai/mistral-medium-3``).
+# Published rates: $0.40/M input, $2.00/M output. Cache rates not published.
+MISTRAL_MEDIUM_PRICING = ModelPricing(
+    input_cost_per_million=0.40,
+    output_cost_per_million=2.00,
+    cache_creation_cost_per_million=0.40,
+    cache_read_cost_per_million=0.40,
+)
+
+# Meta Llama 3.3 70B Instruct (OpenRouter: ``meta-llama/llama-3.3-70b-instruct``).
+# Typical OpenRouter rate: $0.23/M input, $0.40/M output. Cache rates not published.
+LLAMA_3_3_70B_PRICING = ModelPricing(
+    input_cost_per_million=0.23,
+    output_cost_per_million=0.40,
+    cache_creation_cost_per_million=0.23,
+    cache_read_cost_per_million=0.23,
+)
+
 DEFAULT_PRICING = SONNET_PRICING
 
 # NOTE: substring match order matters. Put the most specific keys first so
-# e.g. ``gpt-5-mini`` wins over any future shorter ``gpt-5`` key.
+# e.g. ``gpt-4o-mini`` wins over the shorter ``gpt-4o`` key.
 _PRICING_TABLE: dict[str, ModelPricing] = {
     "haiku": HAIKU_PRICING,
     "sonnet": SONNET_PRICING,
@@ -124,6 +190,13 @@ _PRICING_TABLE: dict[str, ModelPricing] = {
     "gemini-2.5-pro": GEMINI_PRO_PRICING,
     "gemini": GEMINI_FLASH_PRICING,
     "gpt-5-mini": GPT_5_MINI_PRICING,
+    "gpt-4.1-mini": GPT_4_1_MINI_PRICING,
+    "gpt-4o-mini": GPT_4O_MINI_PRICING,
+    "gpt-4o": GPT_4O_PRICING,
+    "deepseek-chat": DEEPSEEK_CHAT_PRICING,
+    "qwen3-plus": QWEN3_PLUS_PRICING,
+    "mistral-medium": MISTRAL_MEDIUM_PRICING,
+    "llama-3.3-70b": LLAMA_3_3_70B_PRICING,
 }
 
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -5,11 +5,18 @@ from __future__ import annotations
 import pytest
 
 from synth_panel.cost import (
+    DEEPSEEK_CHAT_PRICING,
     GEMINI_FLASH_PRICING,
     GEMINI_PRO_PRICING,
+    GPT_4_1_MINI_PRICING,
+    GPT_4O_MINI_PRICING,
+    GPT_4O_PRICING,
     GPT_5_MINI_PRICING,
     HAIKU_PRICING,
+    LLAMA_3_3_70B_PRICING,
+    MISTRAL_MEDIUM_PRICING,
     OPUS_PRICING,
+    QWEN3_PLUS_PRICING,
     SONNET_PRICING,
     ZERO_USAGE,
     BudgetError,
@@ -107,6 +114,42 @@ class TestPricingLookup:
         cost = estimate_cost(usage, pricing)
         assert cost.total_cost == pytest.approx(0.01296, abs=1e-4)
 
+    @pytest.mark.parametrize(
+        "model, expected",
+        [
+            # sp-5ggf: common OpenRouter models must resolve to their own
+            # rates, not fall through to DEFAULT ($15/$75 Opus-era rate).
+            ("gpt-4o-mini", GPT_4O_MINI_PRICING),
+            ("openrouter/openai/gpt-4o-mini", GPT_4O_MINI_PRICING),
+            ("openai/gpt-4o", GPT_4O_PRICING),
+            ("openrouter/openai/gpt-4.1-mini", GPT_4_1_MINI_PRICING),
+            ("openrouter/deepseek/deepseek-chat-v3", DEEPSEEK_CHAT_PRICING),
+            ("openrouter/deepseek/deepseek-chat-v3.1", DEEPSEEK_CHAT_PRICING),
+            ("openrouter/qwen/qwen3-plus", QWEN3_PLUS_PRICING),
+            ("openrouter/mistralai/mistral-medium-3", MISTRAL_MEDIUM_PRICING),
+            ("openrouter/meta-llama/llama-3.3-70b-instruct", LLAMA_3_3_70B_PRICING),
+        ],
+    )
+    def test_openrouter_common_models(self, model, expected):
+        p, est = lookup_pricing(model)
+        assert p is expected
+        assert est is False
+
+    def test_gpt_4o_mini_substring_precedence_over_gpt_4o(self):
+        """``gpt-4o-mini`` must win over ``gpt-4o`` — order in _PRICING_TABLE matters."""
+        p, _ = lookup_pricing("openai/gpt-4o-mini")
+        assert p is GPT_4O_MINI_PRICING
+        assert p is not GPT_4O_PRICING
+
+    def test_gpt_4o_mini_realistic_cost_not_sonnet(self):
+        """Regression for sp-5ggf: 11144in/1655out for gpt-4o-mini must cost
+        ~$0.0027, not ~$0.2913 (the Opus-rate fallthrough observed in the wild)."""
+        usage = TokenUsage(input_tokens=11144, output_tokens=1655)
+        pricing, _ = lookup_pricing("openrouter/openai/gpt-4o-mini")
+        cost = estimate_cost(usage, pricing)
+        # 11144 * 0.15/M + 1655 * 0.60/M = 0.001672 + 0.000993 = 0.002665
+        assert cost.total_cost == pytest.approx(0.002665, abs=1e-5)
+
 
 # --- Provider-string pricing lookup --------------------------------------
 
@@ -135,6 +178,14 @@ class TestProviderLookup:
             # sp-loil: gpt-5-mini via OpenRouter must price at its own rate.
             ("openrouter/openai/gpt-5-mini", GPT_5_MINI_PRICING),
             ("raw-openai/gpt-5-mini", GPT_5_MINI_PRICING),
+            # sp-5ggf: common OpenRouter models must resolve via provider lookup.
+            ("openrouter/openai/gpt-4o-mini", GPT_4O_MINI_PRICING),
+            ("raw-openai/gpt-4o", GPT_4O_PRICING),
+            ("openrouter/openai/gpt-4.1-mini", GPT_4_1_MINI_PRICING),
+            ("openrouter/deepseek/deepseek-chat-v3", DEEPSEEK_CHAT_PRICING),
+            ("openrouter/qwen/qwen3-plus", QWEN3_PLUS_PRICING),
+            ("openrouter/mistralai/mistral-medium-3", MISTRAL_MEDIUM_PRICING),
+            ("openrouter/meta-llama/llama-3.3-70b-instruct", LLAMA_3_3_70B_PRICING),
         ],
     )
     def test_positive_lookup(self, provider: str, expected: object) -> None:


### PR DESCRIPTION
## Summary
- Add explicit pricing entries for common OpenRouter-routed models so cost estimates stop silently falling back to Sonnet rates

## Source
- Polecat: nux
- Issue: sp-5ggf
- MR: sp-wisp-288
- Branch: polecat/nux-mo8x17fo

## Test plan
- [ ] CI passes (updated coverage in test_cost.py)
- [ ] Cost estimate for each listed OpenRouter model matches upstream published rate

## Conflict note
Touches src/synth_panel/cost.py and tests/test_cost.py — overlaps with PR #210 (sp-cxyb SONNET_PRICING fix). Rebase required after #210 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)