### PR TITLE
fix(ensemble): guarantee every weighted model gets >=1 persona (sp-27rz)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -140,13 +140,22 @@ def assign_models_to_personas(
     personas: list[dict[str, Any]],
     model_spec: list[tuple[str, float]],
     default_model: str,
-) -> dict[str, str]:
-    """Assign models to personas based on weighted spec and YAML overrides.
+) -> tuple[dict[str, str], list[str]]:
+    """Assign models to personas using Hamilton's largest-remainder method.
 
     Resolution order: persona YAML 'model' field > weighted assignment > default.
-    Returns a dict mapping persona name → resolved model.
+
+    Guarantees every model in ``model_spec`` receives at least one persona
+    when ``len(needs_assignment) >= len(model_spec)`` (sp-27rz: the prior
+    round-based allocation could silently hand the last model 0 personas,
+    dropping it from per_model_results without any warning). When there
+    are fewer personas than models, affected models still end up at zero,
+    but a warning describing the miss is appended to the returned list so
+    callers can surface it to the user.
+
+    Returns a ``(assignments, warnings)`` tuple.
     """
-    # Personas with YAML model overrides are pre-assigned
+    warnings: list[str] = []
     needs_assignment: list[str] = []
     result: dict[str, str] = {}
     for p in personas:
@@ -157,28 +166,56 @@ def assign_models_to_personas(
             needs_assignment.append(name)
 
     if not needs_assignment:
-        return result
+        return result, warnings
 
-    # Normalize weights
+    n = len(needs_assignment)
     total_weight = sum(w for _, w in model_spec)
     normalized = [(m, w / total_weight) for m, w in model_spec]
 
-    # Assign proportionally: distribute personas across models by weight
-    remaining = len(needs_assignment)
-    assigned_idx = 0
-    for i, (model, weight) in enumerate(normalized):
-        if i == len(normalized) - 1:
-            # Last model gets all remaining to avoid rounding gaps
-            count = remaining
-        else:
-            count = max(0, round(weight * len(needs_assignment)))
-            remaining -= count
-        for _ in range(count):
-            if assigned_idx < len(needs_assignment):
-                result[needs_assignment[assigned_idx]] = model
-                assigned_idx += 1
+    # Hamilton's method (largest-remainder): floor each quota, then hand out
+    # leftover seats in descending order of fractional remainder. Deterministic
+    # ties broken by position in the spec.
+    quotas = [w * n for _, w in normalized]
+    counts = [int(q) for q in quotas]
+    remainders = [q - int(q) for q in quotas]
+    seats_left = n - sum(counts)
+    order = sorted(range(len(counts)), key=lambda i: (-remainders[i], i))
+    for i in order[:seats_left]:
+        counts[i] += 1
 
-    return result
+    # Min-1 guarantee: when there are enough personas to cover every model,
+    # ensure no model is left at zero by taking one seat from the currently
+    # largest bucket. Preserves proportions as closely as possible while
+    # eliminating the silent-drop bug.
+    if n >= len(model_spec):
+        for zi, c in enumerate(counts):
+            if c != 0:
+                continue
+            donor = max(
+                range(len(counts)),
+                key=lambda i: (counts[i], -i),
+            )
+            if counts[donor] <= 1:
+                break
+            counts[donor] -= 1
+            counts[zi] += 1
+
+    # Any remaining zeros mean personas < models — surface loudly.
+    for (model, _), c in zip(normalized, counts):
+        if c == 0:
+            warnings.append(
+                f"model_allocation: '{model}' received 0 of {n} personas "
+                f"(fewer personas than weighted models); it will be absent "
+                f"from per_model_results"
+            )
+
+    idx = 0
+    for (model, _), c in zip(normalized, counts):
+        for _ in range(c):
+            result[needs_assignment[idx]] = model
+            idx += 1
+
+    return result, warnings
 
 
 def _load_profile(args: argparse.Namespace) -> tuple[Any, int | None]:
@@ -708,6 +745,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     persona_models: dict[str, str] | None = None
     model_spec: list[tuple[str, float]] | None = None
     ensemble_mode = has_models and is_ensemble_spec(has_models)
+    assignment_warnings: list[str] = []
 
     if has_models:
         try:
@@ -716,7 +754,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             print(f"Error parsing --models: {exc}", file=sys.stderr)
             return 1
         if not ensemble_mode and not blend_mode:
-            persona_models = assign_models_to_personas(personas, model_spec, model)
+            persona_models, assignment_warnings = assign_models_to_personas(personas, model_spec, model)
+            for w in assignment_warnings:
+                logger.warning("model allocation: %s", w)
+                print(f"Warning: {w}", file=sys.stderr)
         # Use the first model in the spec as the "primary" for cost fallback
         if not has_model:
             model = model_spec[0][0]
@@ -1128,6 +1169,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                     f" panelists reported missing or unavailable input"
                     f" ({missing_input_stats['refusal_rate']:.0%})"
                 )
+        if assignment_warnings:
+            warnings_list = extra.setdefault("warnings", [])
+            if isinstance(warnings_list, list):
+                warnings_list.extend(assignment_warnings)
         # Include blend distributions when --blend is active
         if blend_result:
             extra["blend"] = {

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -146,6 +146,19 @@ def ensemble_run(
         per_model_cost[model] = model_cost.format_usd()
         per_model_usage[model] = model_usage.to_dict()
 
+    # sp-27rz: defensive sanity check — every input model must have produced
+    # a bucket. Silent drops at this layer (mis-iteration, stray early return)
+    # would reintroduce the "absent model" bug the weighted-assign fix closes,
+    # so assert the invariant explicitly rather than trusting the loop.
+    produced = {mr.model for mr in model_results}
+    expected = set(models)
+    if produced != expected:
+        missing = expected - produced
+        raise RuntimeError(
+            f"ensemble_run: per_model_results is missing {sorted(missing)} "
+            f"(expected {sorted(expected)}, produced {sorted(produced)})"
+        )
+
     return EnsembleResult(
         model_results=model_results,
         models=models,

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -137,20 +137,22 @@ class TestAssignModelsToPersonas:
     def test_even_split_two_models(self):
         personas = [{"name": f"P{i}"} for i in range(10)]
         spec = [("haiku", 0.5), ("gemini", 0.5)]
-        result = assign_models_to_personas(personas, spec, "sonnet")
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
         haiku_count = sum(1 for v in result.values() if v == "haiku")
         gemini_count = sum(1 for v in result.values() if v == "gemini")
         assert haiku_count == 5
         assert gemini_count == 5
+        assert warnings == []
 
     def test_uneven_split(self):
         personas = [{"name": f"P{i}"} for i in range(10)]
         spec = [("haiku", 0.7), ("gemini", 0.3)]
-        result = assign_models_to_personas(personas, spec, "sonnet")
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
         haiku_count = sum(1 for v in result.values() if v == "haiku")
         gemini_count = sum(1 for v in result.values() if v == "gemini")
         assert haiku_count == 7
         assert gemini_count == 3
+        assert warnings == []
 
     def test_yaml_override_takes_precedence(self):
         personas = [
@@ -159,7 +161,7 @@ class TestAssignModelsToPersonas:
             {"name": "Charlie"},
         ]
         spec = [("haiku", 0.5), ("gemini", 0.5)]
-        result = assign_models_to_personas(personas, spec, "sonnet")
+        result, _ = assign_models_to_personas(personas, spec, "sonnet")
         assert result["Alice"] == "opus"
         # Bob and Charlie get weighted assignment
         assert result["Bob"] in ("haiku", "gemini")
@@ -171,22 +173,77 @@ class TestAssignModelsToPersonas:
             {"name": "Bob", "model": "haiku"},
         ]
         spec = [("gemini", 1.0)]
-        result = assign_models_to_personas(personas, spec, "sonnet")
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
         assert result["Alice"] == "opus"
         assert result["Bob"] == "haiku"
+        # No weighted assignment occurred, so no warning for gemini.
+        assert warnings == []
 
     def test_single_persona(self):
         personas = [{"name": "Solo"}]
         spec = [("haiku", 0.5), ("gemini", 0.5)]
-        result = assign_models_to_personas(personas, spec, "sonnet")
+        result, _ = assign_models_to_personas(personas, spec, "sonnet")
         assert len(result) == 1
         assert result["Solo"] in ("haiku", "gemini")
 
     def test_all_assigned_to_single_model(self):
         personas = [{"name": f"P{i}"} for i in range(5)]
         spec = [("haiku", 1.0)]
-        result = assign_models_to_personas(personas, spec, "sonnet")
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
         assert all(v == "haiku" for v in result.values())
+        assert warnings == []
+
+    def test_equal_weights_four_models_six_personas(self):
+        """sp-27rz regression: every model must receive >= 1 persona.
+
+        Pre-fix, round() banker's-rounding made the last model silently
+        collect 0 personas (2+2+2+0) and disappear from per_model_results.
+        Hamilton's method now guarantees each model gets at least one.
+        """
+        personas = [{"name": f"P{i}"} for i in range(6)]
+        spec = [("haiku", 0.25), ("gpt-4o-mini", 0.25), ("gemini-flash", 0.25), ("qwen3-plus", 0.25)]
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
+        counts = {m: sum(1 for v in result.values() if v == m) for m, _ in spec}
+        assert sum(counts.values()) == 6
+        # Every weighted model is represented.
+        for m, _ in spec:
+            assert counts[m] >= 1, f"{m} received 0 personas (regression of sp-27rz)"
+        # And a fair allocation: 2+2+1+1 = 6.
+        assert sorted(counts.values(), reverse=True) == [2, 2, 1, 1]
+        assert warnings == []
+
+    def test_min_one_guarantee_with_skewed_weights(self):
+        """Even near-zero weights get one persona when personas suffice."""
+        personas = [{"name": f"P{i}"} for i in range(4)]
+        spec = [("heavy", 0.9), ("light", 0.1)]
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
+        counts = {m: sum(1 for v in result.values() if v == m) for m, _ in spec}
+        assert counts["heavy"] >= 1
+        assert counts["light"] >= 1
+        assert sum(counts.values()) == 4
+        assert warnings == []
+
+    def test_warning_when_personas_fewer_than_models(self):
+        """Personas < models: cannot give every model >=1, warn loudly."""
+        personas = [{"name": "Solo"}]
+        spec = [("haiku", 0.5), ("gemini", 0.5)]
+        result, warnings = assign_models_to_personas(personas, spec, "sonnet")
+        # One model gets the persona, one is absent.
+        assigned_models = set(result.values())
+        assert len(assigned_models) == 1
+        # The absent model's name appears in the warning.
+        assert len(warnings) == 1
+        missing_model = ({"haiku", "gemini"} - assigned_models).pop()
+        assert missing_model in warnings[0]
+        assert "0 of 1" in warnings[0]
+
+    def test_total_assignment_count_preserved(self):
+        """Allocation must distribute exactly ``len(personas)`` assignments."""
+        personas = [{"name": f"P{i}"} for i in range(11)]
+        spec = [("a", 0.33), ("b", 0.33), ("c", 0.34)]
+        result, _ = assign_models_to_personas(personas, spec, "sonnet")
+        assert len(result) == 11
+        assert sum(1 for v in result.values() if v in {"a", "b", "c"}) == 11
 
 
 # ---------------------------------------------------------------------------
@@ -441,6 +498,30 @@ class TestEnsembleRun:
 
         with pytest.raises(ValueError, match="models list must not be empty"):
             _ensemble_run([], [], [], MagicMock())
+
+    def test_all_input_models_produce_buckets(self):
+        """sp-27rz: every input model must appear as a ModelRunResult bucket.
+
+        Regression guard for the invariant that motivated the defensive
+        check at the end of ensemble_run — a silent drop here is exactly
+        the bug weighted-assign already closed, and the ensemble path
+        must stay covered too.
+        """
+        from unittest.mock import patch as _patch
+
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        questions = [{"text": "Q1"}]
+        models = ["haiku", "sonnet", "gemini"]
+        client = MagicMock()
+
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = lambda **kw: self._mock_run_parallel(**kw)
+            result = _ensemble_run(personas, questions, models, client)
+
+        produced = {mr.model for mr in result.model_results}
+        assert produced == set(models)
 
     def test_panelist_results_tagged_with_model(self):
         from unittest.mock import patch as _patch


### PR DESCRIPTION
## Summary
- Guarantee that every model in a weighted ensemble gets at least one persona assigned, instead of rounding low-weight models to zero panelists silently

## Source
- Polecat: rictus
- Issue: sp-27rz
- MR: sp-wisp-9ab
- Branch: polecat/rictus-mo8x1sf4

## Test plan
- [ ] CI passes (updated coverage in test_ensemble.py)
- [ ] Edge-case weighted runs (e.g., 10:1:1 over 5 panelists) still allocate ≥1 panelist per listed model

## Conflict note
Touches src/synth_panel/cli/commands.py, src/synth_panel/ensemble.py, tests/test_ensemble.py — overlaps with the residual CLI/ensemble stack (#196, #197, #198). Rebase likely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)