### PR TITLE
fix(cost): surface DEFAULT_PRICING fallback loudly in panel output (sp-nn8k)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -21,6 +21,7 @@ from synth_panel.cost import (
     CostEstimate,
     TokenUsage,
     aggregate_per_model,
+    build_cost_fallback_warnings,
     estimate_cost,
     format_summary,
     lookup_pricing,
@@ -1095,6 +1096,14 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             panelist_formatter=_cli_panelist_formatter,
         )
 
+        # sp-nn8k: surface DEFAULT_PRICING fallbacks loudly. Contributing
+        # models are the per-panelist buckets we priced above plus the
+        # synthesis model when present.
+        synth_model_for_warning = synthesis_result.model if synthesis_result else None
+        cost_fallback_warnings = build_cost_fallback_warnings(
+            [*panelist_per_model_usage.keys(), synth_model_for_warning]
+        )
+
         extra: dict[str, Any] = _build_rounds_shape(
             instrument=instrument,
             results=results,
@@ -1109,6 +1118,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             metadata=metadata,
             per_model_results=per_model_results,
             cost_breakdown=cost_breakdown,
+            cost_fallback_warnings=cost_fallback_warnings,
         )
         extra["parameters"] = _build_params_metadata(args, temperature, top_p)
         # Surface failure stats + run validity in structured output so
@@ -1440,6 +1450,7 @@ def _build_rounds_shape(
     metadata: dict[str, Any] | None = None,
     per_model_results: dict[str, Any] | None = None,
     cost_breakdown: dict[str, Any] | None = None,
+    cost_fallback_warnings: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build the rounds-shaped panel output payload.
 
@@ -1453,8 +1464,17 @@ def _build_rounds_shape(
     the sp-0h9x rollup shape alongside the primary ``model`` field — a
     superset of the mixed-model artifact that mayor's ensemble audits
     previously had to reconstruct by iterating ``rounds[].results[]``.
+
+    ``cost_fallback_warnings`` (sp-nn8k) is appended to ``warnings`` for
+    every model that was priced via ``DEFAULT_PRICING`` fallback; the
+    top-level ``cost_is_estimated`` boolean mirrors ``bool(...)`` of that
+    list so programmatic consumers can gate on it without string-matching
+    the warning text.
     """
     round_name = instrument.rounds[0].name if instrument.rounds else "default"
+    warnings = list(getattr(instrument, "warnings", []) or [])
+    fallback_warnings = list(cost_fallback_warnings or [])
+    warnings.extend(fallback_warnings)
     result: dict[str, Any] = {
         "rounds": [
             {
@@ -1464,7 +1484,8 @@ def _build_rounds_shape(
             }
         ],
         "path": [],
-        "warnings": list(getattr(instrument, "warnings", []) or []),
+        "warnings": warnings,
+        "cost_is_estimated": bool(fallback_warnings),
         "synthesis": synthesis_dict,
         "panelist_cost": panelist_cost.format_usd(),
         "panelist_usage": (panelist_usage.to_dict() if panelist_usage is not None else None),

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 logger = logging.getLogger(__name__)
@@ -140,6 +141,46 @@ def lookup_pricing(model: str | None = None) -> tuple[ModelPricing, bool]:
             if key in lower:
                 return pricing, False
     return DEFAULT_PRICING, True
+
+
+# sp-nn8k: template used when a model's cost was priced via ``DEFAULT_PRICING``
+# fallback. Surfaced into panel output ``warnings[]`` so downstream consumers
+# can tell an estimated $X.XX apart from a billed rate, and we also set a
+# top-level ``cost_is_estimated: True`` boolean for programmatic gating.
+_COST_FALLBACK_WARNING_TEMPLATE = (
+    "Cost for model {model!r} computed using DEFAULT_PRICING fallback — real "
+    "charges may differ. Consider adding an explicit pricing entry."
+)
+
+
+def collect_estimated_models(models: Iterable[str | None]) -> list[str]:
+    """Return the subset of *models* whose pricing falls back to DEFAULT_PRICING.
+
+    Preserves first-seen order and deduplicates. ``None``/empty entries are
+    skipped so callers can splat together ``panelist_model``,
+    ``synthesis_model``, and per-panelist model keys without pre-filtering.
+    """
+    seen: set[str] = set()
+    estimated: list[str] = []
+    for m in models:
+        if not m or m in seen:
+            continue
+        seen.add(m)
+        _, is_estimated = lookup_pricing(m)
+        if is_estimated:
+            estimated.append(m)
+    return estimated
+
+
+def build_cost_fallback_warnings(models: Iterable[str | None]) -> list[str]:
+    """Return one warning string per model that was priced via DEFAULT_PRICING.
+
+    Thin wrapper over :func:`collect_estimated_models` that formats each
+    offender into the canonical ``"Cost for model 'X' computed using
+    DEFAULT_PRICING fallback ..."`` sentence. Empty when every contributing
+    model has an explicit pricing tier.
+    """
+    return [_COST_FALLBACK_WARNING_TEMPLATE.format(model=m) for m in collect_estimated_models(models)]
 
 
 # Bucket prefixes observed in synthbench `config.provider` strings

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -18,6 +18,7 @@ from synth_panel.cost import (
     ZERO_USAGE,
     CostEstimate,
     TokenUsage,
+    build_cost_fallback_warnings,
     estimate_cost,
     lookup_pricing,
 )
@@ -224,6 +225,11 @@ def build_ensemble_output(
         panelist_per_model=panelist_per_model,
     )
 
+    # sp-nn8k: flag models priced via DEFAULT_PRICING fallback so the
+    # ensemble payload exposes estimated spend the same way the
+    # single-model + mixed-model rollups do.
+    cost_warnings = build_cost_fallback_warnings(ens.models)
+
     return {
         "per_model_results": per_model_results,
         "cost_breakdown": {
@@ -232,6 +238,8 @@ def build_ensemble_output(
         },
         "models": list(ens.models),
         "total_usage": ens.total_usage.to_dict(),
+        "warnings": list(cost_warnings),
+        "cost_is_estimated": bool(cost_warnings),
         "metadata": ens_metadata,
     }
 

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -64,6 +64,7 @@ from synth_panel.cost import (
     ZERO_USAGE,
     CostEstimate,
     aggregate_per_model,
+    build_cost_fallback_warnings,
     estimate_cost,
     lookup_pricing,
 )
@@ -476,6 +477,13 @@ async def _run_panel_async_instrument(
         panelist_formatter=lambda pr, m: _format_panelist_result(pr, m),
     )
 
+    # sp-nn8k: warn loudly when any contributing model was priced via
+    # DEFAULT_PRICING fallback instead of an explicit tier. Candidates are
+    # every model we actually priced above plus the synthesis model.
+    synth_model_name = getattr(mr.final_synthesis, "model", None) if mr.final_synthesis else None
+    cost_warnings = build_cost_fallback_warnings([*per_model_usage.keys(), synth_model_name])
+    merged_warnings = list(mr.warnings) + cost_warnings
+
     return {
         "result_id": result_id,
         "model": model,
@@ -484,7 +492,8 @@ async def _run_panel_async_instrument(
         "rounds": rounds_payload,
         "path": mr.path,
         "terminal_round": mr.terminal_round,
-        "warnings": mr.warnings,
+        "warnings": merged_warnings,
+        "cost_is_estimated": bool(cost_warnings),
         "synthesis": final_synth_dict,
         "total_cost": total_cost.format_usd(),
         "total_usage": mr.usage.to_dict(),
@@ -615,6 +624,11 @@ async def _run_panel_async(
         panelist_formatter=lambda pr, m: _format_panelist_result(pr, m),
     )
 
+    # sp-nn8k: surface DEFAULT_PRICING fallback loudly so estimated totals
+    # don't blend into billed ones silently.
+    synth_model_name = synthesis_dict.get("model") if synthesis_dict else None
+    cost_warnings = build_cost_fallback_warnings([*per_model_usage.keys(), synth_model_name])
+
     result: dict[str, Any] = {
         "result_id": result_id,
         "model": model,
@@ -632,7 +646,8 @@ async def _run_panel_async(
             }
         ],
         "path": [],
-        "warnings": [],
+        "warnings": list(cost_warnings),
+        "cost_is_estimated": bool(cost_warnings),
         "per_model_results": per_model_results,
         "cost_breakdown": cost_breakdown,
         "metadata": metadata,

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -43,6 +43,7 @@ from synth_panel.cost import (
     ZERO_USAGE,
     CostEstimate,
     aggregate_per_model,
+    build_cost_fallback_warnings,
     estimate_cost,
     lookup_pricing,
 )
@@ -239,7 +240,16 @@ class PanelResult(_DictLikeMixin):
             synthesis for v1/v2 and ``questions`` input).
         total_cost: Formatted USD total across panel + synthesis.
         total_usage: Aggregate token usage.
-        warnings: Parser + runtime warnings (empty in the happy path).
+        warnings: Parser + runtime warnings. Includes one
+            ``"Cost for model '<X>' computed using DEFAULT_PRICING
+            fallback..."`` entry per contributing model that had no
+            explicit pricing tier, so callers can spot estimated spend
+            without inspecting ``cost_is_estimated``.
+        cost_is_estimated: ``True`` when any contributing model (panelist
+            or synthesis) was priced via ``DEFAULT_PRICING`` fallback —
+            ``total_cost`` should be treated as an estimate, not a
+            billed amount. ``False`` when every model has an explicit
+            pricing entry.
         terminal_round: The last round whose synthesis fed final
             synthesis. ``None`` for v1 runs and when synthesis is off.
         results: Flat panelist results for the terminal round
@@ -259,6 +269,7 @@ class PanelResult(_DictLikeMixin):
     total_cost: str
     total_usage: dict[str, Any]
     warnings: list[str] = field(default_factory=list)
+    cost_is_estimated: bool = False
     terminal_round: str | None = None
     results: list[dict[str, Any]] = field(default_factory=list)
     metadata: dict[str, Any] | None = None
@@ -328,7 +339,13 @@ def _build_panel_result_from_single_round(
     metadata: dict[str, Any] | None,
     total_usage: CostTokenUsage,
     total_cost: Any,
+    contributing_models: list[str | None] | None = None,
 ) -> PanelResult:
+    # sp-nn8k: when any contributing model hits DEFAULT_PRICING fallback,
+    # emit a warning per offender and flip the top-level estimated flag.
+    # Callers can pass ``contributing_models`` to cover mixed-model runs;
+    # otherwise the single ``model`` is the only candidate.
+    cost_warnings = build_cost_fallback_warnings(contributing_models if contributing_models is not None else [model])
     return PanelResult(
         result_id=result_id,
         model=model,
@@ -345,7 +362,8 @@ def _build_panel_result_from_single_round(
         synthesis=synthesis_dict,
         total_cost=total_cost.format_usd(),
         total_usage=total_usage.to_dict(),
-        warnings=[],
+        warnings=list(cost_warnings),
+        cost_is_estimated=bool(cost_warnings),
         terminal_round=None,
         results=result_dicts,
         metadata=metadata,
@@ -386,6 +404,14 @@ def _build_panel_result_from_multi_round(
         if mr.final_synthesis is not None and hasattr(mr.final_synthesis, "to_dict")
         else None
     )
+
+    # sp-nn8k: append per-model cost-fallback warnings alongside the
+    # parser/runtime warnings carried on ``mr.warnings``. Every panelist
+    # model and the synthesis model (when present) is checked.
+    contributing = {getattr(pr, "model", None) or model for rr in mr.rounds for pr in rr.panelist_results}
+    synth_model = getattr(mr.final_synthesis, "model", None) if mr.final_synthesis else None
+    cost_warnings = build_cost_fallback_warnings([*sorted(contributing), synth_model])
+
     return PanelResult(
         result_id=result_id,
         model=model,
@@ -396,7 +422,8 @@ def _build_panel_result_from_multi_round(
         synthesis=final_synth_dict,
         total_cost=total_cost.format_usd(),
         total_usage=mr.usage.to_dict(),
-        warnings=mr.warnings,
+        warnings=list(mr.warnings) + list(cost_warnings),
+        cost_is_estimated=bool(cost_warnings),
         terminal_round=mr.terminal_round,
         results=flat_results,
         metadata=metadata,
@@ -866,6 +893,8 @@ def run_panel(
         variant_count=variant_count,
     )
 
+    synth_model_for_warning = synthesis_dict.get("model") if synthesis_dict else None
+    contributing_models = [*sorted(per_model_usage.keys()), synth_model_for_warning]
     panel = _build_panel_result_from_single_round(
         result_id=result_id,
         model=model,
@@ -878,6 +907,7 @@ def run_panel(
         metadata=metadata,
         total_usage=total_usage,
         total_cost=total_cost,
+        contributing_models=contributing_models,
     )
     if variant_data:
         panel.metadata = dict(panel.metadata or {})
@@ -1075,6 +1105,7 @@ def get_panel_result(result_id: str) -> PanelResult:
         total_cost=data.get("total_cost", ""),
         total_usage=data.get("total_usage") or {},
         warnings=data.get("warnings") or [],
+        cost_is_estimated=bool(data.get("cost_is_estimated", False)),
         terminal_round=data.get("terminal_round"),
         results=results,
         metadata=data.get("metadata"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from synth_panel.cli.commands import (
+    _build_rounds_shape,
     _load_instrument,
     _load_personas,
     _load_schema,
@@ -2779,3 +2780,63 @@ class TestPanelRunDryRun:
         assert data["estimated_input_tokens"] >= 1
         assert data["rounds"][0]["questions"] == ["Why now?"]
         mock_run_panel.assert_not_called()
+
+
+# --- sp-nn8k: _build_rounds_shape propagates cost_fallback_warnings ------
+
+
+class _StubInstrument:
+    def __init__(self):
+        self.rounds = [type("R", (), {"name": "default"})()]
+        self.warnings = []
+
+
+class TestBuildRoundsShapeCostFallback:
+    """Cost fallback warnings must merge into ``warnings`` and flip the flag."""
+
+    def _zero_cost(self):
+        from synth_panel.cost import CostEstimate
+
+        return CostEstimate()
+
+    def _call(self, **overrides):
+        defaults = dict(
+            instrument=_StubInstrument(),
+            results=[],
+            synthesis_dict=None,
+            panelist_cost=self._zero_cost(),
+            total_usage=TokenUsage(),
+            total_cost=self._zero_cost(),
+            model="sonnet",
+            persona_count=0,
+            question_count=0,
+        )
+        defaults.update(overrides)
+        return _build_rounds_shape(**defaults)
+
+    def test_no_warnings_when_absent(self):
+        out = self._call()
+        assert out["warnings"] == []
+        assert out["cost_is_estimated"] is False
+
+    def test_cost_fallback_warnings_merge(self):
+        warnings_in = ["Cost for model 'novel-x' computed using DEFAULT_PRICING fallback — real charges may differ."]
+        out = self._call(cost_fallback_warnings=warnings_in)
+        assert warnings_in[0] in out["warnings"]
+        assert out["cost_is_estimated"] is True
+
+    def test_instrument_warnings_preserved_alongside_cost_warnings(self):
+        inst = _StubInstrument()
+        inst.warnings = ["unreachable round: dead_end"]
+        cost_warnings = [
+            "Cost for model 'mystery-v9' computed using DEFAULT_PRICING fallback — real charges may differ."
+        ]
+        out = self._call(instrument=inst, cost_fallback_warnings=cost_warnings)
+        assert "unreachable round: dead_end" in out["warnings"]
+        assert cost_warnings[0] in out["warnings"]
+        assert out["cost_is_estimated"] is True
+
+    def test_empty_list_equals_no_warnings(self):
+        out = self._call(cost_fallback_warnings=[])
+        assert out["warnings"] == []
+        assert out["cost_is_estimated"] is False

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -18,6 +18,8 @@ from synth_panel.cost import (
     TokenUsage,
     UsageTracker,
     aggregate_per_model,
+    build_cost_fallback_warnings,
+    collect_estimated_models,
     estimate_cost,
     format_summary,
     lookup_pricing,
@@ -106,6 +108,56 @@ class TestPricingLookup:
         pricing, _ = lookup_pricing("openrouter/openai/gpt-5-mini")
         cost = estimate_cost(usage, pricing)
         assert cost.total_cost == pytest.approx(0.01296, abs=1e-4)
+
+
+# --- sp-nn8k: cost fallback warnings -------------------------------------
+
+
+class TestCostFallbackWarnings:
+    """build_cost_fallback_warnings / collect_estimated_models."""
+
+    def test_no_models_returns_empty(self):
+        assert build_cost_fallback_warnings([]) == []
+        assert collect_estimated_models([]) == []
+
+    def test_skips_none_and_blank(self):
+        assert build_cost_fallback_warnings([None, "", "sonnet"]) == []
+
+    def test_priced_model_produces_no_warning(self):
+        assert build_cost_fallback_warnings(["claude-sonnet-4-6"]) == []
+
+    def test_unpriced_model_produces_one_warning(self):
+        warnings = build_cost_fallback_warnings(["mystery-model-v9"])
+        assert len(warnings) == 1
+        w = warnings[0]
+        assert "mystery-model-v9" in w
+        assert "DEFAULT_PRICING fallback" in w
+        assert "explicit pricing" in w
+
+    def test_deduplicates_same_model(self):
+        warnings = build_cost_fallback_warnings(["novel-x", "novel-x", "novel-x"])
+        assert len(warnings) == 1
+
+    def test_preserves_first_seen_order(self):
+        warnings = build_cost_fallback_warnings(["alpha-unknown", "beta-unknown"])
+        assert "'alpha-unknown'" in warnings[0]
+        assert "'beta-unknown'" in warnings[1]
+
+    def test_mixed_priced_and_estimated(self):
+        """Only the unpriced model(s) surface — priced models are silent."""
+        warnings = build_cost_fallback_warnings(["sonnet", "my-local-7b", "haiku", "exotic-13b"])
+        assert len(warnings) == 2
+        joined = "\n".join(warnings)
+        assert "my-local-7b" in joined
+        assert "exotic-13b" in joined
+        assert "sonnet" not in joined
+        assert "haiku" not in joined
+
+    def test_collect_estimated_models_matches_warnings(self):
+        """collect_estimated_models returns the same identifiers the warnings mention."""
+        models = ["sonnet", "novel-a", "haiku", "novel-b", "novel-a"]
+        estimated = collect_estimated_models(models)
+        assert estimated == ["novel-a", "novel-b"]
 
 
 # --- Provider-string pricing lookup --------------------------------------

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -545,7 +545,62 @@ class TestBuildEnsembleOutput:
         from synth_panel.ensemble import build_ensemble_output
 
         out = build_ensemble_output(self._fixture())
-        assert set(out.keys()) == {"per_model_results", "cost_breakdown", "models", "total_usage", "metadata"}
+        assert set(out.keys()) == {
+            "per_model_results",
+            "cost_breakdown",
+            "models",
+            "total_usage",
+            "warnings",
+            "cost_is_estimated",
+            "metadata",
+        }
+
+    def test_priced_models_have_no_cost_warnings(self):
+        """sp-nn8k: when every model has an explicit pricing tier, warnings
+        is empty and cost_is_estimated is False."""
+        from synth_panel.ensemble import build_ensemble_output
+
+        out = build_ensemble_output(self._fixture())
+        assert out["warnings"] == []
+        assert out["cost_is_estimated"] is False
+
+    def test_unpriced_model_surfaces_fallback_warning(self):
+        """sp-nn8k: an unknown ensemble model must produce a DEFAULT_PRICING
+        warning and flip cost_is_estimated to True."""
+        from synth_panel.cost import CostEstimate, TokenUsage
+        from synth_panel.ensemble import EnsembleResult, ModelRunResult, build_ensemble_output
+
+        usage = TokenUsage(input_tokens=10, output_tokens=5)
+        cost = CostEstimate(input_cost=0.001, output_cost=0.001)
+        mystery_mr = ModelRunResult(
+            model="mystery-model-v9",
+            panelist_results=[
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[{"question": "Q1", "response": "a1", "error": False}],
+                    usage=usage,
+                    model="mystery-model-v9",
+                )
+            ],
+            usage=usage,
+            cost=cost,
+            sessions={},
+        )
+        ens = EnsembleResult(
+            model_results=[mystery_mr],
+            models=["mystery-model-v9"],
+            total_usage=usage,
+            total_cost=cost,
+            per_model_cost={"mystery-model-v9": cost.format_usd()},
+            per_model_usage={"mystery-model-v9": usage.to_dict()},
+            persona_count=1,
+            question_count=1,
+        )
+        out = build_ensemble_output(ens)
+        assert out["cost_is_estimated"] is True
+        assert len(out["warnings"]) == 1
+        assert "mystery-model-v9" in out["warnings"][0]
+        assert "DEFAULT_PRICING fallback" in out["warnings"][0]
 
     def test_per_model_results_has_results_cost_usage(self):
         from synth_panel.ensemble import build_ensemble_output

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -339,6 +339,62 @@ class TestGetPanelResult:
 
 
 # ---------------------------------------------------------------------------
+# sp-nn8k: PanelResult surfaces cost_is_estimated + warnings
+# ---------------------------------------------------------------------------
+
+
+class TestPanelResultCostFallback:
+    """The single-round SDK builder must flag DEFAULT_PRICING fallbacks."""
+
+    def _call(self, *, model, contributing_models=None):
+        from synth_panel.cost import CostEstimate, TokenUsage
+        from synth_panel.sdk import _build_panel_result_from_single_round
+
+        cost = CostEstimate()
+        return _build_panel_result_from_single_round(
+            result_id="rid-test",
+            model=model,
+            personas=[{"name": "A"}],
+            questions=[{"text": "q"}],
+            result_dicts=[],
+            panelist_usage=TokenUsage(),
+            panelist_cost=cost,
+            synthesis_dict=None,
+            metadata=None,
+            total_usage=TokenUsage(),
+            total_cost=cost,
+            contributing_models=contributing_models,
+        )
+
+    def test_priced_model_has_no_warning_and_flag_false(self):
+        panel = self._call(model="claude-sonnet-4-6")
+        assert panel.warnings == []
+        assert panel.cost_is_estimated is False
+
+    def test_unpriced_model_emits_warning_and_sets_flag(self):
+        panel = self._call(model="totally-unknown-model-x9")
+        assert panel.cost_is_estimated is True
+        assert len(panel.warnings) == 1
+        assert "totally-unknown-model-x9" in panel.warnings[0]
+        assert "DEFAULT_PRICING fallback" in panel.warnings[0]
+
+    def test_contributing_models_drives_detection(self):
+        """When contributing_models is passed it supersedes the single model check,
+        so mixed-model runs surface each offender."""
+        panel = self._call(
+            model="sonnet",
+            contributing_models=["sonnet", "exotic-7b", "haiku", "mystery-13b"],
+        )
+        assert panel.cost_is_estimated is True
+        joined = "\n".join(panel.warnings)
+        assert "exotic-7b" in joined
+        assert "mystery-13b" in joined
+        assert "sonnet" not in joined
+        assert "haiku" not in joined
+        assert len(panel.warnings) == 2
+
+
+# ---------------------------------------------------------------------------
 # Extension path
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Surface the DEFAULT_PRICING fallback explicitly in panel output (warning + metadata flag) so users immediately see when a model lacked explicit pricing and silently inherited the default rate

## Source
- Polecat: slit
- Issue: sp-nn8k
- MR: sp-wisp-hu1
- Branch: polecat/slit-mo8x2dmu

## Test plan
- [ ] CI passes (updated coverage in test_cli.py, test_cost.py, test_ensemble.py, test_sdk.py)
- [ ] Running with an un-priced model emits a visible warning + `used_default_pricing` metadata flag

## Conflict note
Wide surface: cli/commands.py, cost.py, ensemble.py, mcp/server.py, sdk.py. Overlaps with the open cost/ensemble stack (#196, #198, #210, #211, #212). Rebase near-certain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)