### PR TITLE
fix(cost): trust provider-reported cost over local pricing table (sp-j3vk)

### DIFF
--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -15,32 +15,58 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class TokenUsage:
-    """Immutable snapshot of token counts for a single LLM turn."""
+    """Immutable snapshot of token counts for a single LLM turn.
+
+    ``provider_reported_cost`` is the authoritative USD cost as billed by
+    the upstream provider (e.g. OpenRouter's ``usage.cost``). When present,
+    ``resolve_cost`` prefers it over the local pricing table; the local
+    table becomes a divergence sanity-check rather than a billing source.
+
+    ``reasoning_tokens`` / ``cached_tokens`` are informational sub-counts
+    already included in ``output_tokens`` / ``input_tokens`` respectively.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
     cache_creation_input_tokens: int = 0
     cache_read_input_tokens: int = 0
+    provider_reported_cost: float | None = None
+    reasoning_tokens: int = 0
+    cached_tokens: int = 0
 
     @property
     def total_tokens(self) -> int:
         return self.input_tokens + self.output_tokens + self.cache_creation_input_tokens + self.cache_read_input_tokens
 
     def __add__(self, other: TokenUsage) -> TokenUsage:
+        if self.provider_reported_cost is None and other.provider_reported_cost is None:
+            summed_cost: float | None = None
+        else:
+            summed_cost = (self.provider_reported_cost or 0.0) + (other.provider_reported_cost or 0.0)
         return TokenUsage(
             input_tokens=self.input_tokens + other.input_tokens,
             output_tokens=self.output_tokens + other.output_tokens,
             cache_creation_input_tokens=(self.cache_creation_input_tokens + other.cache_creation_input_tokens),
             cache_read_input_tokens=(self.cache_read_input_tokens + other.cache_read_input_tokens),
+            provider_reported_cost=summed_cost,
+            reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
+            cached_tokens=self.cached_tokens + other.cached_tokens,
         )
 
     def to_dict(self) -> dict:
-        return {
+        d: dict = {
             "input_tokens": self.input_tokens,
             "output_tokens": self.output_tokens,
             "cache_creation_input_tokens": self.cache_creation_input_tokens,
             "cache_read_input_tokens": self.cache_read_input_tokens,
         }
+        if self.provider_reported_cost is not None:
+            d["provider_reported_cost"] = self.provider_reported_cost
+        if self.reasoning_tokens:
+            d["reasoning_tokens"] = self.reasoning_tokens
+        if self.cached_tokens:
+            d["cached_tokens"] = self.cached_tokens
+        return d
 
     @classmethod
     def from_dict(cls, data: dict) -> TokenUsage:
@@ -49,6 +75,9 @@ class TokenUsage:
             output_tokens=data.get("output_tokens", 0),
             cache_creation_input_tokens=data.get("cache_creation_input_tokens", 0),
             cache_read_input_tokens=data.get("cache_read_input_tokens", 0),
+            provider_reported_cost=data.get("provider_reported_cost"),
+            reasoning_tokens=data.get("reasoning_tokens", 0),
+            cached_tokens=data.get("cached_tokens", 0),
         )
 
 
@@ -322,6 +351,64 @@ def estimate_cost(
     )
 
 
+# Local-vs-provider divergence threshold for the sanity-check warning.
+# Below this ratio we assume the local pricing table is still calibrated;
+# above it we flag a likely stale or mis-keyed entry.
+_DIVERGENCE_WARN_RATIO = 0.20
+
+
+def resolve_cost(
+    usage: TokenUsage,
+    model: str | None = None,
+) -> CostEstimate:
+    """Return the authoritative ``CostEstimate`` for *usage*.
+
+    Precedence:
+
+    1. If ``usage.provider_reported_cost`` is set (e.g. OpenRouter's
+       ``usage.cost``), use it verbatim — this is what was actually
+       billed and already reflects BYOK discounts, upstream pricing
+       changes, and per-token promos the local table cannot track. The
+       amount is deposited on ``CostEstimate.output_cost`` so totals are
+       preserved; input/cache buckets are left at zero because the
+       provider does not always return a breakdown.
+    2. Otherwise fall back to the local pricing table via ``lookup_pricing``.
+
+    When both the provider value and a local estimate are available and
+    they diverge by more than ``_DIVERGENCE_WARN_RATIO`` (20%), a
+    warning is logged so a stale pricing table can be caught during
+    development. The warning is informational only — the provider value
+    is always returned.
+    """
+    pricing, _is_estimated = lookup_pricing(model)
+    local = estimate_cost(usage, pricing)
+
+    if usage.provider_reported_cost is None:
+        return local
+
+    provider_total = float(usage.provider_reported_cost)
+    local_total = local.total_cost
+
+    if local_total > 0 and provider_total > 0:
+        ratio = abs(provider_total - local_total) / max(provider_total, local_total)
+        if ratio > _DIVERGENCE_WARN_RATIO:
+            logger.warning(
+                "Local cost estimate diverges from provider-reported for model=%s: "
+                "local=$%.6f provider=$%.6f ratio=%.1f%% — pricing table may be stale.",
+                model,
+                local_total,
+                provider_total,
+                ratio * 100.0,
+            )
+
+    return CostEstimate(
+        input_cost=0.0,
+        output_cost=provider_total,
+        cache_creation_cost=0.0,
+        cache_read_cost=0.0,
+    )
+
+
 def aggregate_per_model(
     panelist_results,  # Iterable[PanelistResult]; untyped to avoid circular import
     default_model: str,
@@ -345,8 +432,7 @@ def aggregate_per_model(
 
     per_cost: dict[str, CostEstimate] = {}
     for m, usage in per_usage.items():
-        pricing, _ = lookup_pricing(m)
-        per_cost[m] = estimate_cost(usage, pricing)
+        per_cost[m] = resolve_cost(usage, m)
     return per_usage, per_cost
 
 
@@ -447,8 +533,13 @@ class UsageTracker:
         *,
         model: str | None = None,
     ) -> str:
-        pricing, is_estimated = lookup_pricing(model)
-        cost = estimate_cost(self._cumulative, pricing)
+        _, is_estimated = lookup_pricing(model)
+        cost = resolve_cost(self._cumulative, model)
+        # When the provider billed this usage directly, the ``estimated``
+        # tag from the local table is misleading — provider-reported cost
+        # is always authoritative.
+        if self._cumulative.provider_reported_cost is not None:
+            is_estimated = False
         return format_summary(
             label,
             self._cumulative,

--- a/src/synth_panel/llm/models.py
+++ b/src/synth_panel/llm/models.py
@@ -71,23 +71,43 @@ class InputMessage:
 
 @dataclass(frozen=True)
 class TokenUsage:
-    """Token consumption counters for a single LLM call."""
+    """Token consumption counters for a single LLM call.
+
+    ``provider_reported_cost`` is the authoritative USD cost as billed by
+    the upstream provider (e.g. OpenRouter's ``usage.cost``). When present,
+    downstream cost resolution prefers it over the local pricing table.
+
+    ``reasoning_tokens`` / ``cached_tokens`` are informational sub-counts
+    already included in ``output_tokens`` / ``input_tokens`` respectively.
+    They are surfaced separately so reports can show reasoning token spend
+    and cache-hit rates without double-counting tokens.
+    """
 
     input_tokens: int = 0
     output_tokens: int = 0
     cache_write_tokens: int = 0
     cache_read_tokens: int = 0
+    provider_reported_cost: float | None = None
+    reasoning_tokens: int = 0
+    cached_tokens: int = 0
 
     @property
     def total_tokens(self) -> int:
         return self.input_tokens + self.output_tokens + self.cache_write_tokens + self.cache_read_tokens
 
     def __add__(self, other: TokenUsage) -> TokenUsage:
+        if self.provider_reported_cost is None and other.provider_reported_cost is None:
+            summed_cost: float | None = None
+        else:
+            summed_cost = (self.provider_reported_cost or 0.0) + (other.provider_reported_cost or 0.0)
         return TokenUsage(
             input_tokens=self.input_tokens + other.input_tokens,
             output_tokens=self.output_tokens + other.output_tokens,
             cache_write_tokens=self.cache_write_tokens + other.cache_write_tokens,
             cache_read_tokens=self.cache_read_tokens + other.cache_read_tokens,
+            provider_reported_cost=summed_cost,
+            reasoning_tokens=self.reasoning_tokens + other.reasoning_tokens,
+            cached_tokens=self.cached_tokens + other.cached_tokens,
         )
 
 

--- a/src/synth_panel/llm/providers/_openai_format.py
+++ b/src/synth_panel/llm/providers/_openai_format.py
@@ -144,6 +144,74 @@ def build_openai_body(
 # ---------------------------------------------------------------------------
 
 
+def _extract_usage(usage_raw: dict[str, Any]) -> TokenUsage:
+    """Map an OpenAI-compatible ``usage`` block to ``TokenUsage``.
+
+    Beyond the base ``prompt_tokens`` / ``completion_tokens``, this
+    captures OpenRouter's authoritative cost fields and OpenAI-style
+    sub-counts that the upstream API only reports when asked for detail:
+
+    - ``usage.cost`` (float, USD): native cost as billed by OpenRouter,
+      reflecting BYOK discounts and actual upstream pricing. Preferred
+      over the local pricing table when present. ``cost_details`` may
+      expose ``upstream_inference_cost`` (preferred), otherwise the
+      sum of ``upstream_inference_prompt_cost`` and
+      ``upstream_inference_completions_cost``.
+    - ``prompt_tokens_details.cached_tokens``: the subset of
+      ``prompt_tokens`` that was served from cache.
+    - ``completion_tokens_details.reasoning_tokens``: the subset of
+      ``completion_tokens`` spent on reasoning (e.g. GPT-5).
+
+    ``reasoning_tokens`` and ``cached_tokens`` remain sub-counts —
+    callers should not subtract them from the base counts.
+    """
+
+    def _coerce_float(value: Any) -> float | None:
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    provider_cost = _coerce_float(usage_raw.get("cost"))
+    cost_details = usage_raw.get("cost_details")
+    if provider_cost is None and isinstance(cost_details, dict):
+        upstream = _coerce_float(cost_details.get("upstream_inference_cost"))
+        if upstream is not None:
+            provider_cost = upstream
+        else:
+            prompt_cost = _coerce_float(cost_details.get("upstream_inference_prompt_cost"))
+            completion_cost = _coerce_float(cost_details.get("upstream_inference_completions_cost"))
+            if prompt_cost is not None or completion_cost is not None:
+                provider_cost = (prompt_cost or 0.0) + (completion_cost or 0.0)
+
+    prompt_details = usage_raw.get("prompt_tokens_details")
+    cached_tokens = 0
+    if isinstance(prompt_details, dict):
+        cached_tokens = int(prompt_details.get("cached_tokens") or 0)
+
+    completion_details = usage_raw.get("completion_tokens_details")
+    reasoning_tokens = 0
+    if isinstance(completion_details, dict):
+        reasoning_tokens = int(completion_details.get("reasoning_tokens") or 0)
+
+    # NOTE: ``cached_tokens`` is NOT propagated into ``cache_read_tokens``
+    # because OpenAI-style ``prompt_tokens`` already includes the cached
+    # subset. Adding it again would double-count under local pricing (which
+    # bills ``input_tokens`` + ``cache_read_tokens`` separately). The sub-
+    # count is preserved in the dedicated ``cached_tokens`` field for
+    # reporting. When provider_reported_cost is present (OpenRouter), the
+    # local estimate is overridden anyway.
+    return TokenUsage(
+        input_tokens=usage_raw.get("prompt_tokens") or 0,
+        output_tokens=usage_raw.get("completion_tokens") or 0,
+        provider_reported_cost=provider_cost,
+        reasoning_tokens=reasoning_tokens,
+        cached_tokens=cached_tokens,
+    )
+
+
 def _parse_openai_stop(reason: str | None) -> StopReason | None:
     if reason is None:
         return None
@@ -188,10 +256,7 @@ def parse_openai_response(
     usage_raw = data.get("usage") or {}
     if not isinstance(usage_raw, dict):
         usage_raw = {}
-    usage = TokenUsage(
-        input_tokens=usage_raw.get("prompt_tokens") or 0,
-        output_tokens=usage_raw.get("completion_tokens") or 0,
-    )
+    usage = _extract_usage(usage_raw)
 
     return CompletionResponse(
         id=data.get("id", ""),

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -66,6 +66,7 @@ from synth_panel.cost import (
     aggregate_per_model,
     estimate_cost,
     lookup_pricing,
+    resolve_cost,
 )
 from synth_panel.cost import TokenUsage as CostTokenUsage
 from synth_panel.instrument import Instrument, parse_instrument
@@ -728,9 +729,11 @@ async def run_prompt(
         output_tokens=response.usage.output_tokens,
         cache_creation_input_tokens=response.usage.cache_write_tokens,
         cache_read_input_tokens=response.usage.cache_read_tokens,
+        provider_reported_cost=response.usage.provider_reported_cost,
+        reasoning_tokens=response.usage.reasoning_tokens,
+        cached_tokens=response.usage.cached_tokens,
     )
-    pricing, _ = lookup_pricing(model)
-    cost = estimate_cost(usage, pricing)
+    cost = resolve_cost(usage, model)
     return json.dumps(
         {
             "response": response.text,

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -38,6 +38,9 @@ def _convert_llm_usage(llm_usage: LLMTokenUsage) -> TokenUsage:
         output_tokens=llm_usage.output_tokens,
         cache_creation_input_tokens=llm_usage.cache_write_tokens,
         cache_read_input_tokens=llm_usage.cache_read_tokens,
+        provider_reported_cost=llm_usage.provider_reported_cost,
+        reasoning_tokens=llm_usage.reasoning_tokens,
+        cached_tokens=llm_usage.cached_tokens,
     )
 
 

--- a/src/synth_panel/runtime.py
+++ b/src/synth_panel/runtime.py
@@ -154,6 +154,9 @@ def _convert_usage(llm_usage: LLMTokenUsage) -> TokenUsage:
         output_tokens=llm_usage.output_tokens,
         cache_creation_input_tokens=llm_usage.cache_write_tokens,
         cache_read_input_tokens=llm_usage.cache_read_tokens,
+        provider_reported_cost=llm_usage.provider_reported_cost,
+        reasoning_tokens=llm_usage.reasoning_tokens,
+        cached_tokens=llm_usage.cached_tokens,
     )
 
 

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -45,6 +45,7 @@ from synth_panel.cost import (
     aggregate_per_model,
     estimate_cost,
     lookup_pricing,
+    resolve_cost,
 )
 from synth_panel.cost import (
     TokenUsage as CostTokenUsage,
@@ -457,9 +458,11 @@ def run_prompt(
         output_tokens=response.usage.output_tokens,
         cache_creation_input_tokens=response.usage.cache_write_tokens,
         cache_read_input_tokens=response.usage.cache_read_tokens,
+        provider_reported_cost=response.usage.provider_reported_cost,
+        reasoning_tokens=response.usage.reasoning_tokens,
+        cached_tokens=response.usage.cached_tokens,
     )
-    pricing, _ = lookup_pricing(model)
-    cost = estimate_cost(usage, pricing)
+    cost = resolve_cost(usage, model)
     return PromptResult(
         response=response.text,
         model=response.model,

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -36,6 +36,9 @@ def _convert_llm_usage(llm_usage: LLMTokenUsage) -> TokenUsage:
         output_tokens=llm_usage.output_tokens,
         cache_creation_input_tokens=llm_usage.cache_write_tokens,
         cache_read_input_tokens=llm_usage.cache_read_tokens,
+        provider_reported_cost=llm_usage.provider_reported_cost,
+        reasoning_tokens=llm_usage.reasoning_tokens,
+        cached_tokens=llm_usage.cached_tokens,
     )
 
 

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -258,6 +258,113 @@ class TestEstimateCost:
         assert cost.cache_read_cost == pytest.approx(0.10)
 
 
+# --- resolve_cost (sp-j3vk) -----------------------------------------------
+
+
+class TestResolveCost:
+    """sp-j3vk: provider-reported cost must override local pricing table."""
+
+    def test_falls_back_to_local_when_provider_absent(self):
+        from synth_panel.cost import resolve_cost
+
+        usage = TokenUsage(input_tokens=1_000_000, output_tokens=0)
+        cost = resolve_cost(usage, "claude-haiku-3.5")
+        assert cost.total_cost == pytest.approx(1.0)
+
+    def test_provider_reported_overrides_local(self):
+        """Stale local table must not corrupt the actual billed cost."""
+        from synth_panel.cost import resolve_cost
+
+        # Local table would compute this at haiku rates ($1/M input). The
+        # provider says we were billed $0.42 (BYOK discount, promo, etc.).
+        # resolve_cost must return the provider value, not the local estimate.
+        usage = TokenUsage(
+            input_tokens=1_000_000,
+            output_tokens=0,
+            provider_reported_cost=0.42,
+        )
+        cost = resolve_cost(usage, "claude-haiku-3.5")
+        assert cost.total_cost == pytest.approx(0.42)
+
+    def test_provider_reported_preserved_when_local_would_be_zero(self):
+        """ollama/self-hosted case — provider reports cost with zero tokens."""
+        from synth_panel.cost import resolve_cost
+
+        usage = TokenUsage(provider_reported_cost=0.05)
+        cost = resolve_cost(usage, "ollama/llama3")
+        assert cost.total_cost == pytest.approx(0.05)
+
+    def test_divergence_warning_fires_above_20_percent(self, caplog):
+        """sp-j3vk: when local estimate wildly disagrees with provider, warn."""
+        from synth_panel.cost import resolve_cost
+
+        # Local: 1M input × $1/M = $1.00. Provider: $0.10 (90% divergence).
+        usage = TokenUsage(
+            input_tokens=1_000_000,
+            provider_reported_cost=0.10,
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.cost"):
+            cost = resolve_cost(usage, "claude-haiku-3.5")
+        assert cost.total_cost == pytest.approx(0.10)
+        assert any("diverges" in rec.message for rec in caplog.records)
+
+    def test_divergence_silent_within_20_percent(self, caplog):
+        from synth_panel.cost import resolve_cost
+
+        # Local: $1.00. Provider: $1.05 → 4.7% divergence, no warning.
+        usage = TokenUsage(
+            input_tokens=1_000_000,
+            provider_reported_cost=1.05,
+        )
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.cost"):
+            resolve_cost(usage, "claude-haiku-3.5")
+        assert not any("diverges" in rec.message for rec in caplog.records)
+
+
+class TestTokenUsageProviderCost:
+    """TokenUsage carries provider-reported cost through addition and (de)ser."""
+
+    def test_field_defaults_none(self):
+        u = TokenUsage()
+        assert u.provider_reported_cost is None
+        assert u.reasoning_tokens == 0
+        assert u.cached_tokens == 0
+
+    def test_addition_sums_provider_cost(self):
+        a = TokenUsage(provider_reported_cost=0.1, reasoning_tokens=5, cached_tokens=3)
+        b = TokenUsage(provider_reported_cost=0.2, reasoning_tokens=7, cached_tokens=4)
+        c = a + b
+        assert c.provider_reported_cost == pytest.approx(0.3)
+        assert c.reasoning_tokens == 12
+        assert c.cached_tokens == 7
+
+    def test_addition_preserves_none_when_both_absent(self):
+        a = TokenUsage(input_tokens=1)
+        b = TokenUsage(input_tokens=2)
+        c = a + b
+        assert c.provider_reported_cost is None
+
+    def test_addition_treats_missing_as_zero_when_one_present(self):
+        a = TokenUsage(provider_reported_cost=0.5)
+        b = TokenUsage()
+        assert (a + b).provider_reported_cost == pytest.approx(0.5)
+        assert (b + a).provider_reported_cost == pytest.approx(0.5)
+
+    def test_roundtrip_dict_preserves_provider_cost(self):
+        u = TokenUsage(
+            input_tokens=10,
+            output_tokens=20,
+            provider_reported_cost=0.123,
+            reasoning_tokens=5,
+            cached_tokens=2,
+        )
+        assert TokenUsage.from_dict(u.to_dict()) == u
+
+
 # --- aggregate_per_model --------------------------------------------------
 
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -314,6 +314,95 @@ class TestParseOpenaiResponse:
         resp = parse_openai_response(data, "m")
         assert resp.stop_reason == StopReason.MAX_TOKENS
 
+    def test_openrouter_cost_captured(self):
+        """sp-j3vk: OpenRouter's usage.cost must flow into TokenUsage."""
+        from synth_panel.llm.providers._openai_format import parse_openai_response
+
+        data = {
+            "id": "x",
+            "model": "openai/gpt-4o-mini",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "cost": 0.000123,
+            },
+        }
+        resp = parse_openai_response(data, "openai/gpt-4o-mini")
+        assert resp.usage.provider_reported_cost == pytest.approx(0.000123)
+
+    def test_openrouter_cost_details_upstream_inference_cost(self):
+        """Prefer cost_details.upstream_inference_cost over absent top-level cost."""
+        from synth_panel.llm.providers._openai_format import parse_openai_response
+
+        data = {
+            "id": "x",
+            "model": "m",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "cost_details": {"upstream_inference_cost": 0.000456},
+            },
+        }
+        resp = parse_openai_response(data, "m")
+        assert resp.usage.provider_reported_cost == pytest.approx(0.000456)
+
+    def test_openrouter_cost_details_prompt_plus_completion(self):
+        """Fall back to prompt+completion cost sum if upstream total is missing."""
+        from synth_panel.llm.providers._openai_format import parse_openai_response
+
+        data = {
+            "id": "x",
+            "model": "m",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "cost_details": {
+                    "upstream_inference_prompt_cost": 0.0003,
+                    "upstream_inference_completions_cost": 0.0004,
+                },
+            },
+        }
+        resp = parse_openai_response(data, "m")
+        assert resp.usage.provider_reported_cost == pytest.approx(0.0007)
+
+    def test_reasoning_and_cached_tokens_captured(self):
+        """sp-loil: reasoning_tokens and cached_tokens subcounts land in TokenUsage."""
+        from synth_panel.llm.providers._openai_format import parse_openai_response
+
+        data = {
+            "id": "x",
+            "model": "openai/gpt-5-mini",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {
+                "prompt_tokens": 200,
+                "completion_tokens": 50,
+                "prompt_tokens_details": {"cached_tokens": 180},
+                "completion_tokens_details": {"reasoning_tokens": 30},
+            },
+        }
+        resp = parse_openai_response(data, "openai/gpt-5-mini")
+        assert resp.usage.cached_tokens == 180
+        assert resp.usage.reasoning_tokens == 30
+        # Sub-counts do NOT get promoted into cache_read_tokens, otherwise
+        # local cost estimates would double-bill on non-OR providers.
+        assert resp.usage.cache_read_tokens == 0
+
+    def test_missing_cost_is_none_not_zero(self):
+        """Absent provider cost must be None so resolve_cost falls back to table."""
+        from synth_panel.llm.providers._openai_format import parse_openai_response
+
+        data = {
+            "id": "x",
+            "model": "m",
+            "choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+        resp = parse_openai_response(data, "m")
+        assert resp.usage.provider_reported_cost is None
+
 
 # ---------------------------------------------------------------------------
 # Tests: _openai_format.py — parse_openai_sse_stream


### PR DESCRIPTION
## Summary
- When a provider returns its own cost/usage (e.g., OpenRouter `usage.cost`), prefer that over our local pricing-table estimate so users see actual spend, not our best guess

## Source
- Polecat: furiosa
- Issue: sp-j3vk
- MR: sp-wisp-2dk
- Branch: polecat/furiosa-mo8xvwfa

## Test plan
- [ ] CI passes (updated coverage in test_cost.py, test_providers.py)
- [ ] OpenRouter runs show provider-reported cost; Anthropic/OpenAI-direct runs still use the local table

## Conflict note
Wide surface: cost.py, llm/models.py, llm/providers/_openai_format.py, mcp/server.py, orchestrator.py, runtime.py, sdk.py, synthesis.py. Heavy overlap with the open cost/pricing stack (#196, #210, #211, #213). Rebase near-certain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)