### PR TITLE
chore(release): cut v0.9.7 (sp-pjmi)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+## [0.9.7] - 2026-04-21
+
+### Fixed
+- (sp-j3vk) Cost: trust provider-reported cost over the local pricing table. When a provider returns `usage.cost` (OpenRouter) or equivalent in its response, that value is now recorded verbatim instead of being recomputed from token counts against our maintained rate table. This is the architectural root-cause fix that supersedes the sp-cxyb / sp-5ggf / sp-nn8k / sp-loil bandaids: local pricing drift can no longer inflate or deflate reported spend, and OpenAI-via-OpenRouter paths stop reporting 40× overages when our table is stale relative to the provider's billing.
+- (sp-nn8k) Cost: surface `DEFAULT_PRICING` fallback loudly in panel output. When a model is not found in the pricing table and we fall back to the default rate, the panel result now includes a `pricing_fallback` warning listing the affected model(s), so silent mispricing can no longer hide in `$0` or inflated-cost runs. Bandaid ahead of sp-j3vk.
+- (sp-27rz) Ensemble: guarantee every weighted model in `--models` gets at least 1 persona. Prior rounding could drop low-weight models entirely (weight < 1/n_personas produced 0 personas after floor), so the ensemble silently ran without models the user explicitly selected. Now ensures ≥1 persona per listed model, redistributing from higher-weight buckets.
+- (sp-5ggf) Cost: add pricing table entries for common OpenRouter-proxied models (gpt-4o-mini, qwen, deepseek, mistral variants) so they stop falling through to `DEFAULT_PRICING` and reporting wrong costs. Bandaid ahead of sp-j3vk.
+- (sp-cxyb) Cost: correct `SONNET_PRICING` to Claude Sonnet 4.5 rates ($3/M in, $15/M out, $0.30/M cached, $3.75/M cache-write) instead of the stale Opus-3 rates that were doubling reported Sonnet cost. Bandaid ahead of sp-j3vk.
+
 ## [0.9.6] - 2026-04-21
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synthpanel"
-version = "0.9.6"
+version = "0.9.7"
 description = "Run synthetic focus groups using AI personas, with an MCP server for Claude Code / Cursor / Windsurf. CLI tool, Python library, any LLM."
 requires-python = ">=3.10"
 license = {text = "MIT"}

--- a/site/index.html
+++ b/site/index.html
@@ -44,7 +44,7 @@
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "Research Tool",
         "operatingSystem": "Cross-platform",
-        "softwareVersion": "0.9.6",
+        "softwareVersion": "0.9.7",
         "license": "https://opensource.org/licenses/MIT",
         "codeRepository": "https://github.com/DataViking-Tech/SynthPanel",
         "downloadUrl": "https://pypi.org/project/synthpanel/",
@@ -123,7 +123,7 @@
           class="mb-4 inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/5 px-3 py-1 text-xs font-medium text-emerald-300"
         >
           <span class="h-1.5 w-1.5 rounded-full bg-emerald-400"></span>
-          v0.9.6 — public beta
+          v0.9.7 — public beta
         </p>
         <h1
           class="bg-gradient-to-br from-white to-slate-400 bg-clip-text font-mono text-5xl font-bold tracking-tight text-transparent sm:text-6xl"
@@ -473,7 +473,7 @@ synthpanel panel run \
       >
         <div class="flex flex-wrap items-center justify-between gap-3">
           <span>
-            MIT-licensed · v0.9.6 ·
+            MIT-licensed · v0.9.7 ·
             <a
               href="https://github.com/DataViking-Tech/SynthPanel"
               class="hover:text-slate-300"


### PR DESCRIPTION
## Summary
- Bump to v0.9.7 shipping 5 PRs merged since v0.9.6, all on 2026-04-21
- Cost-reporting architectural fix (sp-j3vk) plus 4 pricing-table bandaids, ensemble weighted-model fix, and silent-drop guard
- Syncs pyproject, CHANGELOG, and site/index.html hero badge + footer + Schema.org softwareVersion to v0.9.7

## Changes included
- #210 (sp-cxyb) correct `SONNET_PRICING` to Sonnet 4.5 rates, not Opus-3
- #211 (sp-5ggf) add pricing for common OpenRouter-proxied models
- #212 (sp-27rz) guarantee every weighted model gets >=1 persona
- #213 (sp-nn8k) surface `DEFAULT_PRICING` fallback loudly in panel output
- #214 (sp-j3vk) **architectural:** trust provider-reported cost over local pricing table

sp-j3vk is the root-cause fix that supersedes the four pricing-table bandaids: trusting provider-emitted `usage.cost` means local pricing drift can no longer inflate/deflate reported spend. The bandaids remain as belt-and-braces for providers that don't emit cost.

## Urgency
Mayor ensemble audit is blocked on this release to validate that provider-cost trust eliminates the 40× OpenAI overages.

## Test plan
- [x] `tests/test_site_version.py` passes (sp-lwy guard)
- [ ] CI green on Python 3.10 / 3.14
- [ ] `semver:patch` label applied so auto-tag fires and PyPI publish.yml cuts the wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)