### PR TITLE
fix(mcp): reject weighted model spec at MCP boundary (sp-2rj8)

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -162,6 +162,78 @@ def _resolve_mcp_default_model() -> str:
     return MCP_DEFAULT_MODEL
 
 
+def _looks_like_weighted_model_spec(value: str) -> bool:
+    """Return True when *value* matches the CLI's ``name:weight`` spec shape.
+
+    The CLI's ``--models`` flag accepts ``haiku:0.25,gpt-4o-mini:0.25``
+    via :func:`synth_panel.cli.commands.parse_models_spec`. The MCP
+    surface does not parse that grammar — each string is treated as a
+    raw model alias — so ``"haiku:0.25"`` previously routed to a
+    nonexistent model and silently produced an empty panel (sp-2rj8).
+
+    Detection heuristic: a single trailing ``:<float>`` after the last
+    colon. Legitimate model identifiers that embed colons (``ollama:``
+    / ``local:`` prefixes, OpenRouter ``:free`` / ``:beta`` suffixes)
+    are preserved because their tail is non-numeric.
+    """
+    if ":" not in value:
+        return False
+    if value.startswith(("ollama:", "local:")):
+        return False
+    tail = value.rsplit(":", 1)[1].strip()
+    if not tail:
+        return False
+    try:
+        float(tail)
+    except ValueError:
+        return False
+    return True
+
+
+def _reject_weighted_model_spec(
+    *,
+    model: str | None = None,
+    models: list[str] | None = None,
+    synthesis_model: str | None = None,
+    persona_models: dict[str, str] | None = None,
+) -> str | None:
+    """Return a JSON error string if any model argument uses weighted spec syntax.
+
+    Returns ``None`` when every value is a plain alias. The check covers
+    all model-accepting parameters in the MCP surface so the failure is
+    caught uniformly at the boundary instead of surfacing as provider
+    400s downstream.
+    """
+    offenders: list[str] = []
+
+    def _check(val: Any) -> None:
+        if isinstance(val, str) and _looks_like_weighted_model_spec(val):
+            offenders.append(val)
+
+    _check(model)
+    _check(synthesis_model)
+    if models:
+        for m in models:
+            _check(m)
+    if persona_models:
+        for m in persona_models.values():
+            _check(m)
+
+    if not offenders:
+        return None
+
+    quoted = ", ".join(f"'{o}'" for o in offenders)
+    return json.dumps(
+        {
+            "error": (
+                f"Weighted model spec is not supported via MCP (got {quoted}). "
+                'Pass model aliases only, e.g. ["haiku", "gpt-4o-mini"]; '
+                "weights default to equal across the ensemble."
+            )
+        }
+    )
+
+
 # Re-export for backward compatibility — callers patch these names.
 __all__ = [
     "EXTRACT_SCHEMA_REGISTRY",
@@ -704,6 +776,9 @@ async def run_prompt(
             (error if unsupported), ``False`` forces BYOK. ``None``
             auto-picks based on creds + client capability.
     """
+    spec_error = _reject_weighted_model_spec(model=model)
+    if spec_error is not None:
+        return spec_error
     model = model or _resolve_mcp_default_model()
     decision = _decide_sampling_mode(ctx, use_sampling=use_sampling)
     logger.info("run_prompt: mode=%s model=%s prompt_len=%d", decision.mode, model, len(prompt))
@@ -876,8 +951,11 @@ async def run_panel(
             "themes", "rating") or an inline JSON Schema dict.
         models: List of model names for multi-model ensemble. When
             provided (length ≥ 2), the panel is run once per model and
-            results are compared. Mutually exclusive with ``model``. The
-            ensemble response replaces the single-model shape with:
+            results are compared. Mutually exclusive with ``model``.
+            Plain aliases only — the CLI's weighted ``"haiku:0.25"``
+            syntax is rejected at this boundary; weights default to
+            equal across the ensemble. The ensemble response replaces
+            the single-model shape with:
 
             * ``per_model_results`` — ``{model: {results, cost, usage}}``
               where ``results`` is the formatted panelist list for that
@@ -900,6 +978,14 @@ async def run_panel(
             panels require BYOK. Ensemble mode (``models``) and v3
             branching are BYOK-only.
     """
+    spec_error = _reject_weighted_model_spec(
+        model=model,
+        models=models,
+        synthesis_model=synthesis_model,
+        persona_models=persona_models,
+    )
+    if spec_error is not None:
+        return spec_error
     model = model or _resolve_mcp_default_model()
     variants_k = variants or 0
     if variants_k < 0 or variants_k > 20:
@@ -1176,6 +1262,12 @@ async def run_quick_poll(
             (error if unsupported), ``False`` forces BYOK. ``None``
             auto-picks based on creds + client capability.
     """
+    spec_error = _reject_weighted_model_spec(
+        model=model,
+        synthesis_model=synthesis_model,
+    )
+    if spec_error is not None:
+        return spec_error
     model = model or _resolve_mcp_default_model()
 
     if not question or not question.strip():
@@ -1560,6 +1652,12 @@ async def extend_panel(
         synthesis_model: Synthesis model. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt for the new round.
     """
+    spec_error = _reject_weighted_model_spec(
+        model=model,
+        synthesis_model=synthesis_model,
+    )
+    if spec_error is not None:
+        return spec_error
     model = model or _resolve_mcp_default_model()
     logger.info("extend_panel: result_id=%s questions=%d model=%s", result_id, len(questions), model)
     existing = _data_get_panel_result(result_id)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -830,3 +830,181 @@ class TestComputeVariantData:
         assert data["variant_count"] == 0
         assert data["robustness_scores"] == []
         assert data["per_persona_robustness"] == []
+
+
+# ---------------------------------------------------------------------------
+# Weighted model spec rejection at the MCP boundary (sp-2rj8)
+# ---------------------------------------------------------------------------
+
+
+class TestWeightedModelSpecRejection:
+    """MCP rejects CLI-style ``name:weight`` entries with a clear error.
+
+    The CLI's ``--models haiku:0.25,gpt-4o-mini:0.25`` grammar is not
+    parsed at the MCP boundary — each string was being treated as a
+    raw model name, so ``"haiku:0.25"`` routed to a nonexistent model
+    and produced a silent empty panel. These tests pin the boundary
+    behavior so future regressions fail loudly.
+    """
+
+    def test_looks_like_weighted_model_spec_detects_weights(self):
+        from synth_panel.mcp.server import _looks_like_weighted_model_spec
+
+        assert _looks_like_weighted_model_spec("haiku:0.25") is True
+        assert _looks_like_weighted_model_spec("gpt-4o-mini:0.5") is True
+        assert _looks_like_weighted_model_spec("claude-sonnet-4-6:1") is True
+
+    def test_looks_like_weighted_model_spec_allows_real_identifiers(self):
+        from synth_panel.mcp.server import _looks_like_weighted_model_spec
+
+        # Local model prefixes are preserved.
+        assert _looks_like_weighted_model_spec("ollama:llama3") is False
+        assert _looks_like_weighted_model_spec("ollama:llama3:8b") is False
+        assert _looks_like_weighted_model_spec("local:phi3") is False
+        # OpenRouter non-numeric tail suffixes.
+        assert _looks_like_weighted_model_spec("mistralai/mistral-nemo:free") is False
+        assert _looks_like_weighted_model_spec("anthropic/claude-3.5-sonnet:beta") is False
+        # Plain aliases.
+        assert _looks_like_weighted_model_spec("haiku") is False
+        assert _looks_like_weighted_model_spec("gpt-4o-mini") is False
+        assert _looks_like_weighted_model_spec("anthropic/claude-3-5-sonnet-20241022") is False
+
+    @pytest.mark.asyncio
+    async def test_run_panel_rejects_weighted_models_list(self):
+        """The exact sp-2rj8 repro: weighted ``models`` list must error out."""
+        with patch("synth_panel.mcp.server._run_ensemble_sync") as mock_ens:
+            result = await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                    "models": [
+                        "haiku:0.25",
+                        "gpt-4o-mini:0.25",
+                        "gemini-flash-lite:0.25",
+                        "qwen3-plus:0.25",
+                    ],
+                },
+            )
+            mock_ens.assert_not_called()
+            data = json.loads(result[0][0].text)
+            assert "error" in data
+            msg = data["error"]
+            assert "haiku:0.25" in msg
+            assert "gpt-4o-mini:0.25" in msg
+            assert "not supported via MCP" in msg
+
+    @pytest.mark.asyncio
+    async def test_run_panel_accepts_plain_alias_ensemble(self):
+        """Plain alias lists still reach the ensemble runner unchanged."""
+        with patch("synth_panel.mcp.server._run_ensemble_sync") as mock_ens:
+            mock_ens.return_value = {
+                "per_model_results": {},
+                "cost_breakdown": {},
+                "models": ["haiku", "gpt-4o-mini"],
+                "total_usage": {},
+            }
+            result = await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                    "models": ["haiku", "gpt-4o-mini"],
+                },
+            )
+            mock_ens.assert_called_once()
+            data = json.loads(result[0][0].text)
+            assert "error" not in data
+
+    @pytest.mark.asyncio
+    async def test_run_panel_rejects_weighted_single_model(self):
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "model": "haiku:0.5",
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "haiku:0.5" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_panel_rejects_weighted_synthesis_model(self):
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "synthesis_model": "sonnet:1.0",
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "sonnet:1.0" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_panel_rejects_weighted_persona_models(self):
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "persona_models": {"Alice": "haiku:0.25"},
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "haiku:0.25" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_panel_accepts_ollama_prefix_model(self):
+        """``ollama:llama3`` is a legitimate model id and must not be rejected."""
+        with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = {"results": []}
+            result = await mcp.call_tool(
+                "run_panel",
+                {
+                    "personas": [{"name": "Alice"}],
+                    "questions": [{"text": "Hello?"}],
+                    "model": "ollama:llama3",
+                },
+            )
+            mock_run.assert_called_once()
+            data = json.loads(result[0][0].text)
+            assert "error" not in data
+
+    @pytest.mark.asyncio
+    async def test_run_prompt_rejects_weighted_model(self):
+        result = await mcp.call_tool(
+            "run_prompt",
+            {"prompt": "hello", "model": "haiku:0.5"},
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "haiku:0.5" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_run_quick_poll_rejects_weighted_model(self):
+        result = await mcp.call_tool(
+            "run_quick_poll",
+            {"question": "hello?", "model": "haiku:0.5"},
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "haiku:0.5" in data["error"]
+
+    @pytest.mark.asyncio
+    async def test_extend_panel_rejects_weighted_model(self):
+        result = await mcp.call_tool(
+            "extend_panel",
+            {
+                "result_id": "nonexistent",
+                "questions": [{"text": "follow-up?"}],
+                "model": "haiku:0.5",
+            },
+        )
+        data = json.loads(result[0][0].text)
+        assert "error" in data
+        assert "haiku:0.5" in data["error"]


### PR DESCRIPTION
## Summary
- Reject weighted-model spec (CLI-only syntax) at the MCP boundary with a clear error, instead of silently passing through a malformed request the server can't honour

## Source
- Polecat: rictus
- Issue: sp-2rj8
- MR: sp-wisp-zu1
- Branch: polecat/rictus-mo93894q

## Test plan
- [ ] CI passes (updated coverage in test_mcp_server.py)
- [ ] MCP `run_panel` with `model="claude:3,gpt:1"` returns a user-facing error, not a silent misconfiguration

## Conflict note
Touches src/synth_panel/mcp/server.py — overlaps with PR #196 (sp-zdul). Rebase may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)