### PR TITLE
fix(panel): fail loud when every panelist produces no usable data (sp-efip)

### DIFF
--- a/src/synth_panel/_runners.py
+++ b/src/synth_panel/_runners.py
@@ -30,6 +30,121 @@ from synth_panel.prompts import build_question_prompt, persona_system_prompt
 from synth_panel.stats import robustness_score
 from synth_panel.synthesis import synthesize_panel
 
+# sp-efip: max number of per-persona error samples to surface in the
+# diagnostic output when a run fails wholesale. Keeps CLI banners and
+# MCP error envelopes bounded while still naming real errors.
+_MAX_SAMPLE_ERRORS = 3
+
+
+class PanelTotalFailureError(RuntimeError):
+    """Every panelist failed — no usable Q/A data was produced.
+
+    Raised by ``run_panel_sync`` (and equivalents) when the orchestrator
+    returns results where every panelist either errored wholesale or
+    produced zero tokens with only errored responses. Callers should
+    surface the message verbatim so operators see the failing model(s)
+    and upstream provider error (e.g. "OpenRouter API error 400: …").
+    """
+
+    def __init__(self, message: str, *, diagnostic: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.diagnostic = diagnostic
+
+
+def _first_error_message(pr: Any) -> str | None:
+    """Return a representative error string for *pr*, or None if clean."""
+    err = getattr(pr, "error", None)
+    if err:
+        return str(err)
+    for resp in getattr(pr, "responses", []) or []:
+        if isinstance(resp, dict) and resp.get("error"):
+            text = resp.get("response")
+            if isinstance(text, str) and text:
+                return text
+            return "unspecified per-question error"
+    return None
+
+
+def detect_total_failure(panelist_results: list[Any]) -> dict[str, Any] | None:
+    """Return a diagnostic dict when every panelist failed, else None.
+
+    Total failure means that *no* panelist produced a usable Q/A pair.
+    A panelist counts as failed when any of the following hold:
+
+    * ``pr.error`` is set (wholesale panelist exception), OR
+    * every response in ``pr.responses`` is flagged ``error: True``
+      (per-question exceptions caught inside ``_run_panelist``), OR
+    * the panelist produced zero tokens *and* recorded no primary
+      non-errored response (the 400-on-every-call scenario from
+      sp-efip, where tokens stayed at 0 because every request was
+      rejected upstream).
+
+    The returned dict carries the models exercised and a few sample
+    per-persona error strings so downstream banners / MCP errors can
+    name the upstream failure (e.g. the bad model name and HTTP 400
+    the bead explicitly calls out).
+    """
+    if not panelist_results:
+        return {
+            "panelists": 0,
+            "models": [],
+            "sample_errors": [],
+            "summary": "orchestrator returned no panelist results",
+        }
+
+    models: set[str] = set()
+    sample_errors: list[tuple[str, str]] = []
+    all_failed = True
+
+    for pr in panelist_results:
+        model = getattr(pr, "model", None)
+        if model:
+            models.add(str(model))
+
+        pr_error = getattr(pr, "error", None)
+        responses = getattr(pr, "responses", []) or []
+        primary = [r for r in responses if isinstance(r, dict) and not r.get("follow_up")]
+        has_clean_primary = any(isinstance(r, dict) and not r.get("error") and r.get("response") for r in primary)
+
+        # A panelist is considered usable iff it produced at least one
+        # non-errored primary response. The bead explicitly calls out
+        # the "tokens=0 AND error set" short-circuit, which is already
+        # subsumed by "no clean primary response" — zero-token panelists
+        # whose only responses are error=True rows all fall here.
+        panelist_failed = bool(pr_error) or not has_clean_primary
+        if not panelist_failed:
+            all_failed = False
+            continue
+
+        err_msg = _first_error_message(pr)
+        if err_msg and len(sample_errors) < _MAX_SAMPLE_ERRORS:
+            persona = getattr(pr, "persona_name", "unknown")
+            sample_errors.append((str(persona), err_msg))
+
+    if not all_failed:
+        return None
+
+    return {
+        "panelists": len(panelist_results),
+        "models": sorted(models),
+        "sample_errors": sample_errors,
+        "summary": (f"{len(panelist_results)} panelist(s) produced no usable Q/A pairs"),
+    }
+
+
+def format_total_failure_message(diagnostic: dict[str, Any]) -> str:
+    """Render a single-line message naming failing models + sample error."""
+    models = diagnostic.get("models") or []
+    sample_errors = diagnostic.get("sample_errors") or []
+    parts = [f"Panel run produced no usable results: {diagnostic.get('summary', 'every panelist failed')}"]
+    if models:
+        parts.append(f"models: {', '.join(models)}")
+    if sample_errors:
+        persona, err = sample_errors[0]
+        parts.append(f"first error ({persona}): {err}")
+    return ". ".join(parts)
+
+
 logger = logging.getLogger(__name__)
 
 # Caps mirrored from the MCP server — the SDK inherits the same guardrails.
@@ -274,6 +389,16 @@ def run_panel_sync(
         persona_models=persona_models,
         extract_schema=extract_schema,
     )
+
+    # sp-efip: fail loud when every panelist produced no usable data.
+    # Without this, MCP callers see a normally-shaped "panel complete"
+    # result even when every request 400'd upstream.
+    total_failure = detect_total_failure(panelist_results)
+    if total_failure is not None:
+        raise PanelTotalFailureError(
+            format_total_failure_message(total_failure),
+            diagnostic=total_failure,
+        )
 
     panelist_usage = ZERO_USAGE
     result_dicts: list[dict[str, Any]] = []

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -15,6 +15,10 @@ from typing import Any
 
 import yaml
 
+from synth_panel._runners import (
+    detect_total_failure,
+    format_total_failure_message,
+)
 from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.cost import (
     ZERO_USAGE,
@@ -823,6 +827,29 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             top_p=top_p,
         )
         timer.stop()
+
+        # sp-efip: fail loud if every panelist of every model failed.
+        # Without this, ensemble runs with a knowingly-bad model name
+        # silently returned exit 0 + an empty-but-well-shaped result.
+        ensemble_panelists: list[PanelistResult] = []
+        for mr in ens_result.model_results:
+            ensemble_panelists.extend(mr.panelist_results)
+        ensemble_failure = detect_total_failure(ensemble_panelists)
+        if ensemble_failure is not None:
+            msg = format_total_failure_message(ensemble_failure)
+            print(_build_total_failure_banner(ensemble_failure), file=sys.stderr)
+            if fmt is not OutputFormat.TEXT:
+                emit(
+                    fmt,
+                    message=msg,
+                    extra={
+                        "run_invalid": True,
+                        "total_failure": ensemble_failure,
+                        "error": msg,
+                    },
+                )
+            return 2
+
         output = build_ensemble_output(ens_result)
         # sp-atvc: attach a metadata bundle whose cost.per_model covers
         # every ensemble model, not just the first in the spec.
@@ -924,6 +951,17 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     run_invalid = failure_stats["total_pairs"] > 0 and failure_stats["failure_rate"] > threshold
     strict_violation = strict and failure_stats["errored_pairs"] > 0
 
+    # sp-efip: separate total-failure short-circuit. _analyze_failures
+    # can report total_pairs==0 when every panelist bailed before
+    # recording any response (e.g. runtime init threw) — in that case
+    # the failure_rate math falls to 0 and run_invalid stays False.
+    # Regardless of the pair-rate, if no panelist produced usable data
+    # the run is invalid and the banner must name the failing model(s)
+    # and first upstream error.
+    total_failure = detect_total_failure(panelist_results)
+    if total_failure is not None:
+        run_invalid = True
+
     # sp-bjt4: detect the "polite refusal" failure mode — panelists returned
     # clean responses but uniformly flagged the question as unanswerable
     # because the source material never made it into the prompt. Without
@@ -1020,6 +1058,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         strict_violation=strict_violation,
         missing_input_stats=missing_input_stats,
         missing_input_invalid=missing_input_invalid,
+        total_failure=total_failure,
     )
 
     if fmt is OutputFormat.TEXT:
@@ -1109,6 +1148,13 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             # surfaces it — this is the critical fix for sp-2hg.
             print(banner, file=sys.stderr)
     else:
+        # sp-efip: mirror the TEXT-mode behaviour and print the fatal
+        # banner to stderr even when JSON/NDJSON is the primary output.
+        # Operators grep stderr for "PANEL RUN INVALID" in CI and the
+        # banner is where the failing model + upstream error surface.
+        if banner:
+            print(banner, file=sys.stderr)
+
         # sp-0h9x: always populate per_model_results + cost_breakdown, even
         # for single-model panels. mayor's ensemble audits use persona_models
         # (mixed-model mode) rather than the ``models=[...]`` ensemble path,
@@ -1167,6 +1213,11 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         extra["failure_stats"] = failure_stats
         extra["missing_input_stats"] = missing_input_stats
         extra["run_invalid"] = bool(run_invalid or strict_violation)
+        if total_failure is not None:
+            # sp-efip: carry the structured total-failure diagnostic so
+            # CI/MCP consumers can detect the "every panelist failed"
+            # case without parsing banner text.
+            extra["total_failure"] = total_failure
         if missing_input_invalid:
             # sp-bjt4: surface as a top-level warning so MCP / CI consumers
             # see the condition even if they don't special-case
@@ -1411,6 +1462,42 @@ def _detect_missing_input_refusals(
     }
 
 
+def _build_total_failure_banner(
+    total_failure: dict[str, Any],
+    stats: dict[str, Any] | None = None,
+) -> str:
+    """Render the sp-efip banner for a wholesale "every panelist failed" run.
+
+    Names the model(s) exercised and the first sample error so the user
+    sees the upstream failure (e.g. "OpenRouter API error 400: ...") at
+    the top of stderr — not buried inside a JSON blob or an aggregate
+    failure-rate line. Still prints the errored/total pair count when
+    available, so the aggregate sp-2hg diagnostic stays intact.
+    """
+    bar = "!" * 70
+    lines = [bar]
+    headline = (
+        f"PANEL RUN INVALID: every panelist failed"
+        f" ({total_failure.get('panelists', 0)} panelist(s), no usable Q/A pairs)"
+    )
+    if stats and stats.get("total_pairs"):
+        headline += f" — {stats['errored_pairs']}/{stats['total_pairs']} pairs errored"
+    lines.append(headline + ".")
+    models = total_failure.get("models") or []
+    if models:
+        lines.append(f"  Failing model(s): {', '.join(models)}")
+    sample_errors = total_failure.get("sample_errors") or []
+    for persona, err in sample_errors:
+        snippet = err.strip().splitlines()[0] if err else ""
+        if len(snippet) > 240:
+            snippet = snippet[:237] + "..."
+        lines.append(f"  {persona}: {snippet}")
+    lines.append("No synthesis was performed — the run produced no usable data.")
+    lines.append("Check the model name, provider credentials, and upstream status.")
+    lines.append(bar)
+    return "\n".join(lines)
+
+
 def _build_invalid_banner(
     stats: dict[str, Any],
     threshold: float,
@@ -1419,6 +1506,7 @@ def _build_invalid_banner(
     strict_violation: bool,
     missing_input_stats: dict[str, Any] | None = None,
     missing_input_invalid: bool = False,
+    total_failure: dict[str, Any] | None = None,
 ) -> str:
     """Render the fatal banner printed to stderr on an invalid run.
 
@@ -1431,8 +1519,14 @@ def _build_invalid_banner(
     errored = stats["errored_pairs"]
     rate = stats["failure_rate"] if total > 0 else 0.0
     over_threshold = total > 0 and rate > threshold
-    if not (over_threshold or strict_violation or missing_input_invalid):
+    if not (over_threshold or strict_violation or missing_input_invalid or total_failure):
         return ""
+
+    # sp-efip: total-wipeout banner takes precedence so the user sees
+    # the failing model and first upstream error at the top, not buried
+    # under aggregate failure-rate language.
+    if total_failure is not None:
+        return _build_total_failure_banner(total_failure, stats)
 
     bar = "!" * 70
     lines = [bar]

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -44,6 +44,8 @@ from synth_panel._runners import (
     MAX_PERSONAS,
     MAX_QUESTIONS,
     PANELIST_TIMEOUT,
+    PanelTotalFailureError,
+    detect_total_failure,
 )
 from synth_panel._runners import (
     compute_variant_data as _compute_variant_data,  # re-exported for back-compat
@@ -318,6 +320,7 @@ def _run_ensemble_sync(
     top_p: float | None = None,
 ) -> dict[str, Any]:
     """Run the same panel with each model and return comparative results."""
+    from synth_panel._runners import format_total_failure_message
     from synth_panel.ensemble import build_ensemble_output, ensemble_run
 
     client = LLMClient()
@@ -333,6 +336,20 @@ def _run_ensemble_sync(
         temperature=temperature,
         top_p=top_p,
     )
+
+    # sp-efip: fail loud when every panelist of every model failed.
+    # Without this, ensemble runs with a knowingly-bad model name
+    # returned a well-shaped result containing 0-token panelists.
+    ensemble_panelists: list[PanelistResult] = []
+    for mr in ens.model_results:
+        ensemble_panelists.extend(mr.panelist_results)
+    ensemble_failure = detect_total_failure(ensemble_panelists)
+    if ensemble_failure is not None:
+        raise PanelTotalFailureError(
+            format_total_failure_message(ensemble_failure),
+            diagnostic=ensemble_failure,
+        )
+
     return build_ensemble_output(ens, panelist_formatter=_format_panelist_result)
 
 
@@ -1042,16 +1059,27 @@ async def run_panel(
                 raw = pack_body.get("instrument", pack_body)
                 inst = parse_instrument(raw)
                 ens_questions = [{"text": q["text"]} for q in inst.questions]
-        ens_result = await asyncio.to_thread(
-            _run_ensemble_sync,
-            merged,
-            ens_questions,
-            models,
-            response_schema,
-            extract_schema,
-            temperature,
-            top_p,
-        )
+        try:
+            ens_result = await asyncio.to_thread(
+                _run_ensemble_sync,
+                merged,
+                ens_questions,
+                models,
+                response_schema,
+                extract_schema,
+                temperature,
+                top_p,
+            )
+        except PanelTotalFailureError as exc:
+            logger.error("run_panel ensemble: total failure: %s", exc)
+            return json.dumps(
+                {
+                    "error": str(exc),
+                    "run_invalid": True,
+                    "total_failure": exc.diagnostic,
+                },
+                indent=2,
+            )
         return json.dumps(ens_result, indent=2)
 
     # Resolve instrument source (pack > inline instrument > questions).
@@ -1065,9 +1093,41 @@ async def run_panel(
         instrument_obj = parse_instrument(raw)
 
     if instrument_obj is not None:
-        result = await _run_panel_async_instrument(
+        try:
+            result = await _run_panel_async_instrument(
+                merged,
+                instrument_obj,
+                model,
+                ctx,
+                response_schema,
+                synthesis=synthesis,
+                synthesis_model=synthesis_model,
+                synthesis_prompt=synthesis_prompt,
+                temperature=temperature,
+                top_p=top_p,
+                persona_models=persona_models,
+                extract_schema=resolved_extract_schema,
+                synthesis_temperature=synthesis_temperature,
+            )
+        except PanelTotalFailureError as exc:
+            logger.error("run_panel instrument: total failure: %s", exc)
+            return json.dumps(
+                {
+                    "error": str(exc),
+                    "run_invalid": True,
+                    "total_failure": exc.diagnostic,
+                },
+                indent=2,
+            )
+        return json.dumps(result, indent=2)
+
+    if not questions:
+        return json.dumps({"error": "No questions or instrument provided."})
+
+    try:
+        result = await _run_panel_async(
             merged,
-            instrument_obj,
+            questions,
             model,
             ctx,
             response_schema,
@@ -1079,28 +1139,18 @@ async def run_panel(
             persona_models=persona_models,
             extract_schema=resolved_extract_schema,
             synthesis_temperature=synthesis_temperature,
+            variants=variants_k,
         )
-        return json.dumps(result, indent=2)
-
-    if not questions:
-        return json.dumps({"error": "No questions or instrument provided."})
-
-    result = await _run_panel_async(
-        merged,
-        questions,
-        model,
-        ctx,
-        response_schema,
-        synthesis=synthesis,
-        synthesis_model=synthesis_model,
-        synthesis_prompt=synthesis_prompt,
-        temperature=temperature,
-        top_p=top_p,
-        persona_models=persona_models,
-        extract_schema=resolved_extract_schema,
-        synthesis_temperature=synthesis_temperature,
-        variants=variants_k,
-    )
+    except PanelTotalFailureError as exc:
+        logger.error("run_panel: total failure: %s", exc)
+        return json.dumps(
+            {
+                "error": str(exc),
+                "run_invalid": True,
+                "total_failure": exc.diagnostic,
+            },
+            indent=2,
+        )
     return json.dumps(result, indent=2)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -900,6 +900,243 @@ class TestPanelRun:
         assert data["failure_stats"]["failure_rate"] == 1.0
         mock_synth.assert_not_called()
 
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_total_failure_names_model_and_upstream_error(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """sp-efip: a knowingly-bad model name that 400s on every call must
+        exit non-zero and name the failing model + upstream status on stderr.
+
+        Regression guard: previously the CLI returned a normally-shaped
+        result with 0-token panelists and a misleading "panel complete"
+        exit code when every request was rejected upstream.
+        """
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        upstream_err = "OpenRouter API error 400: invalid model 'haiku:0.25' is not a recognized identifier"
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[
+                        {"question": "Q1", "response": f"[error: {upstream_err}]", "error": True},
+                    ],
+                    usage=ZERO_USAGE,
+                    model="haiku:0.25",
+                ),
+                PanelistResult(
+                    persona_name="Bob",
+                    responses=[
+                        {"question": "Q1", "response": f"[error: {upstream_err}]", "error": True},
+                    ],
+                    usage=ZERO_USAGE,
+                    model="haiku:0.25",
+                ),
+            ],
+            registry,
+            {},
+        )
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q1\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "haiku:0.25",
+            ]
+        )
+        assert code == 2
+        captured = capsys.readouterr()
+        # Banner on stderr must name the failing model and the 400 status.
+        assert "PANEL RUN INVALID" in captured.err
+        assert "haiku:0.25" in captured.err
+        assert "400" in captured.err
+        # JSON payload must carry the structured diagnostic for MCP/CI.
+        data = json.loads(captured.out)
+        assert data["run_invalid"] is True
+        assert data["total_failure"]["panelists"] == 2
+        assert data["total_failure"]["models"] == ["haiku:0.25"]
+        assert data["total_failure"]["sample_errors"], "sample_errors must be populated"
+        first_persona, first_err = data["total_failure"]["sample_errors"][0]
+        assert first_persona in {"Alice", "Bob"}
+        assert "400" in first_err
+        mock_synth.assert_not_called()
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_panel_run_total_failure_when_every_panelist_exploded(
+        self, mock_client_cls, mock_run, mock_synth, capsys, tmp_path
+    ):
+        """sp-efip: wholesale panelist exceptions (pr.error set, responses
+        empty) must also trigger the total-failure banner even if the
+        aggregate failure rate somehow rounds to the threshold."""
+        from synth_panel.orchestrator import PanelistResult, WorkerRegistry
+
+        registry = WorkerRegistry()
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[],
+                    usage=ZERO_USAGE,
+                    error="OpenRouter API error 400: bad model 'haiku:0.25'",
+                    model="haiku:0.25",
+                ),
+            ],
+            registry,
+            {},
+        )
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q1\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+            ]
+        )
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "PANEL RUN INVALID" in captured.err
+        assert "haiku:0.25" in captured.err
+        assert "400" in captured.err
+        mock_synth.assert_not_called()
+
+
+# --- sp-efip: total-failure detector unit tests ---------------------------
+
+
+class TestDetectTotalFailure:
+    """Unit coverage for the shared helper that the CLI + MCP both use."""
+
+    def test_detects_all_error_responses(self):
+        from synth_panel._runners import detect_total_failure
+        from synth_panel.orchestrator import PanelistResult
+
+        results = [
+            PanelistResult(
+                persona_name="Alice",
+                responses=[{"question": "Q", "response": "[error: 400]", "error": True}],
+                usage=ZERO_USAGE,
+                model="haiku:0.25",
+            ),
+        ]
+        failure = detect_total_failure(results)
+        assert failure is not None
+        assert failure["panelists"] == 1
+        assert failure["models"] == ["haiku:0.25"]
+        assert failure["sample_errors"][0][0] == "Alice"
+        assert "400" in failure["sample_errors"][0][1]
+
+    def test_detects_wholesale_panelist_error(self):
+        from synth_panel._runners import detect_total_failure
+        from synth_panel.orchestrator import PanelistResult
+
+        results = [
+            PanelistResult(
+                persona_name="Alice",
+                responses=[],
+                usage=ZERO_USAGE,
+                error="provider 400",
+                model="bad-model",
+            ),
+        ]
+        failure = detect_total_failure(results)
+        assert failure is not None
+        assert failure["models"] == ["bad-model"]
+        assert failure["sample_errors"][0] == ("Alice", "provider 400")
+
+    def test_returns_none_when_any_panelist_has_usable_data(self):
+        from synth_panel._runners import detect_total_failure
+        from synth_panel.orchestrator import PanelistResult
+
+        results = [
+            PanelistResult(
+                persona_name="Alice",
+                responses=[{"question": "Q", "response": "[error: boom]", "error": True}],
+                usage=ZERO_USAGE,
+                model="m1",
+            ),
+            PanelistResult(
+                persona_name="Bob",
+                responses=[{"question": "Q", "response": "a real answer"}],
+                usage=TokenUsage(input_tokens=10, output_tokens=5),
+                model="m1",
+            ),
+        ]
+        assert detect_total_failure(results) is None
+
+    def test_empty_results_is_total_failure(self):
+        from synth_panel._runners import detect_total_failure
+
+        failure = detect_total_failure([])
+        assert failure is not None
+        assert failure["panelists"] == 0
+
+
+# --- sp-efip: run_panel_sync raises on total failure ----------------------
+
+
+class TestRunPanelSyncTotalFailure:
+    """The shared runner used by MCP + SDK must raise, not silently return
+    a 'success' envelope, when every panelist failed."""
+
+    @patch("synth_panel._runners.run_panel_parallel")
+    def test_raises_when_every_panelist_errored(self, mock_run):
+        from synth_panel._runners import PanelTotalFailureError, run_panel_sync
+        from synth_panel.orchestrator import PanelistResult
+
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="Alice",
+                    responses=[{"question": "Q", "response": "[error: 400]", "error": True}],
+                    usage=ZERO_USAGE,
+                    model="haiku:0.25",
+                ),
+            ],
+            None,
+            {},
+        )
+
+        client = MagicMock()
+        with pytest.raises(PanelTotalFailureError) as excinfo:
+            run_panel_sync(
+                client=client,
+                personas=[{"name": "Alice"}],
+                questions=[{"text": "Q"}],
+                model="haiku:0.25",
+                synthesis=False,
+            )
+        assert "haiku:0.25" in str(excinfo.value)
+        assert "400" in str(excinfo.value)
+        diag = excinfo.value.diagnostic
+        assert diag["models"] == ["haiku:0.25"]
+
 
 # --- sp-bjt4: missing-input refusal detection -----------------------------
 


### PR DESCRIPTION
## Summary
- Fail loudly (non-zero exit + clear error) when every panelist produced no usable data, instead of silently writing an empty result file that looks successful

## Source
- Polecat: nux
- Issue: sp-efip
- MR: sp-wisp-anz
- Branch: polecat/nux-mo937oy8

## Test plan
- [ ] CI passes (updated coverage in test_cli.py)
- [ ] Panel run where all panelists error exits non-zero with an explanatory message, instead of emitting an empty results JSON

## Conflict note
Touches src/synth_panel/cli/commands.py and src/synth_panel/mcp/server.py — overlaps with open CLI/MCP PRs (#196, #198, #218). Rebase likely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)