### PR TITLE
fix(cost): route per-model and per-panelist cost through resolve_cost (sp-kvpx)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Fixed
+- (sp-kvpx) Cost: route per-model and per-panelist cost through `resolve_cost` so `cost_breakdown.total`, `per_model_results[*].cost`, and per-panelist `cost` honor sp-j3vk's provider-reported precedence. Prior to this, `ensemble_run`, `build_mixed_model_rollup`, the sync MCP/SDK runner, and `format_panelist_result` all called `estimate_cost(usage, lookup_pricing(model))` directly, so every non-top-level cost in the ensemble payload stayed on the local pricing table. Observed divergence in the mayor round-5 audit: `total_cost=$0.27` (authoritative) vs `cost_breakdown.total=$0.71` on the same panel.
+
 ### Added
 - (sp-ftr) Ship the advertised `/synthpanel-poll` slash command. `commands/synthpanel-poll.md` wraps the `run_quick_poll` MCP tool so installed plugin users get a one-shot poll command — sp-tcf claimed this was done but never actually added the file.
 

--- a/src/synth_panel/_runners.py
+++ b/src/synth_panel/_runners.py
@@ -15,7 +15,7 @@ import logging
 from collections import Counter
 from typing import Any
 
-from synth_panel.cost import ZERO_USAGE, estimate_cost, lookup_pricing
+from synth_panel.cost import ZERO_USAGE, resolve_cost
 from synth_panel.cost import TokenUsage as CostTokenUsage
 from synth_panel.instrument import Instrument
 from synth_panel.llm.client import LLMClient
@@ -229,8 +229,13 @@ def resolve_extract_schema(
 def format_panelist_result(pr: PanelistResult, model: str) -> dict[str, Any]:
     """Render a :class:`PanelistResult` into the serialisable dict shape callers expect."""
     pr_model = pr.model or model
-    pricing, _ = lookup_pricing(pr_model)
-    persona_cost = estimate_cost(pr.usage, pricing)
+    # sp-kvpx: route through resolve_cost so per-panelist ``cost`` honors
+    # sp-j3vk's precedence (provider-reported → local fallback). Prior to
+    # this, ensemble/mixed-model runs quoted per-persona cost from the
+    # local pricing table regardless of what the provider actually billed,
+    # so ``per_model_results[*].results[i].cost`` drifted from the top-level
+    # ``total_cost`` by the same ratio sp-j3vk fixed at the aggregate layer.
+    persona_cost = resolve_cost(pr.usage, pr_model)
     rd: dict[str, Any] = {
         "persona": pr.persona_name,
         "responses": pr.responses,
@@ -406,8 +411,9 @@ def run_panel_sync(
         result_dicts.append(format_panelist_result(pr, model))
         panelist_usage = panelist_usage + pr.usage
 
-    pricing, _ = lookup_pricing(model)
-    panelist_cost = estimate_cost(panelist_usage, pricing)
+    # sp-kvpx: use resolve_cost so panelist_cost honors sp-j3vk precedence
+    # (provider-reported → local fallback) for the MCP/SDK sync path too.
+    panelist_cost = resolve_cost(panelist_usage, model)
 
     base_results = [pr for pr in panelist_results if pr.persona_name not in variant_names]
     synthesis_dict: dict[str, Any] | None = None

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -19,8 +19,7 @@ from synth_panel.cost import (
     CostEstimate,
     TokenUsage,
     build_cost_fallback_warnings,
-    estimate_cost,
-    lookup_pricing,
+    resolve_cost,
 )
 from synth_panel.llm.client import LLMClient
 from synth_panel.orchestrator import PanelistResult, run_panel_parallel
@@ -125,8 +124,14 @@ def ensemble_run(
         for pr in panelist_results:
             model_usage = model_usage + pr.usage
 
-        pricing, _ = lookup_pricing(model)
-        model_cost = estimate_cost(model_usage, pricing)
+        # sp-kvpx: route through resolve_cost so per-model cost honors
+        # sp-j3vk's precedence (provider-reported → local fallback). The
+        # prior ``estimate_cost(model_usage, pricing)`` ignored the
+        # summed ``usage.provider_reported_cost``, so ensemble
+        # ``cost_breakdown`` / ``per_model_cost`` drifted from the
+        # authoritative top-level total for every model whose local
+        # pricing entry diverged from the real OpenRouter bill.
+        model_cost = resolve_cost(model_usage, model)
 
         # Tag each result with its model
         for pr in panelist_results:
@@ -310,8 +315,8 @@ def build_mixed_model_rollup(
         model_usage = ZERO_USAGE
         for pr in prs:
             model_usage = model_usage + pr.usage
-        pricing, _ = lookup_pricing(model_name)
-        model_cost = estimate_cost(model_usage, pricing)
+        # sp-kvpx: resolve_cost for per-model mixed-model rollup too.
+        model_cost = resolve_cost(model_usage, model_name)
         per_model_results[model_name] = {
             "results": [fmt(pr, model_name) for pr in prs],
             "cost": model_cost.format_usd(),

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -692,6 +692,78 @@ class TestEnsembleRun:
                 assert row["cost"] != "$0.0000"
                 assert row["error"] is None
 
+    def test_format_panelist_result_honors_provider_reported(self):
+        """sp-kvpx regression: per-panelist cost must use resolve_cost.
+
+        ``format_panelist_result`` is the common formatter used by ensemble,
+        mixed-model rollups, and SDK output. It previously always quoted
+        the local pricing estimate, so per-persona ``cost`` in
+        ``per_model_results[*].results[i]`` drifted from the top-level
+        authoritative number any time the provider bill and the local
+        rate differed (or the local entry was missing and fell through
+        to DEFAULT_PRICING).
+        """
+        from synth_panel._runners import format_panelist_result
+        from synth_panel.cost import TokenUsage as CostTokenUsage
+
+        pr = PanelistResult(
+            persona_name="Alice",
+            responses=[{"question": "Q1", "response": "ok", "error": False}],
+            usage=CostTokenUsage(input_tokens=100, output_tokens=50, provider_reported_cost=0.1234),
+            model="haiku",
+        )
+        row = format_panelist_result(pr, "haiku")
+        # Provider-reported cost wins over any local table estimate.
+        assert row["cost"] == "$0.1234"
+
+    def test_ensemble_cost_honors_provider_reported(self):
+        """sp-kvpx regression: ensemble_run per-model cost must use resolve_cost.
+
+        Prior to the fix, ``ensemble_run`` called
+        ``estimate_cost(model_usage, lookup_pricing(model))`` directly,
+        bypassing sp-j3vk's provider-reported precedence. A model whose
+        panelists reported ``usage.provider_reported_cost=0.42`` would
+        still be billed at the local-table rate, so ``per_model_cost``
+        (and therefore ``cost_breakdown`` in the public payload) drifted
+        from the authoritative top-level total.
+        """
+        from unittest.mock import patch as _patch
+
+        from synth_panel.cost import TokenUsage as CostTokenUsage
+        from synth_panel.ensemble import ensemble_run as _ensemble_run
+
+        def mock_with_provider_cost(**kwargs):
+            model = kwargs["model"]
+            personas = kwargs["personas"]
+            # Each panelist reports a wildly different cost from what the
+            # local pricing table would estimate for 100/50 tokens. If the
+            # fix works, that's the number that propagates; if it regresses,
+            # the per-model cost stays at the local-table estimate.
+            results = [
+                PanelistResult(
+                    persona_name=p["name"],
+                    responses=[{"question": "Q1", "response": "ok", "error": False}],
+                    usage=CostTokenUsage(
+                        input_tokens=100,
+                        output_tokens=50,
+                        provider_reported_cost=0.42,
+                    ),
+                    model=model,
+                )
+                for p in personas
+            ]
+            return results, MagicMock(), {p["name"]: MagicMock() for p in personas}
+
+        personas = [{"name": "Alice"}, {"name": "Bob"}]
+        with _patch("synth_panel.ensemble.run_panel_parallel") as mock_rpp:
+            mock_rpp.side_effect = mock_with_provider_cost
+            ens = _ensemble_run(personas, [{"text": "Q1"}], ["haiku"], MagicMock())
+
+        # Two panelists × $0.42 provider-reported = $0.84 authoritative.
+        assert ens.model_results[0].cost.total_cost == pytest.approx(0.84)
+        assert ens.per_model_cost["haiku"] == "$0.8400"
+        assert ens.total_cost.total_cost == pytest.approx(0.84)
+
 
 # ---------------------------------------------------------------------------
 # Tests: build_ensemble_output (public JSON shape)


### PR DESCRIPTION
## Summary

Extends sp-j3vk's provider-reported cost precedence to the remaining four cost call sites. Without this, `cost_breakdown` and `per_model_results[*].cost` stayed on the local pricing table even when the provider reported an authoritative billed cost — leading to the divergence observed in the mayor round-5 audit:

- `total_cost = $0.27` (authoritative, via `aggregate_per_model → resolve_cost`)
- `cost_breakdown.total = $0.71` (local-table estimates summed)

Same panel, same usage. 2.6× inflation on the per-model breakdown because deepseek-v3 was falling through to `DEFAULT_PRICING` and Anthropic-direct returns no provider cost so the whole ensemble stayed on the stale local rate.

## Sites fixed

- `src/synth_panel/ensemble.py:128-129` — `ensemble_run` per-model cost
- `src/synth_panel/ensemble.py:318-319` — `build_mixed_model_rollup` per-model cost
- `src/synth_panel/_runners.py:232-233` — `format_panelist_result` per-panelist cost (feeds `per_model_results[*].results[i].cost` via sp-hwe)
- `src/synth_panel/_runners.py:414-415` — sync MCP/SDK `panelist_cost`

All four now call `resolve_cost(usage, model)`, which uses provider-reported when present and falls back to the local pricing table otherwise — the same precedence sp-j3vk established for the top-level total.

## Test plan

- [x] `tests/test_ensemble.py::test_ensemble_cost_honors_provider_reported` — asserts `ensemble_run` per-model cost uses provider-reported when set
- [x] `tests/test_ensemble.py::test_format_panelist_result_honors_provider_reported` — asserts per-panelist cost uses provider-reported when set
- [x] Full test suite: 1201 passed (excluding two pre-existing local-env failures unrelated to this change)
- [x] ruff check + format clean

Bead: sp-kvpx (P1)