### PR TITLE
feat(analysis): response_schema validation + deterministic distributions (sp-2hpi)

### DIFF
--- a/src/synth_panel/analysis/__init__.py
+++ b/src/synth_panel/analysis/__init__.py
@@ -1,19 +1,46 @@
-"""Panel-result analysis utilities (inspection, schema walking).
+"""Panel-result analysis utilities.
 
-This package intentionally stays narrow: heavy statistical analysis
-lives in :mod:`synth_panel.analyze`. Here we collect lightweight,
-no-LLM result introspection helpers that downstream tooling (CLI,
-MCP, CI gates) can compose.
+Two layers live here:
+
+* Inspection helpers (:mod:`synth_panel.analysis.inspect`) — schema
+  walkers and no-LLM result summaries.
+* Structured-response aggregation (sp-2hpi scaffolding) —
+  :mod:`synth_panel.analysis.distribution` computes per-question
+  distributions from ``response_schema``-typed responses, and
+  :mod:`synth_panel.analysis.subgroup` splits those distributions by
+  persona field.
+
+Heavy statistical analysis that's entangled with the legacy
+narrative-synthesis pipeline continues to live in
+:mod:`synth_panel.analyze`.
 """
 
+from synth_panel.analysis.distribution import (
+    InvalidResponseSchemaError,
+    coerce_enum_value,
+    coerce_scale_value,
+    coerce_tagged_themes,
+    distribution_for_question,
+)
 from synth_panel.analysis.inspect import (
     InspectReport,
     build_inspect_report,
     format_inspect_text,
 )
+from synth_panel.analysis.subgroup import (
+    UnknownPersonaFieldError,
+    subgroup_breakdown,
+)
 
 __all__ = [
     "InspectReport",
+    "InvalidResponseSchemaError",
+    "UnknownPersonaFieldError",
     "build_inspect_report",
+    "coerce_enum_value",
+    "coerce_scale_value",
+    "coerce_tagged_themes",
+    "distribution_for_question",
     "format_inspect_text",
+    "subgroup_breakdown",
 ]

--- a/src/synth_panel/analysis/distribution.py
+++ b/src/synth_panel/analysis/distribution.py
@@ -1,0 +1,323 @@
+"""Deterministic distributions over structured panelist responses (sp-2hpi).
+
+Given a question's ``response_schema`` and the per-panelist raw responses,
+this module computes a distribution summary without any LLM call:
+
+* ``scale``  — frequency table, mean, median, stdev, min, max
+* ``enum``   — frequency table over the declared options (zero-filled)
+* ``tagged_themes`` — per-tag frequency over the declared taxonomy
+  (zero-filled), with a bucket for off-taxonomy ``other`` themes
+* ``text``   — only ``n`` and ``n_nonempty`` (text carries no
+  distribution on its own; extraction lives upstream)
+
+The output is intentionally plain dicts/lists so the result can be
+serialized directly into the panel result's ``analysis`` section.
+This module is the scaffolding the narrative-over-stats and
+``--analysis-mode`` layers will ride on top of in follow-up work.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Any
+
+__all__ = [
+    "InvalidResponseSchemaError",
+    "coerce_enum_value",
+    "coerce_scale_value",
+    "coerce_tagged_themes",
+    "distribution_for_question",
+]
+
+
+_RECOGNIZED_TYPES: frozenset[str] = frozenset({"text", "scale", "enum", "tagged_themes"})
+
+
+class InvalidResponseSchemaError(ValueError):
+    """Raised when a response_schema lacks a recognized ``type``.
+
+    Matches the contract in :mod:`synth_panel.instrument`: a ``response_schema``
+    dict without a recognized ``type`` is treated as a legacy inline JSON
+    Schema by the parser. This module only computes distributions for the
+    *semantic* types, so callers must pre-filter.
+    """
+
+
+def distribution_for_question(
+    responses: list[Any],
+    response_schema: dict[str, Any],
+) -> dict[str, Any]:
+    """Compute a distribution summary for one question's responses.
+
+    Args:
+        responses: Raw per-panelist response values. Shape depends on
+            ``response_schema['type']``; unparseable entries are counted
+            as ``n_invalid``, not dropped silently.
+        response_schema: Question-level schema as validated by
+            :func:`synth_panel.instrument._validate_response_schema`.
+
+    Returns:
+        A plain dict with at least ``type``, ``n`` (total responses),
+        ``n_valid``, and ``n_invalid``. Shape beyond that is type-specific
+        — see module docstring.
+
+    Raises:
+        InvalidResponseSchemaError: If ``response_schema`` is missing a
+            recognized ``type``.
+    """
+    t = response_schema.get("type") if isinstance(response_schema, dict) else None
+    if t not in _RECOGNIZED_TYPES:
+        raise InvalidResponseSchemaError(f"response_schema must have type in {sorted(_RECOGNIZED_TYPES)}, got {t!r}")
+
+    n = len(responses)
+    if t == "scale":
+        return _scale_distribution(responses, response_schema, n)
+    if t == "enum":
+        return _enum_distribution(responses, response_schema, n)
+    if t == "tagged_themes":
+        return _tagged_themes_distribution(responses, response_schema, n)
+    return _text_distribution(responses, n)
+
+
+# ---------------------------------------------------------------------------
+# Scale
+# ---------------------------------------------------------------------------
+
+
+def coerce_scale_value(value: Any, lo: int, hi: int) -> int | None:
+    """Return a clamped integer scale value, or ``None`` if uncoerceable.
+
+    Accepts ints, floats (rounded half-to-even per ``round()``),
+    and numeric strings. Values outside [lo, hi] return ``None`` —
+    the caller decides whether to clamp or count as invalid.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        iv = value
+    elif isinstance(value, float):
+        if math.isnan(value) or math.isinf(value):
+            return None
+        iv = round(value)
+    elif isinstance(value, str):
+        s = value.strip()
+        if not s:
+            return None
+        try:
+            iv = round(float(s))
+        except ValueError:
+            return None
+    else:
+        return None
+    if iv < lo or iv > hi:
+        return None
+    return iv
+
+
+def _scale_distribution(responses: list[Any], schema: dict[str, Any], n: int) -> dict[str, Any]:
+    lo = int(schema["min"])
+    hi = int(schema["max"])
+    coerced = [coerce_scale_value(r, lo, hi) for r in responses]
+    valid = [v for v in coerced if v is not None]
+    n_valid = len(valid)
+    n_invalid = n - n_valid
+
+    # Zero-filled frequency table across the full integer range so callers
+    # can render a histogram without post-processing.
+    freq_counter = Counter(valid)
+    distribution = [{"value": v, "count": freq_counter.get(v, 0)} for v in range(lo, hi + 1)]
+
+    stats: dict[str, Any] = {
+        "min": lo,
+        "max": hi,
+        "n_valid": n_valid,
+        "n_invalid": n_invalid,
+    }
+    if n_valid:
+        mean = sum(valid) / n_valid
+        stats["mean"] = round(mean, 4)
+        stats["median"] = _median(valid)
+        if n_valid > 1:
+            var = sum((v - mean) ** 2 for v in valid) / (n_valid - 1)
+            stats["stdev"] = round(math.sqrt(var), 4)
+        else:
+            stats["stdev"] = 0.0
+        stats["observed_min"] = min(valid)
+        stats["observed_max"] = max(valid)
+
+    return {
+        "type": "scale",
+        "n": n,
+        "n_valid": n_valid,
+        "n_invalid": n_invalid,
+        "distribution": distribution,
+        "stats": stats,
+    }
+
+
+def _median(values: list[int]) -> float:
+    s = sorted(values)
+    m = len(s)
+    mid = m // 2
+    if m % 2:
+        return float(s[mid])
+    return round((s[mid - 1] + s[mid]) / 2, 4)
+
+
+# ---------------------------------------------------------------------------
+# Enum
+# ---------------------------------------------------------------------------
+
+
+def coerce_enum_value(value: Any, options: list[str]) -> str | None:
+    """Match a free response to an enum option (case-insensitive, trimmed).
+
+    Returns the canonical option string as declared in ``options`` when a
+    match is found, or ``None`` otherwise. An exact match always wins over
+    a case-insensitive one.
+    """
+    if not isinstance(value, str):
+        return None
+    s = value.strip()
+    if not s:
+        return None
+    if s in options:
+        return s
+    lowered = s.lower()
+    for opt in options:
+        if opt.lower() == lowered:
+            return opt
+    return None
+
+
+def _enum_distribution(responses: list[Any], schema: dict[str, Any], n: int) -> dict[str, Any]:
+    options: list[str] = list(schema["options"])
+    coerced = [coerce_enum_value(r, options) for r in responses]
+    valid = [v for v in coerced if v is not None]
+    n_valid = len(valid)
+    n_invalid = n - n_valid
+
+    counter = Counter(valid)
+    distribution = [{"option": opt, "count": counter.get(opt, 0)} for opt in options]
+
+    top_option: str | None = None
+    if n_valid:
+        # Stable: options are iterated in declaration order — the first
+        # option that ties for the max count is returned.
+        top_option = max(options, key=lambda o: counter.get(o, 0))
+        if counter.get(top_option, 0) == 0:
+            top_option = None
+
+    return {
+        "type": "enum",
+        "n": n,
+        "n_valid": n_valid,
+        "n_invalid": n_invalid,
+        "options": options,
+        "distribution": distribution,
+        "top_option": top_option,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tagged themes
+# ---------------------------------------------------------------------------
+
+
+def coerce_tagged_themes(value: Any, taxonomy: list[str], *, multi: bool) -> tuple[list[str], list[str]] | None:
+    """Split a response into (in-taxonomy tags, off-taxonomy tags).
+
+    Accepts a list of strings, a single string (which becomes a 1-element
+    list), or a delimited string (comma / semicolon / pipe / newline). When
+    ``multi`` is False, only the first tag is kept. Returns ``None`` if the
+    input cannot be coerced into any tag list.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        parts: list[str] = []
+        buf = value
+        for delim in (",", ";", "|", "\n"):
+            buf = buf.replace(delim, "\x00")
+        parts = [p.strip() for p in buf.split("\x00") if p.strip()]
+    elif isinstance(value, (list, tuple)):
+        parts = [str(p).strip() for p in value if str(p).strip()]
+    else:
+        return None
+
+    if not parts:
+        return None
+
+    if not multi:
+        parts = parts[:1]
+
+    lowered = {tag.lower(): tag for tag in taxonomy}
+    in_tax: list[str] = []
+    off_tax: list[str] = []
+    for p in parts:
+        canon = lowered.get(p.lower())
+        if canon is not None:
+            if canon not in in_tax:
+                in_tax.append(canon)
+        else:
+            if p not in off_tax:
+                off_tax.append(p)
+    return in_tax, off_tax
+
+
+def _tagged_themes_distribution(responses: list[Any], schema: dict[str, Any], n: int) -> dict[str, Any]:
+    taxonomy: list[str] = list(schema["taxonomy"])
+    multi: bool = bool(schema.get("multi", False))
+
+    tag_counter: Counter[str] = Counter()
+    off_counter: Counter[str] = Counter()
+    n_valid = 0
+    total_mentions = 0
+    for r in responses:
+        coerced = coerce_tagged_themes(r, taxonomy, multi=multi)
+        if coerced is None:
+            continue
+        in_tax, off_tax = coerced
+        if in_tax or off_tax:
+            n_valid += 1
+            total_mentions += len(in_tax) + len(off_tax)
+        for tag in in_tax:
+            tag_counter[tag] += 1
+        for tag in off_tax:
+            off_counter[tag] += 1
+
+    n_invalid = n - n_valid
+    distribution = [{"theme": tag, "count": tag_counter.get(tag, 0)} for tag in taxonomy]
+    off_taxonomy = [
+        {"theme": tag, "count": count} for tag, count in sorted(off_counter.items(), key=lambda kv: (-kv[1], kv[0]))
+    ]
+
+    return {
+        "type": "tagged_themes",
+        "n": n,
+        "n_valid": n_valid,
+        "n_invalid": n_invalid,
+        "multi": multi,
+        "taxonomy": taxonomy,
+        "distribution": distribution,
+        "off_taxonomy": off_taxonomy,
+        "total_mentions": total_mentions,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Text
+# ---------------------------------------------------------------------------
+
+
+def _text_distribution(responses: list[Any], n: int) -> dict[str, Any]:
+    n_nonempty = sum(
+        1 for r in responses if (isinstance(r, str) and r.strip()) or (r is not None and not isinstance(r, str))
+    )
+    return {
+        "type": "text",
+        "n": n,
+        "n_valid": n_nonempty,
+        "n_invalid": n - n_nonempty,
+    }

--- a/src/synth_panel/analysis/subgroup.py
+++ b/src/synth_panel/analysis/subgroup.py
@@ -1,0 +1,168 @@
+"""Subgroup breakdowns over structured responses (sp-2hpi).
+
+Pair a persona-field key with per-panelist responses and this module
+returns a nested distribution: one bucket per observed value of the
+persona field, each bucket carrying the same distribution shape
+:func:`synth_panel.analysis.distribution.distribution_for_question`
+produces for the whole panel.
+
+This is the scaffold the ``--analysis-mode structured`` layer will use
+to emit ``subgroup_breakdowns`` alongside the top-level ``distribution``.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Any
+
+from synth_panel.analysis.distribution import distribution_for_question
+
+__all__ = [
+    "UnknownPersonaFieldError",
+    "subgroup_breakdown",
+]
+
+
+class UnknownPersonaFieldError(KeyError):
+    """Raised when a requested persona field is missing from every persona."""
+
+
+def subgroup_breakdown(
+    responses: list[Any],
+    personas: list[dict[str, Any]],
+    *,
+    field: str,
+    response_schema: dict[str, Any],
+    age_bands: list[tuple[int, int]] | None = None,
+    missing_label: str = "unknown",
+) -> dict[str, Any]:
+    """Return per-subgroup distributions for one question.
+
+    Responses and personas are paired positionally — caller is responsible
+    for keeping the two lists aligned (``results[i].persona`` matches
+    ``responses[i]``).
+
+    Args:
+        responses: Per-panelist responses to aggregate.
+        personas: Persona dicts in the same order as ``responses``.
+        field: Persona key to group by (e.g. ``"occupation"``, ``"age"``).
+        response_schema: Question-level schema (forwarded unchanged to the
+            inner :func:`distribution_for_question`).
+        age_bands: Optional list of inclusive ``(lo, hi)`` pairs to bucket
+            numeric age values. Applied only when ``field == "age"`` and
+            the persona value is an int/float. Out-of-band ages fall into
+            ``missing_label``.
+        missing_label: Bucket label for personas that lack the field or
+            whose value is ``None``.
+
+    Returns:
+        Dict with ``field``, ``n_buckets``, and ``buckets`` — a list of
+        ``{"label", "n", "distribution": {...}}`` entries sorted by bucket
+        label for deterministic output (age bands keep declaration order).
+
+    Raises:
+        ValueError: If ``len(responses) != len(personas)``.
+        UnknownPersonaFieldError: If *no* persona carries the requested
+            field (a partial presence is tolerated — missing personas go
+            into ``missing_label``).
+    """
+    if len(responses) != len(personas):
+        raise ValueError(f"responses and personas must be the same length ({len(responses)} vs {len(personas)})")
+
+    use_bands = field == "age" and age_bands is not None
+    if use_bands:
+        bands = _validate_age_bands(age_bands or [])
+
+    buckets: OrderedDict[str, list[Any]] = OrderedDict()
+    if use_bands:
+        for lo, hi in bands:
+            buckets[_band_label(lo, hi)] = []
+    any_present = False
+
+    for resp, persona in zip(responses, personas):
+        if field in persona:
+            any_present = True
+        raw = persona.get(field)
+        if use_bands and _is_numeric(raw):
+            label = _band_for_age(float(raw), bands) or missing_label
+        else:
+            label = _label_for(raw, missing_label)
+        buckets.setdefault(label, []).append(resp)
+
+    if not any_present:
+        raise UnknownPersonaFieldError(f"persona field {field!r} missing from every persona")
+
+    bucket_list: list[dict[str, Any]] = []
+    labels: list[str]
+    if use_bands:
+        labels = list(buckets.keys())  # preserve declared band order + tail
+        # Ensure missing_label goes last if present
+        if missing_label in labels:
+            labels = [lbl for lbl in labels if lbl != missing_label] + [missing_label]
+    else:
+        # Deterministic ordering: non-missing labels alphabetically, then missing_label.
+        named = sorted(lbl for lbl in buckets if lbl != missing_label)
+        labels = named + ([missing_label] if missing_label in buckets else [])
+
+    for label in labels:
+        values = buckets.get(label, [])
+        bucket_list.append(
+            {
+                "label": label,
+                "n": len(values),
+                "distribution": distribution_for_question(values, response_schema),
+            }
+        )
+
+    return {
+        "field": field,
+        "n_buckets": len(bucket_list),
+        "buckets": bucket_list,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_numeric(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _validate_age_bands(bands: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    cleaned: list[tuple[int, int]] = []
+    for i, band in enumerate(bands):
+        if (
+            not isinstance(band, tuple)
+            or len(band) != 2
+            or not all(isinstance(x, int) and not isinstance(x, bool) for x in band)
+        ):
+            raise ValueError(f"age_bands[{i}] must be a (lo, hi) tuple of ints")
+        lo, hi = band
+        if lo > hi:
+            raise ValueError(f"age_bands[{i}]: lo ({lo}) must be <= hi ({hi})")
+        cleaned.append((lo, hi))
+    return cleaned
+
+
+def _band_label(lo: int, hi: int) -> str:
+    return f"{lo}-{hi}"
+
+
+def _band_for_age(age: float, bands: list[tuple[int, int]]) -> str | None:
+    for lo, hi in bands:
+        if lo <= age <= hi:
+            return _band_label(lo, hi)
+    return None
+
+
+def _label_for(raw: Any, missing_label: str) -> str:
+    if raw is None:
+        return missing_label
+    if isinstance(raw, bool):
+        return "true" if raw else "false"
+    if isinstance(raw, (list, tuple)):
+        # Stringify lists deterministically so callers get a stable label.
+        return "|".join(str(x) for x in raw)
+    return str(raw)

--- a/src/synth_panel/instrument.py
+++ b/src/synth_panel/instrument.py
@@ -87,12 +87,77 @@ class InstrumentError(ValueError):
     """Raised when an instrument definition is invalid."""
 
 
-def _validate_questions(questions: list[dict[str, Any]], context: str) -> None:
-    """Validate extraction_schema on questions.
+_RESPONSE_SCHEMA_TYPES: frozenset[str] = frozenset({"text", "scale", "enum", "tagged_themes"})
 
-    String values are checked against the bundled schema registry.
-    Dict values are accepted as inline JSON Schemas without further
-    validation. Other types raise :class:`InstrumentError`.
+
+def _validate_response_schema(rs: Any, *, context: str, q_index: int) -> None:
+    """Validate a question-level ``response_schema`` entry.
+
+    Recognized shapes (sp-2hpi):
+
+    - ``{"type": "text", "max_tokens": N?}`` — free text (default)
+    - ``{"type": "scale", "min": M, "max": N}`` — numeric scale with integer bounds (min < max)
+    - ``{"type": "enum", "options": [...]}`` — categorical choice, non-empty list of strings
+    - ``{"type": "tagged_themes", "taxonomy": [...], "multi": bool?}`` — structured tags from a fixed taxonomy
+
+    Unknown shapes are rejected so instruments fail fast. A plain dict
+    without a recognized ``type`` (legacy use of ``response_schema`` as a
+    free JSON Schema) is accepted unchanged for backward compatibility.
+    """
+    if not isinstance(rs, dict):
+        raise InstrumentError(
+            f"{context} question[{q_index}]: response_schema must be a mapping, got {type(rs).__name__}"
+        )
+    t = rs.get("type")
+    if not isinstance(t, str) or t not in _RESPONSE_SCHEMA_TYPES:
+        # Legacy / inline JSON Schema — accept without semantic checks.
+        return
+
+    loc = f"{context} question[{q_index}] response_schema"
+    if t == "scale":
+        lo = rs.get("min")
+        hi = rs.get("max")
+        if not isinstance(lo, int) or isinstance(lo, bool):
+            raise InstrumentError(f"{loc}: 'min' must be an integer, got {type(lo).__name__}")
+        if not isinstance(hi, int) or isinstance(hi, bool):
+            raise InstrumentError(f"{loc}: 'max' must be an integer, got {type(hi).__name__}")
+        if lo >= hi:
+            raise InstrumentError(f"{loc}: 'min' ({lo}) must be strictly less than 'max' ({hi})")
+    elif t == "enum":
+        opts = rs.get("options")
+        if not isinstance(opts, list) or not opts:
+            raise InstrumentError(f"{loc}: 'options' must be a non-empty list of strings")
+        if not all(isinstance(o, str) and o for o in opts):
+            raise InstrumentError(f"{loc}: 'options' entries must be non-empty strings")
+        if len(set(opts)) != len(opts):
+            raise InstrumentError(f"{loc}: 'options' must be unique")
+    elif t == "tagged_themes":
+        taxonomy = rs.get("taxonomy")
+        if not isinstance(taxonomy, list) or not taxonomy:
+            raise InstrumentError(f"{loc}: 'taxonomy' must be a non-empty list of strings")
+        if not all(isinstance(tag, str) and tag for tag in taxonomy):
+            raise InstrumentError(f"{loc}: 'taxonomy' entries must be non-empty strings")
+        if len(set(taxonomy)) != len(taxonomy):
+            raise InstrumentError(f"{loc}: 'taxonomy' must be unique")
+        multi = rs.get("multi", False)
+        if not isinstance(multi, bool):
+            raise InstrumentError(f"{loc}: 'multi' must be a boolean, got {type(multi).__name__}")
+    elif t == "text":
+        mt = rs.get("max_tokens")
+        if mt is not None and (not isinstance(mt, int) or isinstance(mt, bool) or mt <= 0):
+            raise InstrumentError(f"{loc}: 'max_tokens' must be a positive integer when provided")
+
+
+def _validate_questions(questions: list[dict[str, Any]], context: str) -> None:
+    """Validate ``extraction_schema`` and ``response_schema`` on questions.
+
+    For ``extraction_schema``: string values are checked against the bundled
+    schema registry; dict values are accepted as inline JSON Schemas without
+    further validation. Other types raise :class:`InstrumentError`.
+
+    For ``response_schema``: dicts with a recognized ``type`` (text, scale,
+    enum, tagged_themes) are shape-checked; legacy inline JSON Schemas
+    (dicts without a recognized type) pass through untouched.
 
     Args:
         questions: List of question dicts to validate.
@@ -103,18 +168,20 @@ def _validate_questions(questions: list[dict[str, Any]], context: str) -> None:
         if not isinstance(q, dict):
             continue
         es = q.get("extraction_schema")
-        if es is None:
-            continue
-        if isinstance(es, str):
-            if not is_known_schema(es):
-                from synth_panel.structured.schemas import SchemaNotFoundError
+        if es is not None:
+            if isinstance(es, str):
+                if not is_known_schema(es):
+                    from synth_panel.structured.schemas import SchemaNotFoundError
 
-                raise InstrumentError(str(SchemaNotFoundError(es)))
-        elif not isinstance(es, dict):
-            raise InstrumentError(
-                f"{context} question[{i}]: extraction_schema must be a string (schema name) or mapping, "
-                f"got {type(es).__name__}"
-            )
+                    raise InstrumentError(str(SchemaNotFoundError(es)))
+            elif not isinstance(es, dict):
+                raise InstrumentError(
+                    f"{context} question[{i}]: extraction_schema must be a string (schema name) or mapping, "
+                    f"got {type(es).__name__}"
+                )
+        rs = q.get("response_schema")
+        if rs is not None:
+            _validate_response_schema(rs, context=context, q_index=i)
 
 
 def parse_instrument(data: dict[str, Any]) -> Instrument:

--- a/tests/test_analysis_pipeline.py
+++ b/tests/test_analysis_pipeline.py
@@ -1,0 +1,397 @@
+"""Tests for sp-2hpi analysis scaffolding: response_schema validation +
+deterministic distributions + subgroup breakdowns.
+
+The analysis pipeline must be deterministic: the same inputs always
+produce the same output shape and counts, because downstream layers
+(narrative-over-stats, structured-mode output, --analysis-mode auto)
+will rely on byte-stable aggregation in tests and CI.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_panel.analysis import (
+    InvalidResponseSchemaError,
+    UnknownPersonaFieldError,
+    coerce_enum_value,
+    coerce_scale_value,
+    coerce_tagged_themes,
+    distribution_for_question,
+    subgroup_breakdown,
+)
+from synth_panel.instrument import InstrumentError, parse_instrument
+
+# ---------------------------------------------------------------------------
+# response_schema validation in the instrument parser
+# ---------------------------------------------------------------------------
+
+
+class TestResponseSchemaValidation:
+    def test_scale_schema_accepted(self):
+        data = {"questions": [{"text": "Rate it", "response_schema": {"type": "scale", "min": 0, "max": 10}}]}
+        inst = parse_instrument(data)
+        assert inst.questions[0]["response_schema"]["type"] == "scale"
+
+    def test_scale_min_not_int_raises(self):
+        data = {"questions": [{"text": "q", "response_schema": {"type": "scale", "min": "0", "max": 10}}]}
+        with pytest.raises(InstrumentError, match="'min' must be an integer"):
+            parse_instrument(data)
+
+    def test_scale_min_gte_max_raises(self):
+        data = {"questions": [{"text": "q", "response_schema": {"type": "scale", "min": 5, "max": 5}}]}
+        with pytest.raises(InstrumentError, match="strictly less than"):
+            parse_instrument(data)
+
+    def test_enum_schema_accepted(self):
+        data = {
+            "questions": [
+                {
+                    "text": "Pick",
+                    "response_schema": {"type": "enum", "options": ["a", "b", "c"]},
+                }
+            ]
+        }
+        inst = parse_instrument(data)
+        assert inst.questions[0]["response_schema"]["options"] == ["a", "b", "c"]
+
+    def test_enum_empty_options_raises(self):
+        data = {"questions": [{"text": "q", "response_schema": {"type": "enum", "options": []}}]}
+        with pytest.raises(InstrumentError, match="non-empty list"):
+            parse_instrument(data)
+
+    def test_enum_duplicate_options_raises(self):
+        data = {
+            "questions": [
+                {
+                    "text": "q",
+                    "response_schema": {"type": "enum", "options": ["a", "a"]},
+                }
+            ]
+        }
+        with pytest.raises(InstrumentError, match="must be unique"):
+            parse_instrument(data)
+
+    def test_tagged_themes_accepted(self):
+        data = {
+            "questions": [
+                {
+                    "text": "Tag",
+                    "response_schema": {
+                        "type": "tagged_themes",
+                        "taxonomy": ["price", "quality"],
+                        "multi": True,
+                    },
+                }
+            ]
+        }
+        inst = parse_instrument(data)
+        assert inst.questions[0]["response_schema"]["multi"] is True
+
+    def test_tagged_themes_missing_taxonomy_raises(self):
+        data = {"questions": [{"text": "q", "response_schema": {"type": "tagged_themes"}}]}
+        with pytest.raises(InstrumentError, match="'taxonomy'"):
+            parse_instrument(data)
+
+    def test_text_max_tokens_zero_raises(self):
+        data = {"questions": [{"text": "q", "response_schema": {"type": "text", "max_tokens": 0}}]}
+        with pytest.raises(InstrumentError, match="positive integer"):
+            parse_instrument(data)
+
+    def test_response_schema_not_dict_raises(self):
+        data = {"questions": [{"text": "q", "response_schema": "scale"}]}
+        with pytest.raises(InstrumentError, match="must be a mapping"):
+            parse_instrument(data)
+
+    def test_legacy_inline_schema_passthrough(self):
+        """Dicts without a recognized 'type' are accepted unchanged for
+        backward compatibility with inline JSON Schema usage."""
+        data = {
+            "questions": [
+                {
+                    "text": "q",
+                    "response_schema": {
+                        "type": "object",
+                        "properties": {"answer": {"type": "string"}},
+                    },
+                }
+            ]
+        }
+        inst = parse_instrument(data)
+        assert inst.questions[0]["response_schema"]["type"] == "object"
+
+
+# ---------------------------------------------------------------------------
+# Coercion helpers
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceScale:
+    def test_in_range_int(self):
+        assert coerce_scale_value(7, 0, 10) == 7
+
+    def test_float_rounds(self):
+        assert coerce_scale_value(7.4, 0, 10) == 7
+        assert coerce_scale_value(7.6, 0, 10) == 8
+
+    def test_numeric_string(self):
+        assert coerce_scale_value("8", 0, 10) == 8
+        assert coerce_scale_value("  8.2 ", 0, 10) == 8
+
+    def test_out_of_range_returns_none(self):
+        assert coerce_scale_value(-1, 0, 10) is None
+        assert coerce_scale_value(11, 0, 10) is None
+
+    def test_bool_rejected(self):
+        assert coerce_scale_value(True, 0, 10) is None
+
+    def test_unparseable_string(self):
+        assert coerce_scale_value("eight", 0, 10) is None
+        assert coerce_scale_value("", 0, 10) is None
+
+
+class TestCoerceEnum:
+    def test_exact_match(self):
+        assert coerce_enum_value("yes", ["yes", "no"]) == "yes"
+
+    def test_case_insensitive_returns_canonical(self):
+        assert coerce_enum_value("YES", ["yes", "no"]) == "yes"
+        assert coerce_enum_value("  No ", ["yes", "no"]) == "no"
+
+    def test_unknown_returns_none(self):
+        assert coerce_enum_value("maybe", ["yes", "no"]) is None
+        assert coerce_enum_value("", ["yes", "no"]) is None
+
+    def test_non_string_returns_none(self):
+        assert coerce_enum_value(42, ["yes", "no"]) is None
+
+
+class TestCoerceTaggedThemes:
+    def test_comma_separated_string(self):
+        in_tax, off_tax = coerce_tagged_themes("price, quality, support", ["price", "quality"], multi=True)
+        assert in_tax == ["price", "quality"]
+        assert off_tax == ["support"]
+
+    def test_list_input(self):
+        in_tax, off_tax = coerce_tagged_themes(["Price", "Unknown"], ["price", "quality"], multi=True)
+        assert in_tax == ["price"]
+        assert off_tax == ["Unknown"]
+
+    def test_multi_false_keeps_only_first(self):
+        in_tax, off_tax = coerce_tagged_themes("price, quality", ["price", "quality"], multi=False)
+        assert in_tax == ["price"]
+        assert off_tax == []
+
+    def test_empty_returns_none(self):
+        assert coerce_tagged_themes("", ["price"], multi=True) is None
+        assert coerce_tagged_themes(None, ["price"], multi=True) is None
+
+
+# ---------------------------------------------------------------------------
+# distribution_for_question — scale
+# ---------------------------------------------------------------------------
+
+
+class TestScaleDistribution:
+    def test_scale_distribution_computed_deterministically(self):
+        schema = {"type": "scale", "min": 0, "max": 3}
+        responses = [0, 1, 1, 2, 3, 3, 3]
+        out = distribution_for_question(responses, schema)
+        assert out["type"] == "scale"
+        assert out["n"] == 7
+        assert out["n_valid"] == 7
+        assert out["n_invalid"] == 0
+        assert out["distribution"] == [
+            {"value": 0, "count": 1},
+            {"value": 1, "count": 2},
+            {"value": 2, "count": 1},
+            {"value": 3, "count": 3},
+        ]
+        assert out["stats"]["mean"] == pytest.approx(13 / 7, abs=1e-4)
+        assert out["stats"]["median"] == 2.0
+        assert out["stats"]["observed_min"] == 0
+        assert out["stats"]["observed_max"] == 3
+
+    def test_scale_deterministic_repeats(self):
+        schema = {"type": "scale", "min": 1, "max": 5}
+        responses = [5, 4, "3", 2.7, None, "x"]
+        first = distribution_for_question(responses, schema)
+        second = distribution_for_question(responses, schema)
+        assert first == second
+        assert first["n_invalid"] == 2  # None and "x"
+        assert first["n_valid"] == 4
+
+    def test_scale_all_invalid_omits_stats_body(self):
+        schema = {"type": "scale", "min": 0, "max": 10}
+        out = distribution_for_question(["nope", None, False], schema)
+        assert out["n_valid"] == 0
+        assert "mean" not in out["stats"]
+
+
+# ---------------------------------------------------------------------------
+# distribution_for_question — enum
+# ---------------------------------------------------------------------------
+
+
+class TestEnumDistribution:
+    def test_enum_frequencies_stable(self):
+        schema = {"type": "enum", "options": ["yes", "no", "maybe"]}
+        responses = ["yes", "YES", "no", "maybe", "maybe", "unknown"]
+        out = distribution_for_question(responses, schema)
+        assert out["type"] == "enum"
+        assert out["distribution"] == [
+            {"option": "yes", "count": 2},
+            {"option": "no", "count": 1},
+            {"option": "maybe", "count": 2},
+        ]
+        assert out["n_valid"] == 5
+        assert out["n_invalid"] == 1
+        assert out["top_option"] in {"yes", "maybe"}  # tie — first in declaration wins
+        assert out["top_option"] == "yes"
+
+    def test_enum_zero_filled_when_no_responses_match(self):
+        schema = {"type": "enum", "options": ["a", "b"]}
+        out = distribution_for_question(["c", "d"], schema)
+        assert out["distribution"] == [
+            {"option": "a", "count": 0},
+            {"option": "b", "count": 0},
+        ]
+        assert out["top_option"] is None
+
+
+# ---------------------------------------------------------------------------
+# distribution_for_question — tagged_themes
+# ---------------------------------------------------------------------------
+
+
+class TestTaggedThemesAggregation:
+    def test_tagged_themes_aggregation(self):
+        schema = {
+            "type": "tagged_themes",
+            "taxonomy": ["price", "quality", "support"],
+            "multi": True,
+        }
+        responses = [
+            "price, quality",
+            ["support", "other"],
+            "QUALITY",
+            None,
+            "",
+        ]
+        out = distribution_for_question(responses, schema)
+        assert out["type"] == "tagged_themes"
+        assert out["distribution"] == [
+            {"theme": "price", "count": 1},
+            {"theme": "quality", "count": 2},
+            {"theme": "support", "count": 1},
+        ]
+        assert out["off_taxonomy"] == [{"theme": "other", "count": 1}]
+        assert out["n_valid"] == 3
+        assert out["total_mentions"] == 5
+
+    def test_tagged_themes_single_tag_when_multi_false(self):
+        schema = {
+            "type": "tagged_themes",
+            "taxonomy": ["a", "b"],
+            "multi": False,
+        }
+        out = distribution_for_question(["a, b", "b, a"], schema)
+        # Only the first tag is counted per response
+        assert out["distribution"] == [
+            {"theme": "a", "count": 1},
+            {"theme": "b", "count": 1},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# distribution_for_question — text & error paths
+# ---------------------------------------------------------------------------
+
+
+class TestTextDistribution:
+    def test_text_counts_nonempty(self):
+        schema = {"type": "text"}
+        out = distribution_for_question(["hi", "", "  ", "there"], schema)
+        assert out == {"type": "text", "n": 4, "n_valid": 2, "n_invalid": 2}
+
+
+class TestInvalidSchema:
+    def test_unknown_type_raises(self):
+        with pytest.raises(InvalidResponseSchemaError):
+            distribution_for_question([], {"type": "matrix"})
+
+    def test_missing_type_raises(self):
+        with pytest.raises(InvalidResponseSchemaError):
+            distribution_for_question([], {})
+
+
+# ---------------------------------------------------------------------------
+# subgroup_breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestSubgroupBreakdown:
+    def test_subgroup_breakdown_by_pack(self):
+        schema = {"type": "enum", "options": ["yes", "no"]}
+        personas = [
+            {"name": "a", "pack": "alpha"},
+            {"name": "b", "pack": "alpha"},
+            {"name": "c", "pack": "beta"},
+        ]
+        responses = ["yes", "no", "yes"]
+        out = subgroup_breakdown(responses, personas, field="pack", response_schema=schema)
+        assert out["field"] == "pack"
+        assert out["n_buckets"] == 2
+        # Alphabetical ordering of named buckets
+        assert [b["label"] for b in out["buckets"]] == ["alpha", "beta"]
+        alpha = out["buckets"][0]
+        assert alpha["n"] == 2
+        assert alpha["distribution"]["distribution"] == [
+            {"option": "yes", "count": 1},
+            {"option": "no", "count": 1},
+        ]
+
+    def test_age_bands(self):
+        schema = {"type": "scale", "min": 0, "max": 10}
+        personas = [
+            {"age": 22},
+            {"age": 35},
+            {"age": 41},
+            {"age": 70},  # out of band — goes to missing
+        ]
+        responses = [8, 7, 9, 5]
+        out = subgroup_breakdown(
+            responses,
+            personas,
+            field="age",
+            response_schema=schema,
+            age_bands=[(18, 29), (30, 44)],
+        )
+        labels = [b["label"] for b in out["buckets"]]
+        assert labels == ["18-29", "30-44", "unknown"]
+        assert out["buckets"][0]["n"] == 1  # 22
+        assert out["buckets"][1]["n"] == 2  # 35, 41
+        assert out["buckets"][2]["n"] == 1  # 70
+
+    def test_missing_field_bucket(self):
+        schema = {"type": "text"}
+        personas = [{"pack": "x"}, {}, {"pack": "y"}]
+        responses = ["a", "b", "c"]
+        out = subgroup_breakdown(responses, personas, field="pack", response_schema=schema)
+        labels = [b["label"] for b in out["buckets"]]
+        assert "unknown" in labels
+        assert labels[-1] == "unknown"  # missing_label always last
+
+    def test_no_persona_has_field_raises(self):
+        schema = {"type": "text"}
+        with pytest.raises(UnknownPersonaFieldError):
+            subgroup_breakdown(["a"], [{"name": "p"}], field="pack", response_schema=schema)
+
+    def test_length_mismatch_raises(self):
+        with pytest.raises(ValueError, match="same length"):
+            subgroup_breakdown(
+                ["a"],
+                [{"pack": "x"}, {"pack": "y"}],
+                field="pack",
+                response_schema={"type": "text"},
+            )


### PR DESCRIPTION
## Summary

First slice of sp-2hpi (structured-first synthesis for n>500 scale). Adds the
analysis pipeline scaffolding the larger refactor will build on, without
touching runtime dispatch or synthesis yet.

- **Instrument parser** recognizes and shape-validates the new question-level `response_schema` types: `scale` (int bounds), `enum` (unique non-empty options), `tagged_themes` (unique taxonomy + `multi` flag), and `text` (optional positive `max_tokens`). Legacy inline JSON Schemas pass through unchanged for backward compatibility.
- **`synth_panel.analysis.distribution`** computes deterministic per-type distributions with zero-filled frequency tables, `mean`/`median`/`stdev` for scales, and an `off_taxonomy` bucket for tagged themes. Coercion helpers (`coerce_scale_value`, `coerce_enum_value`, `coerce_tagged_themes`) report `n_invalid` rather than silently dropping entries.
- **`synth_panel.analysis.subgroup`** splits a question by any persona field with deterministic bucket ordering (alphabetical for strings, declared order for age bands, missing bucket always last).
- **35 new tests** in `tests/test_analysis_pipeline.py` covering schema errors, coercion edge cases, determinism, and subgroup ordering.

## Scope

This is PR1 of a multi-PR effort. Deliberately **not** in this PR:

- `--analysis-mode {narrative, structured, auto}` CLI flag + dispatcher
- Auto-threshold at n>500 in the panel runner
- `correlations.py` (pairwise scale×scale, theme×subgroup crosstabs)
- Narrative-reads-stats prompt / synthesizer change
- `metadata.cost.aggregation_cost` field
- Top-level `analysis` section wiring in output
- Deprecation warning for unstructured instruments at scaled use
- `docs/migration-structured.md`

These are tracked as follow-up work on sp-2hpi.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [x] `pytest tests/test_analysis_pipeline.py tests/test_instrument.py -q` — 86 passed
- [x] `pytest tests/ -q --ignore=tests/test_aliases.py --ignore=tests/test_mcp_stdio_sampling.py` — 1158 passed, 2 skipped
- [ ] CI green
- [ ] CODEOWNER review

🤖 Generated with [Claude Code](https://claude.com/claude-code)