### PR TITLE
feat(llm): rate-limit-aware client + --max-concurrent / --rate-limit-rps (sp-i2ub)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -887,7 +887,12 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     request_id = _uuid.uuid4().hex[:12]
     logger.info("[%s] panel run: model=%s personas=%d questions=%d", request_id, model, len(personas), len(questions))
 
-    client = LLMClient()
+    max_concurrent = getattr(args, "max_concurrent", None)
+    rate_limit_rps = getattr(args, "rate_limit_rps", None)
+    client = LLMClient(
+        max_concurrent=max_concurrent,
+        rate_limit_rps=rate_limit_rps,
+    )
     timer = PanelTimer()
 
     # ── sp-5on.15: variant expansion ─────────────────────────────────
@@ -1019,6 +1024,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             temperature=temperature,
             top_p=top_p,
             persona_models=persona_models,
+            max_workers=max_concurrent,
         )
 
     # Build output results and aggregate panelist usage

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -329,6 +329,30 @@ def build_parser() -> argparse.ArgumentParser:
             "Exits without calling any provider."
         ),
     )
+    panel_run_parser.add_argument(
+        "--max-concurrent",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Cap concurrent in-flight LLM requests across the panel. "
+            "Applies at the client layer, so it throttles all providers "
+            "on the same client. Defaults to unbounded (one worker per "
+            "panelist). Use this to keep provider rate limits happy on "
+            "large n runs."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--rate-limit-rps",
+        type=float,
+        default=None,
+        metavar="RPS",
+        help=(
+            "Cap requests-per-second across the panel via a token bucket. "
+            "Smooths bursts on top of --max-concurrent. Accepts fractional "
+            "values (e.g. 0.5 for one request every two seconds)."
+        ),
+    )
 
     # panel inspect (sp-76gm: stats + schema walker for a saved result)
     panel_inspect_parser = panel_subparsers.add_parser(

--- a/src/synth_panel/llm/client.py
+++ b/src/synth_panel/llm/client.py
@@ -33,6 +33,43 @@ _PROVIDER_REGISTRY: list[tuple[ProviderConfig, type[LLMProvider]]] = [
 _DEFAULT_INITIAL_BACKOFF = 0.2  # 200ms
 _DEFAULT_MAX_BACKOFF = 2.0  # 2s
 _DEFAULT_MAX_RETRIES = 2
+# Rate-limit backoff has a higher ceiling because providers often hand out
+# Retry-After values in the 1-30s range. Without this, we'd clamp useful
+# server-supplied waits down to max_backoff and burn the retry budget.
+_DEFAULT_MAX_BACKOFF_RATE_LIMIT = 60.0
+_DEFAULT_MAX_RETRIES_RATE_LIMIT = 5
+
+
+class _TokenBucket:
+    """Simple thread-safe token bucket for RPS throttling.
+
+    Capacity defaults to the rate, giving a burst of up to one second of
+    calls; refill is continuous.
+    """
+
+    def __init__(self, rate_per_second: float, capacity: float | None = None) -> None:
+        if rate_per_second <= 0:
+            raise ValueError("rate_per_second must be > 0")
+        self._rate = rate_per_second
+        self._capacity = capacity if capacity is not None else rate_per_second
+        self._tokens = self._capacity
+        self._last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    def acquire(self, tokens: float = 1.0) -> None:
+        """Block until *tokens* are available, then subtract them."""
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                elapsed = now - self._last_refill
+                self._tokens = min(self._capacity, self._tokens + elapsed * self._rate)
+                self._last_refill = now
+                if self._tokens >= tokens:
+                    self._tokens -= tokens
+                    return
+                needed = tokens - self._tokens
+                wait = needed / self._rate
+            time.sleep(wait)
 
 
 class LLMClient:
@@ -46,6 +83,9 @@ class LLMClient:
             max_tokens=1024,
             messages=[InputMessage(role="user", content=[TextBlock(text="Hi")])],
         ))
+
+    For scaled panel runs, pass ``max_concurrent`` to cap in-flight calls
+    and ``rate_limit_rps`` to smooth the request rate per second.
     """
 
     def __init__(
@@ -54,12 +94,24 @@ class LLMClient:
         max_retries: int = _DEFAULT_MAX_RETRIES,
         initial_backoff: float = _DEFAULT_INITIAL_BACKOFF,
         max_backoff: float = _DEFAULT_MAX_BACKOFF,
+        max_retries_rate_limit: int = _DEFAULT_MAX_RETRIES_RATE_LIMIT,
+        max_backoff_rate_limit: float = _DEFAULT_MAX_BACKOFF_RATE_LIMIT,
+        max_concurrent: int | None = None,
+        rate_limit_rps: float | None = None,
     ) -> None:
         self._max_retries = max_retries
         self._initial_backoff = initial_backoff
         self._max_backoff = max_backoff
+        self._max_retries_rate_limit = max_retries_rate_limit
+        self._max_backoff_rate_limit = max_backoff_rate_limit
         self._provider_cache: dict[str, LLMProvider] = {}
         self._cache_lock = threading.Lock()
+        self._concurrency: threading.Semaphore | None = (
+            threading.Semaphore(max_concurrent) if max_concurrent and max_concurrent > 0 else None
+        )
+        self._bucket: _TokenBucket | None = (
+            _TokenBucket(rate_limit_rps) if rate_limit_rps and rate_limit_rps > 0 else None
+        )
 
     def _resolve_provider(self, model: str) -> LLMProvider:
         """Resolve a provider for the given canonical model name."""
@@ -123,9 +175,17 @@ class LLMClient:
         request = self._prepare(request)
         provider = self._resolve_provider(request.model)
         logger.debug("send model=%s max_tokens=%d", request.model, request.max_tokens)
-        t0 = time.monotonic()
-        response = self._with_retry(provider.send, request)
-        elapsed = time.monotonic() - t0
+        if self._bucket is not None:
+            self._bucket.acquire()
+        if self._concurrency is not None:
+            self._concurrency.acquire()
+        try:
+            t0 = time.monotonic()
+            response = self._with_retry(provider.send, request)
+            elapsed = time.monotonic() - t0
+        finally:
+            if self._concurrency is not None:
+                self._concurrency.release()
         logger.debug(
             "response model=%s latency=%.2fs tokens_in=%d tokens_out=%d",
             response.model,
@@ -141,38 +201,66 @@ class LLMClient:
         provider = self._resolve_provider(request.model)
         return provider.stream(request)
 
+    def _sleep_for_retry(self, exc: LLMError, backoff: float) -> float:
+        """Compute how long to sleep before the next retry.
+
+        Honors ``retry_after`` from the error (server-supplied wait, e.g.
+        via ``Retry-After`` header) when present; otherwise uses the
+        current exponential backoff with full jitter.
+        """
+        if exc.retry_after is not None:
+            # Clamp to the rate-limit ceiling so a pathological
+            # Retry-After (e.g. 3600s) doesn't stall the whole run.
+            return min(exc.retry_after, self._max_backoff_rate_limit)
+        return random.uniform(0, backoff)
+
     def _with_retry(
         self,
         fn: Callable[[CompletionRequest], CompletionResponse],
         request: CompletionRequest,
     ) -> CompletionResponse:
-        """Execute *fn* with exponential backoff + jitter on retryable errors."""
+        """Execute *fn* with exponential backoff + jitter on retryable errors.
+
+        Rate-limit errors get a larger retry budget and a higher backoff
+        ceiling than other retryable categories, and respect a server
+        ``Retry-After`` hint when present.
+        """
         last_error: LLMError | None = None
         backoff = self._initial_backoff
 
-        for attempt in range(1 + self._max_retries):
+        attempt = 0
+        while True:
             try:
                 return fn(request)
             except LLMError as exc:
                 last_error = exc
-                if not exc.retryable or attempt >= self._max_retries:
+                if not exc.retryable:
                     break
-                # Exponential backoff with full jitter
-                jitter = random.uniform(0, backoff)
+                if exc.category == LLMErrorCategory.RATE_LIMIT:
+                    budget = self._max_retries_rate_limit
+                    ceiling = self._max_backoff_rate_limit
+                else:
+                    budget = self._max_retries
+                    ceiling = self._max_backoff
+                if attempt >= budget:
+                    break
+                sleep_for = self._sleep_for_retry(exc, backoff)
                 logger.warning(
-                    "retryable error (attempt %d/%d, backoff=%.2fs): %s",
+                    "retryable error (attempt %d/%d, category=%s, sleep=%.2fs): %s",
                     attempt + 1,
-                    self._max_retries + 1,
-                    jitter,
+                    budget + 1,
+                    exc.category.value,
+                    sleep_for,
                     exc,
                 )
-                time.sleep(jitter)
-                backoff = min(backoff * 2, self._max_backoff)
+                time.sleep(sleep_for)
+                backoff = min(backoff * 2, ceiling)
+                attempt += 1
 
         assert last_error is not None
         if last_error.retryable:
             raise LLMError(
-                f"Retries exhausted after {self._max_retries + 1} attempts: {last_error}",
+                f"Retries exhausted after {attempt + 1} attempts: {last_error}",
                 LLMErrorCategory.RETRIES_EXHAUSTED,
                 cause=last_error,
             )

--- a/src/synth_panel/llm/errors.py
+++ b/src/synth_panel/llm/errors.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
+from email.utils import parsedate_to_datetime
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import httpx
 
 
 class LLMErrorCategory(Enum):
@@ -37,11 +42,13 @@ class LLMError(Exception):
         category: LLMErrorCategory,
         *,
         status_code: int | None = None,
+        retry_after: float | None = None,
         cause: Exception | None = None,
     ) -> None:
         super().__init__(message)
         self.category = category
         self.status_code = status_code
+        self.retry_after = retry_after
         self.__cause__ = cause
 
     @property
@@ -49,7 +56,10 @@ class LLMError(Exception):
         return self.category in RETRYABLE_CATEGORIES
 
     def __repr__(self) -> str:
-        return f"LLMError(category={self.category.value!r}, status={self.status_code}, msg={str(self)!r})"
+        return (
+            f"LLMError(category={self.category.value!r}, status={self.status_code}, "
+            f"retry_after={self.retry_after}, msg={str(self)!r})"
+        )
 
 
 def classify_http_status(status: int) -> LLMErrorCategory:
@@ -63,3 +73,83 @@ def classify_http_status(status: int) -> LLMErrorCategory:
     if status >= 500:
         return LLMErrorCategory.SERVER_ERROR
     return LLMErrorCategory.TRANSPORT
+
+
+def parse_retry_after(value: str | None) -> float | None:
+    """Parse a Retry-After header value.
+
+    The header may be an integer/float number of seconds or an HTTP-date.
+    Returns seconds-to-wait as a float, or None if the value is missing
+    or unparseable. Negative values are clamped to 0.
+    """
+    if not value:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        seconds = float(value)
+    except ValueError:
+        pass
+    else:
+        return max(0.0, seconds)
+
+    try:
+        from datetime import datetime, timezone
+
+        when = parsedate_to_datetime(value)
+        if when is None:
+            return None
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        delta = (when - datetime.now(timezone.utc)).total_seconds()
+        return max(0.0, delta)
+    except (TypeError, ValueError):
+        return None
+
+
+def retry_after_from_headers(headers: object) -> float | None:
+    """Extract a retry-after hint from an HTTP response's headers.
+
+    Accepts any httpx-style case-insensitive ``headers`` mapping. Looks at
+    ``Retry-After`` first (RFC 7231), then common provider extensions
+    (``x-ratelimit-reset``, ``anthropic-ratelimit-requests-reset``).
+    Returns seconds-to-wait as a float, or None.
+    """
+    if headers is None:
+        return None
+    get = getattr(headers, "get", None)
+    if get is None:
+        return None
+    for name in (
+        "retry-after",
+        "x-ratelimit-reset",
+        "anthropic-ratelimit-requests-reset",
+        "anthropic-ratelimit-tokens-reset",
+    ):
+        raw = get(name)
+        parsed = parse_retry_after(raw)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def llm_error_from_response(
+    resp: httpx.Response,
+    provider_name: str,
+) -> LLMError:
+    """Build an LLMError from a non-2xx ``httpx.Response``.
+
+    Classifies by status code and extracts a retry-after hint from the
+    response headers. Use this helper from provider ``send``/``stream``
+    paths to keep retry-after propagation consistent across providers.
+    """
+    status = resp.status_code
+    category = classify_http_status(status)
+    retry_after = retry_after_from_headers(resp.headers) if category == LLMErrorCategory.RATE_LIMIT else None
+    return LLMError(
+        f"{provider_name} API error {status}: {resp.text[:500]}",
+        category,
+        status_code=status,
+        retry_after=retry_after,
+    )

--- a/src/synth_panel/llm/providers/anthropic.py
+++ b/src/synth_panel/llm/providers/anthropic.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import httpx
 
-from synth_panel.llm.errors import LLMError, LLMErrorCategory, classify_http_status
+from synth_panel.llm.errors import LLMError, LLMErrorCategory, llm_error_from_response
 from synth_panel.llm.models import (
     CompletionRequest,
     CompletionResponse,
@@ -191,12 +191,7 @@ class AnthropicProvider(LLMProvider):
             ) from exc
 
         if resp.status_code != 200:
-            cat = classify_http_status(resp.status_code)
-            raise LLMError(
-                f"Anthropic API error {resp.status_code}: {resp.text[:500]}",
-                cat,
-                status_code=resp.status_code,
-            )
+            raise llm_error_from_response(resp, "Anthropic")
 
         try:
             data = resp.json()
@@ -241,12 +236,7 @@ class AnthropicProvider(LLMProvider):
             ) as resp:
                 if resp.status_code != 200:
                     resp.read()
-                    cat = classify_http_status(resp.status_code)
-                    raise LLMError(
-                        f"Anthropic API error {resp.status_code}: {resp.text[:500]}",
-                        cat,
-                        status_code=resp.status_code,
-                    )
+                    raise llm_error_from_response(resp, "Anthropic")
                 yield from _parse_sse_stream(resp.iter_lines())
         except httpx.HTTPError as exc:
             raise LLMError(

--- a/src/synth_panel/llm/providers/gemini.py
+++ b/src/synth_panel/llm/providers/gemini.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 import httpx
 
 from synth_panel.credentials import get_credential
-from synth_panel.llm.errors import LLMError, LLMErrorCategory, classify_http_status
+from synth_panel.llm.errors import LLMError, LLMErrorCategory, llm_error_from_response
 from synth_panel.llm.models import (
     CompletionRequest,
     CompletionResponse,
@@ -69,12 +69,7 @@ class GeminiProvider(LLMProvider):
             ) from exc
 
         if resp.status_code != 200:
-            cat = classify_http_status(resp.status_code)
-            raise LLMError(
-                f"Gemini API error {resp.status_code}: {resp.text[:500]}",
-                cat,
-                status_code=resp.status_code,
-            )
+            raise llm_error_from_response(resp, "Gemini")
 
         try:
             data = resp.json()
@@ -100,12 +95,7 @@ class GeminiProvider(LLMProvider):
             ) as resp:
                 if resp.status_code != 200:
                     resp.read()
-                    cat = classify_http_status(resp.status_code)
-                    raise LLMError(
-                        f"Gemini API error {resp.status_code}: {resp.text[:500]}",
-                        cat,
-                        status_code=resp.status_code,
-                    )
+                    raise llm_error_from_response(resp, "Gemini")
                 yield from parse_openai_sse_stream(resp.iter_lines())
         except httpx.HTTPError as exc:
             raise LLMError(

--- a/src/synth_panel/llm/providers/openai_compat.py
+++ b/src/synth_panel/llm/providers/openai_compat.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 
 import httpx
 
-from synth_panel.llm.errors import LLMError, LLMErrorCategory, classify_http_status
+from synth_panel.llm.errors import LLMError, LLMErrorCategory, llm_error_from_response
 from synth_panel.llm.models import (
     CompletionRequest,
     CompletionResponse,
@@ -64,12 +64,7 @@ class OpenAICompatibleProvider(LLMProvider):
             ) from exc
 
         if resp.status_code != 200:
-            cat = classify_http_status(resp.status_code)
-            raise LLMError(
-                f"OpenAI API error {resp.status_code}: {resp.text[:500]}",
-                cat,
-                status_code=resp.status_code,
-            )
+            raise llm_error_from_response(resp, "OpenAI")
 
         try:
             data = resp.json()
@@ -95,12 +90,7 @@ class OpenAICompatibleProvider(LLMProvider):
             ) as resp:
                 if resp.status_code != 200:
                     resp.read()
-                    cat = classify_http_status(resp.status_code)
-                    raise LLMError(
-                        f"OpenAI API error {resp.status_code}: {resp.text[:500]}",
-                        cat,
-                        status_code=resp.status_code,
-                    )
+                    raise llm_error_from_response(resp, "OpenAI")
                 yield from parse_openai_sse_stream(resp.iter_lines())
         except httpx.HTTPError as exc:
             raise LLMError(

--- a/src/synth_panel/llm/providers/openrouter.py
+++ b/src/synth_panel/llm/providers/openrouter.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 
 import httpx
 
-from synth_panel.llm.errors import LLMError, LLMErrorCategory, classify_http_status
+from synth_panel.llm.errors import LLMError, LLMErrorCategory, llm_error_from_response
 from synth_panel.llm.models import (
     CompletionRequest,
     CompletionResponse,
@@ -89,12 +89,7 @@ class OpenRouterProvider(LLMProvider):
             ) from exc
 
         if resp.status_code != 200:
-            cat = classify_http_status(resp.status_code)
-            raise LLMError(
-                f"OpenRouter API error {resp.status_code}: {resp.text[:500]}",
-                cat,
-                status_code=resp.status_code,
-            )
+            raise llm_error_from_response(resp, "OpenRouter")
 
         try:
             data = resp.json()
@@ -138,12 +133,7 @@ class OpenRouterProvider(LLMProvider):
             ) as resp:
                 if resp.status_code != 200:
                     resp.read()
-                    cat = classify_http_status(resp.status_code)
-                    raise LLMError(
-                        f"OpenRouter API error {resp.status_code}: {resp.text[:500]}",
-                        cat,
-                        status_code=resp.status_code,
-                    )
+                    raise llm_error_from_response(resp, "OpenRouter")
                 yield from parse_openai_sse_stream(resp.iter_lines())
         except httpx.HTTPError as exc:
             raise LLMError(

--- a/src/synth_panel/llm/providers/xai.py
+++ b/src/synth_panel/llm/providers/xai.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 
 import httpx
 
-from synth_panel.llm.errors import LLMError, LLMErrorCategory, classify_http_status
+from synth_panel.llm.errors import LLMError, LLMErrorCategory, llm_error_from_response
 from synth_panel.llm.models import (
     CompletionRequest,
     CompletionResponse,
@@ -60,12 +60,7 @@ class XAIProvider(LLMProvider):
             ) from exc
 
         if resp.status_code != 200:
-            cat = classify_http_status(resp.status_code)
-            raise LLMError(
-                f"xAI API error {resp.status_code}: {resp.text[:500]}",
-                cat,
-                status_code=resp.status_code,
-            )
+            raise llm_error_from_response(resp, "xAI")
 
         try:
             data = resp.json()
@@ -91,12 +86,7 @@ class XAIProvider(LLMProvider):
             ) as resp:
                 if resp.status_code != 200:
                     resp.read()
-                    cat = classify_http_status(resp.status_code)
-                    raise LLMError(
-                        f"xAI API error {resp.status_code}: {resp.text[:500]}",
-                        cat,
-                        status_code=resp.status_code,
-                    )
+                    raise llm_error_from_response(resp, "xAI")
                 yield from parse_openai_sse_stream(resp.iter_lines())
         except httpx.HTTPError as exc:
             raise LLMError(

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,377 @@
+"""Rate-limit-aware LLM client tests (sp-i2ub slice a).
+
+Covers:
+  - Retry-After header parsing (seconds, HTTP-date, garbage)
+  - LLMError.retry_after propagation
+  - llm_error_from_response helper extracts retry-after on 429
+  - LLMClient honors retry_after on rate-limit retries
+  - LLMClient rate-limit retry budget exceeds the default budget
+  - LLMClient.send Semaphore caps in-flight concurrency
+  - LLMClient.send token bucket caps requests-per-second
+  - Panel completes with a mock provider that returns 429 on every Nth call
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from email.utils import formatdate
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synth_panel.llm.client import LLMClient, _TokenBucket
+from synth_panel.llm.errors import (
+    LLMError,
+    LLMErrorCategory,
+    llm_error_from_response,
+    parse_retry_after,
+    retry_after_from_headers,
+)
+from synth_panel.llm.models import (
+    CompletionRequest,
+    CompletionResponse,
+    InputMessage,
+    TextBlock,
+    TokenUsage,
+)
+
+
+def _req(model: str = "claude-sonnet-4-6-20250414") -> CompletionRequest:
+    return CompletionRequest(
+        model=model,
+        max_tokens=64,
+        messages=[InputMessage(role="user", content=[TextBlock(text="hi")])],
+    )
+
+
+def _resp(text: str = "ok") -> CompletionResponse:
+    return CompletionResponse(
+        id="r",
+        model="test",
+        content=[TextBlock(text=text)],
+        usage=TokenUsage(input_tokens=1, output_tokens=1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Retry-After parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseRetryAfter:
+    def test_integer_seconds(self):
+        assert parse_retry_after("5") == 5.0
+
+    def test_float_seconds(self):
+        assert parse_retry_after("2.5") == 2.5
+
+    def test_negative_clamped(self):
+        assert parse_retry_after("-3") == 0.0
+
+    def test_none(self):
+        assert parse_retry_after(None) is None
+
+    def test_empty(self):
+        assert parse_retry_after("") is None
+        assert parse_retry_after("   ") is None
+
+    def test_garbage(self):
+        assert parse_retry_after("tomorrow") is None
+
+    def test_http_date_future(self):
+        # A date 30s in the future should yield ~30s.
+        future = time.time() + 30
+        header = formatdate(future, usegmt=True)
+        got = parse_retry_after(header)
+        assert got is not None
+        assert 25 <= got <= 35
+
+    def test_http_date_past_is_zero(self):
+        past = time.time() - 60
+        header = formatdate(past, usegmt=True)
+        got = parse_retry_after(header)
+        assert got == 0.0
+
+
+class TestRetryAfterFromHeaders:
+    def test_retry_after(self):
+        headers = {"retry-after": "7"}
+        assert retry_after_from_headers(headers) == 7.0
+
+    def test_anthropic_ratelimit_requests_reset(self):
+        headers = {"anthropic-ratelimit-requests-reset": "12"}
+        assert retry_after_from_headers(headers) == 12.0
+
+    def test_x_ratelimit_reset(self):
+        headers = {"x-ratelimit-reset": "3"}
+        assert retry_after_from_headers(headers) == 3.0
+
+    def test_none_headers(self):
+        assert retry_after_from_headers(None) is None
+
+    def test_missing(self):
+        assert retry_after_from_headers({}) is None
+
+
+# ---------------------------------------------------------------------------
+# LLMError + llm_error_from_response
+# ---------------------------------------------------------------------------
+
+
+class TestLLMError:
+    def test_default_retry_after_none(self):
+        err = LLMError("boom", LLMErrorCategory.RATE_LIMIT)
+        assert err.retry_after is None
+
+    def test_retry_after_stored(self):
+        err = LLMError("boom", LLMErrorCategory.RATE_LIMIT, retry_after=4.0)
+        assert err.retry_after == 4.0
+
+
+class TestLLMErrorFromResponse:
+    def test_429_with_retry_after(self):
+        resp = MagicMock()
+        resp.status_code = 429
+        resp.text = "too many"
+        resp.headers = {"retry-after": "15"}
+        err = llm_error_from_response(resp, "Anthropic")
+        assert err.category == LLMErrorCategory.RATE_LIMIT
+        assert err.status_code == 429
+        assert err.retry_after == 15.0
+        assert "Anthropic" in str(err)
+
+    def test_429_without_retry_after(self):
+        resp = MagicMock()
+        resp.status_code = 429
+        resp.text = "slow down"
+        resp.headers = {}
+        err = llm_error_from_response(resp, "OpenAI")
+        assert err.category == LLMErrorCategory.RATE_LIMIT
+        assert err.retry_after is None
+
+    def test_500_ignores_retry_after_header(self):
+        # Only rate-limit responses populate retry_after; a 500 with a
+        # random Retry-After would mislead the client.
+        resp = MagicMock()
+        resp.status_code = 500
+        resp.text = "oops"
+        resp.headers = {"retry-after": "30"}
+        err = llm_error_from_response(resp, "xAI")
+        assert err.category == LLMErrorCategory.SERVER_ERROR
+        assert err.retry_after is None
+
+
+# ---------------------------------------------------------------------------
+# LLMClient rate-limit behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitRetry:
+    def test_honors_retry_after_over_backoff(self):
+        """When a 429 carries retry_after, sleep that long, not the backoff."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(
+                max_retries=0,
+                max_retries_rate_limit=1,
+                initial_backoff=10.0,  # big, to prove we ignore it
+                max_backoff=10.0,
+                max_backoff_rate_limit=60.0,
+            )
+            provider = MagicMock()
+            provider.send.side_effect = [
+                LLMError(
+                    "rate limit",
+                    LLMErrorCategory.RATE_LIMIT,
+                    status_code=429,
+                    retry_after=0.05,
+                ),
+                _resp("recovered"),
+            ]
+            client._provider_cache["claude-sonnet-4-6-20250414"] = provider
+            sleep_calls: list[float] = []
+
+            def fake_sleep(s: float) -> None:
+                sleep_calls.append(s)
+
+            with patch("synth_panel.llm.client.time.sleep", side_effect=fake_sleep):
+                result = client.send(_req())
+            assert result.text == "recovered"
+            assert len(sleep_calls) == 1
+            # Server-supplied retry_after should dominate the exponential backoff.
+            assert sleep_calls[0] == pytest.approx(0.05, abs=1e-6)
+
+    def test_retry_after_clamped_to_ceiling(self):
+        """An absurd Retry-After is clamped to max_backoff_rate_limit."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(
+                max_retries=0,
+                max_retries_rate_limit=1,
+                max_backoff_rate_limit=2.0,
+            )
+            provider = MagicMock()
+            provider.send.side_effect = [
+                LLMError(
+                    "rate limit",
+                    LLMErrorCategory.RATE_LIMIT,
+                    retry_after=3600.0,
+                ),
+                _resp(),
+            ]
+            client._provider_cache["claude-sonnet-4-6-20250414"] = provider
+            sleep_calls: list[float] = []
+            with patch(
+                "synth_panel.llm.client.time.sleep",
+                side_effect=lambda s: sleep_calls.append(s),
+            ):
+                client.send(_req())
+            assert sleep_calls == [2.0]
+
+    def test_rate_limit_budget_larger_than_default(self):
+        """Rate-limit retries use their own budget, not max_retries."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(
+                max_retries=0,  # transport/server have 0 retries
+                max_retries_rate_limit=3,  # but rate-limit has 3
+                initial_backoff=0.001,
+                max_backoff=0.001,
+                max_backoff_rate_limit=0.001,
+            )
+            provider = MagicMock()
+            # 3 rate-limits, then success — must succeed via RL budget.
+            provider.send.side_effect = [
+                LLMError("rl", LLMErrorCategory.RATE_LIMIT, retry_after=0.001),
+                LLMError("rl", LLMErrorCategory.RATE_LIMIT, retry_after=0.001),
+                LLMError("rl", LLMErrorCategory.RATE_LIMIT, retry_after=0.001),
+                _resp("ok"),
+            ]
+            client._provider_cache["claude-sonnet-4-6-20250414"] = provider
+            result = client.send(_req())
+            assert result.text == "ok"
+            assert provider.send.call_count == 4
+
+    def test_rate_limit_exhaustion_raises(self):
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(
+                max_retries_rate_limit=2,
+                max_backoff_rate_limit=0.001,
+            )
+            provider = MagicMock()
+            provider.send.side_effect = LLMError("rl", LLMErrorCategory.RATE_LIMIT, retry_after=0.001)
+            client._provider_cache["claude-sonnet-4-6-20250414"] = provider
+            with pytest.raises(LLMError) as exc_info:
+                client.send(_req())
+            assert exc_info.value.category == LLMErrorCategory.RETRIES_EXHAUSTED
+            assert provider.send.call_count == 3  # 1 initial + 2 retries
+
+
+# ---------------------------------------------------------------------------
+# Concurrency cap
+# ---------------------------------------------------------------------------
+
+
+class TestMaxConcurrent:
+    def test_semaphore_caps_in_flight(self):
+        """With max_concurrent=2, only 2 sends may be in flight at once."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(max_concurrent=2)
+            in_flight = 0
+            peak = 0
+            lock = threading.Lock()
+
+            def fake_send(_req: CompletionRequest) -> CompletionResponse:
+                nonlocal in_flight, peak
+                with lock:
+                    in_flight += 1
+                    peak = max(peak, in_flight)
+                time.sleep(0.02)
+                with lock:
+                    in_flight -= 1
+                return _resp()
+
+            provider = MagicMock()
+            provider.send.side_effect = fake_send
+            client._provider_cache["claude-sonnet-4-6-20250414"] = provider
+
+            threads = [threading.Thread(target=lambda: client.send(_req())) for _ in range(8)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+            assert peak <= 2
+            assert provider.send.call_count == 8
+
+    def test_no_semaphore_when_unset(self):
+        """Without max_concurrent, calls proceed unthrottled."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient()
+            assert client._concurrency is None
+
+
+# ---------------------------------------------------------------------------
+# RPS throttle
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitRps:
+    def test_token_bucket_rejects_nonpositive_rate(self):
+        with pytest.raises(ValueError):
+            _TokenBucket(0)
+
+    def test_token_bucket_throttles(self):
+        """A 20-rps bucket should take ~0.25s for 5 tokens past the initial burst."""
+        bucket = _TokenBucket(20.0, capacity=1)
+        t0 = time.monotonic()
+        for _ in range(5):
+            bucket.acquire()
+        elapsed = time.monotonic() - t0
+        # 1 initial + 4 refilled at 20/s = 4/20 = 0.2s minimum.
+        assert elapsed >= 0.15
+
+    def test_client_uses_rps(self):
+        """LLMClient wires rate_limit_rps to a token bucket."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(rate_limit_rps=10.0)
+            assert client._bucket is not None
+
+
+# ---------------------------------------------------------------------------
+# Panel-style integration: mock 429 every Nth call
+# ---------------------------------------------------------------------------
+
+
+class TestPanelSurvives429s:
+    def test_every_third_call_429(self):
+        """A panel-like sequence where every 3rd call 429s still completes."""
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            client = LLMClient(
+                max_retries=0,
+                max_retries_rate_limit=3,
+                max_backoff_rate_limit=0.001,
+            )
+
+            state = {"calls": 0}
+
+            def flaky(_req: CompletionRequest) -> CompletionResponse:
+                state["calls"] += 1
+                # 1st, 2nd pass; 3rd 429; 4th pass; 5th pass; 6th 429; ...
+                if state["calls"] % 3 == 0:
+                    raise LLMError(
+                        "slow down",
+                        LLMErrorCategory.RATE_LIMIT,
+                        status_code=429,
+                        retry_after=0.001,
+                    )
+                return _resp("ok")
+
+            provider = MagicMock()
+            provider.send.side_effect = flaky
+            client._provider_cache["claude-sonnet-4-6-20250414"] = provider
+
+            # Simulate 10 panelists doing one call each.
+            for _ in range(10):
+                result = client.send(_req())
+                assert result.text == "ok"
+            # 10 logical sends + some retries for the 429s.
+            assert provider.send.call_count >= 10


### PR DESCRIPTION
## Summary

First slice of the scaled-orchestration substrate (sp-i2ub). Establishes a rate-limit handling layer beneath every synthesis mode so 429s and bursty concurrent panels no longer tank a run.

- `LLMError` gains `retry_after`; `errors.parse_retry_after` parses both seconds and HTTP-date `Retry-After` values (RFC 7231).
- `errors.llm_error_from_response` centralizes non-2xx → `LLMError` construction and extracts `Retry-After` (plus common provider extensions like `anthropic-ratelimit-requests-reset`, `x-ratelimit-reset`) on 429s.
- All five providers (Anthropic, OpenAI-compat, OpenRouter, Gemini, xAI) use the helper, so retry-after propagation is consistent across both `send()` and `stream()` paths.
- `LLMClient` honors `retry_after` when present (clamped to a rate-limit-specific backoff ceiling), and rate-limit errors get their own, larger retry budget than transport/server errors.
- New `LLMClient` knobs `max_concurrent` (`threading.Semaphore`) and `rate_limit_rps` (token bucket) cap in-flight calls and smooth request rate across the whole panel, with no effect when unset.
- `synthpanel panel run` exposes `--max-concurrent` and `--rate-limit-rps` and wires `max_concurrent` through to the orchestrator's `max_workers` so we don't spin threads for no reason on large n.

## Scope

Slice (a) of the sp-i2ub bead's explicit "Natural PR split". Follow-up beads for the rest of the substrate:
- sp-hsk3 (b) panelist checkpointing + `--resume`
- sp-utnk (c) mid-run `--max-cost` gate
- sp-56pb (d) partial-valid JSON on every abort path
- sp-1qio (e) `--progress` observability + `docs/running-at-scale.md`

## Test plan

- [x] `tests/test_rate_limit.py` — 42 new + existing client/errors tests pass locally
- [x] `pytest tests/ -q --no-cov --ignore=tests/test_aliases.py --ignore=tests/test_mcp_stdio_sampling.py` — 1135 pass, 2 skipped (composio test failure is pre-existing, missing pydantic in venv — unrelated to this change)
- [x] `ruff check src/ tests/` — clean
- [x] `ruff format --check src/ tests/` — clean
- [ ] CI green
- [ ] CODEOWNER review (per branch ruleset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)