### PR TITLE
feat(convergence): live JSD telemetry + auto-stop for panel runs (sp-yaru)

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,6 +738,27 @@ synthpanel panel run \
 
 The blended output includes per-model distributions and the weighted ensemble distribution, letting you inspect both individual model perspectives and the consensus view.
 
+## Running at Scale
+
+For panels of 500 to 10,000+ panelists, synthpanel can track response-distribution convergence live via Jensen-Shannon divergence and optionally auto-stop once every bounded (Likert / yes-no / pick-one / enum) question has stabilized. The post-run JSON gains a top-level `convergence` section showing the smallest `n` at which each question converged, so you can confidently run smaller next time.
+
+```bash
+synthpanel panel run \
+  --personas large-panel.yaml \
+  --instrument pricing-discovery \
+  --convergence-check-every 20 \
+  --auto-stop \
+  --output-format json > result.json
+
+jq '.convergence.overall_converged_at, .convergence.auto_stopped' result.json
+# 473
+# true
+```
+
+See [docs/convergence.md](docs/convergence.md) for methodology, tuning, and the
+optional `--convergence-baseline` flag that compares your run against a real-human
+baseline from [SynthBench](https://github.com/DataViking-Tech/synthbench) (install via `pip install 'synthpanel[convergence]'`).
+
 ## Versions
 
 | Version | Highlights |

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -1,0 +1,157 @@
+# Convergence telemetry
+
+At competitive-parity scales (n=500..10k), synthpanel panels spend most of
+their token budget producing diminishing returns. Once a response
+distribution has stabilized for a given question, running more panelists
+adds <2% signal for 10-20× the cost. The convergence feature exposes that
+signal live so you can (a) see when the distribution stabilized, (b)
+optionally auto-stop the run at that point, and (c) walk back to a
+smaller representative n next time.
+
+## TL;DR
+
+```bash
+synthpanel panel run \
+  --personas my-panel.yaml \
+  --instrument pricing-discovery \
+  --convergence-check-every 20 \
+  --auto-stop \
+  --output-format json > result.json
+
+# result.json now contains a `convergence` section.
+jq '.convergence.overall_converged_at, .convergence.auto_stopped' result.json
+```
+
+## How it works
+
+1. At startup synthpanel inspects the instrument and flags every question
+   with a bounded response space — Likert (`rating`), yes/no (`answer`),
+   pick-one (`choice`), or any JSON Schema with an `enum` field. Free-text
+   questions are ignored; JSD on paraphrase noise is ill-defined.
+2. As panelists complete, their categorical responses feed a per-question
+   running `Counter`. Every `--convergence-check-every N` panelists the
+   tracker computes the Jensen-Shannon divergence between the
+   distribution-so-far and the last-batch distribution, and a rolling
+   average over the last `--convergence-m` checks.
+3. A question is declared "converged at n" the first time its rolling
+   JSD stays below `--convergence-eps` for `--convergence-m` consecutive
+   checks, provided `n >= --convergence-min-n`.
+4. With `--auto-stop`, when *every* tracked question has converged the
+   run cancels pending futures and returns the panelists finished so far.
+
+## Flags
+
+| Flag | Default | Meaning |
+|------|---------|---------|
+| `--convergence-check-every N` | off (required to opt in) | Compute a convergence check every N completing panelists. |
+| `--convergence-log PATH` | stderr | Write each check as a JSON line to PATH instead of stderr. |
+| `--auto-stop` | off | Halt the run once every tracked question has converged. |
+| `--convergence-eps` | 0.02 | JSD threshold below which a question is treated as converged. |
+| `--convergence-min-n` | 50 | Minimum panelists before `--auto-stop` is allowed to fire. |
+| `--convergence-m` | 3 | Consecutive checks below epsilon required to declare convergence. |
+| `--convergence-baseline DATASET:Q` | off | Load a human baseline curve from synthbench and include in the report. Requires `pip install 'synthpanel[convergence]'`. |
+
+## Interpreting the report
+
+The JSON output grows a top-level `convergence` key:
+
+```jsonc
+{
+  "convergence": {
+    "final_n": 487,
+    "check_every": 20,
+    "epsilon": 0.02,
+    "min_n": 50,
+    "m_consecutive": 3,
+    "auto_stopped": true,
+    "overall_converged_at": 473,       // max converged_at across tracked questions
+    "tracked_questions": ["pricing", "tier_preference"],
+    "per_question": {
+      "pricing": {
+        "final_n": 487,
+        "converged_at": 473,
+        "support_size": 5,
+        "curve": [                      // downsampled to ~20 points
+          {"n": 20, "jsd": 0.11},
+          {"n": 40, "jsd": 0.045},
+          ...
+        ]
+      },
+      "tier_preference": {
+        "final_n": 487,
+        "converged_at": 410,
+        "support_size": 3,
+        "curve": [...]
+      }
+    },
+    "human_baseline": {                  // present only with --convergence-baseline
+      "dataset": "gss",
+      "question_key": "happiness",
+      "converged_at": 410,
+      "curve": [...]
+    }
+  }
+}
+```
+
+**Reading it:**
+- `overall_converged_at` is the answer to *"how many panelists did you
+  actually need?"* — run this many next time and trust the shape of the
+  distribution.
+- `auto_stopped: true` means the run halted itself; `false` means it ran
+  to completion but the report still shows where it converged.
+- The per-question `curve` is downsampled to ~20 points for plotting;
+  consult the `--convergence-log` JSONL stream for the full sequence if
+  you need to re-plot.
+- When `human_baseline` is present, compare `overall_converged_at`
+  against `human_baseline.converged_at` to measure the sampling-efficiency
+  ratio vs real humans. A ratio close to 1.0 means your synthetic panel
+  is as "efficient" as the human baseline at stabilizing — higher means
+  you need more synthetic respondents to match the same information
+  content.
+
+## When is auto-stop safe?
+
+Safe:
+- You want a point estimate ("the distribution is roughly X/Y/Z") rather
+  than a precise confidence interval.
+- Your bounded questions carry the signal you actually care about.
+- You have set `--convergence-min-n` high enough that the distribution
+  can't trivially look stable just because you've seen 20 panelists.
+
+Unsafe:
+- You are planning to slice the responses by a demographic subgroup.
+  JSD on the full population can look stable long before any given
+  subgroup has enough samples — inspect per-slice n before trusting the
+  halt.
+- Your key questions are free-text (not tracked) and the synthesis is
+  the deliverable. In that case leave `--auto-stop` off and just use
+  the telemetry to calibrate future runs.
+
+## Tuning
+
+- **`--convergence-check-every`**: lower values (10-20) give smoother
+  curves; higher values (50-100) reduce per-check noise at large n. For
+  panels under ~500 the default of 20 is fine.
+- **`--convergence-eps`**: 0.02 is tight — distributions that differ by
+  at most a couple of percentage points count as equal. Loosen to 0.05
+  if your support is small (e.g., yes/no) and you want faster halts.
+- **`--convergence-m`**: 3 is the minimum useful "stay below eps"
+  bar; lower values (1-2) are noise-prone, higher (5+) only help on
+  extremely heavy-tailed distributions.
+
+## Methodology notes
+
+Jensen-Shannon divergence is computed in base-2 so the output is bounded
+in `[0, 1]`. Empty or zero-support distributions return `0` (no signal —
+waiting on more data). Follow-up questions are excluded from tracking
+because they contain conditional text that would pollute the running
+distribution. Panelist errors silently drop out of the running counter
+— the distribution reflects only panelists that actually answered.
+
+## Related beads
+
+- `sp-yaru` — this feature
+- `sb-ygp7` — synthbench convergence bootstrap (required for
+  `--convergence-baseline`)
+- `sb-gh1n` — real-human microdata baseline (optional upgrade)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ composio = [
     "composio>=0.5",
     "pydantic>=2.0",
 ]
+convergence = [
+    "synthbench>=0.1",
+]
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1102,11 +1102,8 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             temperature=temperature,
             top_p=top_p,
             persona_models=persona_models,
-<<<<<<< HEAD
             max_workers=max_concurrent,
-=======
             convergence_tracker=convergence_tracker,
->>>>>>> 27d1fa6 (feat(convergence): live JSD telemetry + auto-stop for panel runs (sp-yaru))
         )
 
     # Build output results and aggregate panelist usage

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -23,6 +23,16 @@ from synth_panel._runners import (
     format_total_failure_message,
 )
 from synth_panel.cli.output import OutputFormat, emit
+from synth_panel.convergence import (
+    DEFAULT_CHECK_EVERY,
+    DEFAULT_EPSILON,
+    DEFAULT_M_CONSECUTIVE,
+    DEFAULT_MIN_N,
+    ConvergenceTracker,
+    SynthbenchUnavailableError,
+    identify_tracked_questions,
+    load_synthbench_baseline,
+)
 from synth_panel.cost import (
     ZERO_USAGE,
     CostEstimate,
@@ -995,6 +1005,65 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         emit(fmt, message="Ensemble complete", extra=output)
         return 0
 
+    # ── sp-yaru: convergence telemetry ───────────────────────────────────
+    # Build the tracker when any convergence flag opts in. We always
+    # respect --auto-stop / --convergence-baseline even if the user
+    # forgot --convergence-check-every, by falling back to the default
+    # cadence so those flags never silently no-op.
+    convergence_tracker: ConvergenceTracker | None = None
+    convergence_baseline_payload: dict[str, Any] | None = None
+    convergence_baseline_error: str | None = None
+    wants_convergence = any(
+        [
+            getattr(args, "convergence_check_every", None) is not None,
+            getattr(args, "auto_stop", False),
+            getattr(args, "convergence_log", None) is not None,
+            getattr(args, "convergence_baseline", None) is not None,
+            getattr(args, "convergence_eps", None) is not None,
+            getattr(args, "convergence_min_n", None) is not None,
+            getattr(args, "convergence_m", None) is not None,
+        ]
+    )
+    if wants_convergence:
+        tracked = identify_tracked_questions(questions)
+        if not tracked:
+            print(
+                "Warning: --convergence-* flags set but the instrument has no "
+                "bounded (Likert / yes-no / pick-one / enum) questions; "
+                "convergence tracking disabled.",
+                file=sys.stderr,
+            )
+        else:
+            # Resolve baseline before kicking off the run so a missing
+            # synthbench dep fails fast — we do not want to burn LLM
+            # spend on a run whose report we cannot assemble.
+            baseline_spec = getattr(args, "convergence_baseline", None)
+            if baseline_spec:
+                try:
+                    convergence_baseline_payload = load_synthbench_baseline(baseline_spec)
+                except SynthbenchUnavailableError as exc:
+                    print(f"Error: {exc}", file=sys.stderr)
+                    return 1
+                except (ValueError, RuntimeError) as exc:
+                    convergence_baseline_error = str(exc)
+                    print(
+                        f"Warning: could not load convergence baseline: {exc}",
+                        file=sys.stderr,
+                    )
+            convergence_tracker = ConvergenceTracker(
+                tracked,
+                check_every=getattr(args, "convergence_check_every", None) or DEFAULT_CHECK_EVERY,
+                epsilon=getattr(args, "convergence_eps", None) or DEFAULT_EPSILON,
+                min_n=(
+                    getattr(args, "convergence_min_n", None)
+                    if getattr(args, "convergence_min_n", None) is not None
+                    else DEFAULT_MIN_N
+                ),
+                m_consecutive=getattr(args, "convergence_m", None) or DEFAULT_M_CONSECUTIVE,
+                auto_stop=bool(getattr(args, "auto_stop", False)),
+                log_path=getattr(args, "convergence_log", None),
+            )
+
     # Run all panelists in parallel via the orchestrator
     blend_result = None  # populated only when --blend is active
     if blend_mode and model_spec:
@@ -1033,7 +1102,11 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             temperature=temperature,
             top_p=top_p,
             persona_models=persona_models,
+<<<<<<< HEAD
             max_workers=max_concurrent,
+=======
+            convergence_tracker=convergence_tracker,
+>>>>>>> 27d1fa6 (feat(convergence): live JSD telemetry + auto-stop for panel runs (sp-yaru))
         )
 
     # Build output results and aggregate panelist usage
@@ -1370,6 +1443,30 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             # Repeat the banner at the bottom so a scrolled terminal still
             # surfaces it — this is the critical fix for sp-2hg.
             print(banner, file=sys.stderr)
+        # sp-yaru: even in TEXT mode, render a compact convergence summary
+        # so operators watching stdout can see "converged at n=473" without
+        # re-running with --output-format json.
+        if convergence_tracker is not None:
+            report = convergence_tracker.build_report(baseline=convergence_baseline_payload)
+            convergence_tracker.close()
+            print("\n" + "=" * 60)
+            print("CONVERGENCE")
+            print("=" * 60)
+            overall = report.get("overall_converged_at")
+            if overall is None:
+                print(f"  overall: not yet converged (final n={report['final_n']})")
+            else:
+                print(f"  overall converged_at: n={overall}")
+            if report.get("auto_stopped"):
+                print(f"  auto-stopped at n={report['final_n']}")
+            for qkey, qdata in report.get("per_question", {}).items():
+                ca = qdata.get("converged_at")
+                ca_str = f"n={ca}" if ca else "pending"
+                print(f"  {qkey}: converged_at={ca_str}, support={qdata.get('support_size', 0)}")
+            if convergence_baseline_payload:
+                hb_n = convergence_baseline_payload.get("converged_at")
+                if hb_n is not None:
+                    print(f"  human baseline: converged_at=n={hb_n}")
     else:
         # sp-efip: mirror the TEXT-mode behaviour and print the fatal
         # banner to stderr even when JSON/NDJSON is the primary output.
@@ -1466,6 +1563,15 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # model answered which persona without re-deriving from the spec.
         if persona_models:
             extra["model_assignment"] = dict(persona_models)
+        # sp-yaru: surface convergence telemetry for large runs.
+        if convergence_tracker is not None:
+            convergence_report = convergence_tracker.build_report(
+                baseline=convergence_baseline_payload,
+            )
+            if convergence_baseline_error:
+                convergence_report["human_baseline_error"] = convergence_baseline_error
+            extra["convergence"] = convergence_report
+            convergence_tracker.close()
         # Include blend distributions when --blend is active
         if blend_result:
             extra["blend"] = {

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -345,7 +345,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Exits without calling any provider."
         ),
     )
-<<<<<<< HEAD
+    # sp-i2ub: scaled-orchestration knobs
     panel_run_parser.add_argument(
         "--max-concurrent",
         type=int,
@@ -368,7 +368,8 @@ def build_parser() -> argparse.ArgumentParser:
             "Cap requests-per-second across the panel via a token bucket. "
             "Smooths bursts on top of --max-concurrent. Accepts fractional "
             "values (e.g. 0.5 for one request every two seconds)."
-=======
+        ),
+    )
     # sp-yaru: convergence telemetry for large panels
     panel_run_parser.add_argument(
         "--convergence-check-every",
@@ -440,7 +441,6 @@ def build_parser() -> argparse.ArgumentParser:
             "pip install 'synthpanel[convergence]'. Format: "
             "'dataset:question_key' (e.g. 'gss:happiness') or just 'dataset' "
             "when the dataset has a single default question."
->>>>>>> 27d1fa6 (feat(convergence): live JSD telemetry + auto-stop for panel runs (sp-yaru))
         ),
     )
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -345,6 +345,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Exits without calling any provider."
         ),
     )
+<<<<<<< HEAD
     panel_run_parser.add_argument(
         "--max-concurrent",
         type=int,
@@ -367,6 +368,79 @@ def build_parser() -> argparse.ArgumentParser:
             "Cap requests-per-second across the panel via a token bucket. "
             "Smooths bursts on top of --max-concurrent. Accepts fractional "
             "values (e.g. 0.5 for one request every two seconds)."
+=======
+    # sp-yaru: convergence telemetry for large panels
+    panel_run_parser.add_argument(
+        "--convergence-check-every",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="convergence_check_every",
+        help=(
+            "Compute a running Jensen-Shannon divergence every N completing "
+            "panelists for every bounded (Likert / yes-no / pick-one / enum) "
+            "question. Enables the post-run convergence report. Default: off; "
+            "setting this flag opts in. See docs/convergence.md."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--convergence-log",
+        default=None,
+        metavar="PATH",
+        dest="convergence_log",
+        help=(
+            "Write each convergence check as a JSON line to PATH instead of "
+            "stderr. Useful for streaming into dashboards during long runs."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--auto-stop",
+        action="store_true",
+        default=False,
+        dest="auto_stop",
+        help=(
+            "Halt the panel once every tracked question's rolling-average JSD "
+            "stays below --convergence-eps for --convergence-m consecutive "
+            "checks (and n >= --convergence-min-n). Default: off. Requires "
+            "--convergence-check-every."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--convergence-eps",
+        type=float,
+        default=None,
+        metavar="FLOAT",
+        dest="convergence_eps",
+        help="JSD threshold below which a question is treated as converged (default: 0.02).",
+    )
+    panel_run_parser.add_argument(
+        "--convergence-min-n",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="convergence_min_n",
+        help="Minimum panelist count before --auto-stop is allowed to fire (default: 50).",
+    )
+    panel_run_parser.add_argument(
+        "--convergence-m",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="convergence_m",
+        help="Consecutive checks below epsilon required to declare convergence (default: 3).",
+    )
+    panel_run_parser.add_argument(
+        "--convergence-baseline",
+        default=None,
+        metavar="DATASET:QUESTION",
+        dest="convergence_baseline",
+        help=(
+            "Load a human baseline convergence curve from synthbench and "
+            "include it in the report. Requires the optional dependency: "
+            "pip install 'synthpanel[convergence]'. Format: "
+            "'dataset:question_key' (e.g. 'gss:happiness') or just 'dataset' "
+            "when the dataset has a single default question."
+>>>>>>> 27d1fa6 (feat(convergence): live JSD telemetry + auto-stop for panel runs (sp-yaru))
         ),
     )
 

--- a/src/synth_panel/convergence.py
+++ b/src/synth_panel/convergence.py
@@ -1,0 +1,607 @@
+"""Live convergence telemetry for panel runs (sp-yaru).
+
+At competitive-parity scales (n=500..10k) a narrative synthesis is less useful
+than watching the per-question response distribution stabilize. This module
+provides a :class:`ConvergenceTracker` that:
+
+1. Identifies which instrument questions have a *bounded* response space
+   (Likert / yes-no / pick-one / enum). Free-text questions are ignored.
+2. Records each completing panelist's categorical response and computes
+   Jensen-Shannon divergence between the distribution-so-far and the
+   last-``K``-batch after every K panelists.
+3. Optionally signals auto-stop once the rolling JSD stays below an
+   epsilon threshold for M consecutive checks (with a minimum-n floor).
+4. Produces a post-run ``convergence`` report describing per-question
+   curves, the smallest n at which convergence held, and — when the
+   caller supplied one — a human-baseline comparison.
+
+The tracker is **pure** — callers (the orchestrator) drive it and decide
+what to do with its signals. This keeps it trivially unit-testable
+without mocking the LLM stack.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sys
+import threading
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+DEFAULT_CHECK_EVERY = 20
+DEFAULT_EPSILON = 0.02
+DEFAULT_MIN_N = 50
+DEFAULT_M_CONSECUTIVE = 3
+DEFAULT_CURVE_POINTS = 20
+
+# Structured-response key heuristics. The bundled schemas
+# (src/synth_panel/structured/schemas.py) each reserve exactly one field
+# that carries the categorical answer; everything else is free-text
+# reasoning. Ordered most-specific → least-specific so a combined schema
+# is still keyed deterministically.
+_BOUNDED_KEYS: tuple[str, ...] = ("rating", "answer", "choice", "value", "label")
+
+
+# ---------------------------------------------------------------------------
+# JSD
+# ---------------------------------------------------------------------------
+
+
+def jensen_shannon_divergence(p: dict[str, float], q: dict[str, float]) -> float:
+    """Return JSD(P||Q) in base-2 so the result is bounded in ``[0, 1]``.
+
+    ``p`` and ``q`` are discrete distributions expressed as ``category → mass``.
+    They are normalized internally; empty distributions (or any pair whose
+    supports fail to normalize) return ``0.0`` — there is no meaningful
+    divergence to report on zero samples, and callers treat that as
+    "converged by default" only when enough panelists have arrived
+    (``min_n`` handles that separately).
+    """
+    if not p or not q:
+        return 0.0
+    p_total = sum(p.values())
+    q_total = sum(q.values())
+    if p_total <= 0 or q_total <= 0:
+        return 0.0
+    p_norm = {k: v / p_total for k, v in p.items()}
+    q_norm = {k: v / q_total for k, v in q.items()}
+    support = set(p_norm) | set(q_norm)
+
+    def _kl(a: dict[str, float], b: dict[str, float]) -> float:
+        total = 0.0
+        for k in support:
+            ak = a.get(k, 0.0)
+            bk = b.get(k, 0.0)
+            if ak <= 0.0 or bk <= 0.0:
+                continue
+            total += ak * math.log2(ak / bk)
+        return total
+
+    m = {k: 0.5 * (p_norm.get(k, 0.0) + q_norm.get(k, 0.0)) for k in support}
+    jsd = 0.5 * _kl(p_norm, m) + 0.5 * _kl(q_norm, m)
+    # Clamp floating-point drift so downstream eps comparisons stay stable.
+    return max(0.0, min(1.0, jsd))
+
+
+# ---------------------------------------------------------------------------
+# Question inspection
+# ---------------------------------------------------------------------------
+
+
+_KNOWN_BOUNDED_SCHEMA_NAMES: frozenset[str] = frozenset({"likert", "yes_no", "pick_one", "ranking"})
+
+
+def _question_key(question: dict[str, Any], index: int) -> str:
+    """Return a stable, human-meaningful key for a question."""
+    if not isinstance(question, dict):
+        return f"q{index}"
+    for candidate in ("key", "id", "name"):
+        value = question.get(candidate)
+        if isinstance(value, str) and value:
+            return value
+    text = question.get("text")
+    if isinstance(text, str) and text:
+        # Use the first 40 chars as a readable fallback key.
+        return text.strip()[:40] or f"q{index}"
+    return f"q{index}"
+
+
+def _schema_is_bounded(schema: Any) -> bool:
+    """True when a JSON Schema dict describes a categorical / enum output."""
+    if isinstance(schema, str):
+        return schema in _KNOWN_BOUNDED_SCHEMA_NAMES
+    if not isinstance(schema, dict):
+        return False
+    # Top-level enum field
+    if isinstance(schema.get("enum"), list):
+        return True
+    props = schema.get("properties")
+    if isinstance(props, dict):
+        for prop in props.values():
+            if not isinstance(prop, dict):
+                continue
+            if isinstance(prop.get("enum"), list):
+                return True
+            # Known scalar types that imply a small support. We
+            # deliberately do NOT treat plain ``"type": "string"`` as
+            # bounded — that would pull every free-text field into the
+            # tracker and pollute the report.
+            if prop.get("type") == "boolean":
+                return True
+    return False
+
+
+def _is_tracked(question: dict[str, Any]) -> bool:
+    """True when a question's response space is bounded enough to track."""
+    if not isinstance(question, dict):
+        return False
+    extraction = question.get("extraction_schema")
+    if _schema_is_bounded(extraction):
+        return True
+    response = question.get("response_schema")
+    if isinstance(response, dict):
+        if response.get("type") == "scaled":
+            return True
+        if response.get("type") == "enum":
+            return True
+        if isinstance(response.get("options"), list):
+            return True
+    return bool(_schema_is_bounded(response))
+
+
+def identify_tracked_questions(
+    questions: list[dict[str, Any]],
+) -> list[tuple[int, str, dict[str, Any]]]:
+    """Return ``[(index, key, question_dict)]`` for every bounded question.
+
+    Questions whose response space is unconstrained (free text) are
+    dropped — JSD on free-text responses is ill-defined and would just
+    measure paraphrase noise.
+    """
+    tracked: list[tuple[int, str, dict[str, Any]]] = []
+    for i, q in enumerate(questions):
+        if _is_tracked(q):
+            tracked.append((i, _question_key(q, i), q))
+    return tracked
+
+
+# ---------------------------------------------------------------------------
+# Response → category extraction
+# ---------------------------------------------------------------------------
+
+
+def _coerce_category(value: Any) -> str | None:
+    """Normalize a structured response value into a hashable category label."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            return None
+        return str(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, list):
+        # For multi-pick or ranking responses use a stable joined form.
+        parts = [_coerce_category(v) for v in value]
+        parts_clean = [p for p in parts if p is not None]
+        return "|".join(parts_clean) if parts_clean else None
+    if isinstance(value, dict):
+        # Pick the most-specific known field, otherwise sort-join keys so
+        # the category is stable across runs.
+        for key in _BOUNDED_KEYS:
+            if key in value:
+                return _coerce_category(value[key])
+        try:
+            return json.dumps(value, sort_keys=True, default=str)
+        except TypeError:
+            return None
+    return None
+
+
+def extract_category(response_entry: dict[str, Any]) -> str | None:
+    """Pull a bounded category from one panelist response dict.
+
+    The orchestrator stores each response as
+    ``{"question": str, "response": text|dict, "structured"?: bool, "extraction"?: dict}``.
+    We prefer structured payloads (extraction or structured response dicts)
+    because their support is intentional; plain strings fall through only
+    if the whole value parses to one of the bounded key fields.
+    """
+    if not isinstance(response_entry, dict):
+        return None
+    if response_entry.get("error"):
+        return None
+    # Prefer an explicit extraction payload.
+    extraction = response_entry.get("extraction")
+    if isinstance(extraction, dict):
+        for key in _BOUNDED_KEYS:
+            if key in extraction:
+                return _coerce_category(extraction[key])
+        # Fallback: extraction dict with a single key.
+        if len(extraction) == 1:
+            only_key = next(iter(extraction))
+            return _coerce_category(extraction[only_key])
+    # Then structured response bodies.
+    response = response_entry.get("response")
+    if isinstance(response, dict):
+        return _coerce_category(response)
+    # Plain text responses: only yield a category when the raw value is
+    # itself a short bounded token (e.g. ``"yes"``). Otherwise return
+    # None so tracking stays opt-in per question.
+    if isinstance(response, str):
+        text = response.strip().lower()
+        if text in {"yes", "no", "true", "false"}:
+            return text
+    return None
+
+
+def extract_categorical_responses(
+    panelist_result: Any,
+    tracked: list[tuple[int, str, dict[str, Any]]],
+) -> dict[str, str]:
+    """Return ``{question_key: category_label}`` for one panelist.
+
+    Missing responses (failures, un-extractable free text) are simply
+    omitted so the running distributions stay honest.
+    """
+    responses = getattr(panelist_result, "responses", None)
+    if not isinstance(responses, list):
+        return {}
+    # The orchestrator may inject follow-up turns, so we step through
+    # main-question responses in order, skipping follow-up-flagged rows.
+    main_iter = (r for r in responses if isinstance(r, dict) and not r.get("follow_up"))
+    main_list = list(main_iter)
+    out: dict[str, str] = {}
+    for q_idx, q_key, _q in tracked:
+        if q_idx >= len(main_list):
+            continue
+        category = extract_category(main_list[q_idx])
+        if category is not None:
+            out[q_key] = category
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tracker
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _QuestionState:
+    """Per-question running state inside the tracker."""
+
+    key: str
+    cumulative: Counter = field(default_factory=Counter)
+    last_batch: Counter = field(default_factory=Counter)
+    rolling_jsd: list[float] = field(default_factory=list)
+    per_n_jsd: list[tuple[int, float]] = field(default_factory=list)
+    # Smallest n at which *rolling_jsd* stayed below epsilon for M checks
+    converged_at: int | None = None
+
+
+@dataclass
+class ConvergenceCheck:
+    """One instant-in-time convergence reading, emitted per K panelists."""
+
+    n_completed: int
+    per_question: dict[str, dict[str, float]]
+
+
+class ConvergenceTracker:
+    """Running convergence metrics for a panel run.
+
+    The tracker is thread-compatible: orchestrator threads may call
+    :meth:`record` concurrently; a single internal lock serializes state
+    updates. Callers should drive :meth:`should_stop` from a single
+    thread after each record, and prepare the final report via
+    :meth:`build_report` once the run ends.
+    """
+
+    def __init__(
+        self,
+        tracked: list[tuple[int, str, dict[str, Any]]],
+        *,
+        check_every: int = DEFAULT_CHECK_EVERY,
+        epsilon: float = DEFAULT_EPSILON,
+        min_n: int = DEFAULT_MIN_N,
+        m_consecutive: int = DEFAULT_M_CONSECUTIVE,
+        auto_stop: bool = False,
+        log_path: str | None = None,
+    ) -> None:
+        if check_every < 1:
+            raise ValueError("check_every must be >= 1")
+        if epsilon < 0.0:
+            raise ValueError("epsilon must be >= 0")
+        if min_n < 0:
+            raise ValueError("min_n must be >= 0")
+        if m_consecutive < 1:
+            raise ValueError("m_consecutive must be >= 1")
+
+        self._tracked = tracked
+        self._keys = [k for _i, k, _q in tracked]
+        self._check_every = check_every
+        self._epsilon = epsilon
+        self._min_n = min_n
+        self._m = m_consecutive
+        self._auto_stop = auto_stop
+        self._log_path = log_path
+        self._states: dict[str, _QuestionState] = {k: _QuestionState(key=k) for k in self._keys}
+        self._n = 0
+        self._last_check_n = 0
+        self._auto_stopped = False
+        self._checks: list[ConvergenceCheck] = []
+        self._lock = threading.Lock()
+        self._log_fh: Any = None
+        if log_path:
+            try:
+                self._log_fh = open(log_path, "a", buffering=1, encoding="utf-8")  # noqa: SIM115
+            except OSError as exc:
+                logger.warning("could not open convergence log %s: %s", log_path, exc)
+                self._log_fh = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def tracked_keys(self) -> list[str]:
+        return list(self._keys)
+
+    @property
+    def auto_stopped(self) -> bool:
+        return self._auto_stopped
+
+    @property
+    def overall_converged_at(self) -> int | None:
+        with self._lock:
+            return self._overall_converged_at_locked()
+
+    def record(self, categorical: dict[str, str]) -> bool:
+        """Add one panelist's categorical responses.
+
+        Returns ``True`` when the batch just crossed a check boundary
+        *and* the run should stop (auto_stop satisfied). Callers that
+        do not want auto-stop can ignore the return value — the stop
+        signal is only raised when :attr:`auto_stop` is enabled.
+        """
+        with self._lock:
+            self._n += 1
+            for key, value in categorical.items():
+                state = self._states.get(key)
+                if state is None:
+                    continue
+                state.cumulative[value] += 1
+                state.last_batch[value] += 1
+            if self._n - self._last_check_n >= self._check_every:
+                check = self._run_check_locked()
+                self._emit_log(check)
+                self._last_check_n = self._n
+                # Reset last-batch buckets after each check.
+                for state in self._states.values():
+                    state.last_batch = Counter()
+                if self._auto_stop and self._is_converged_locked() and self._n >= self._min_n:
+                    self._auto_stopped = True
+                    return True
+        return False
+
+    def close(self) -> None:
+        """Flush and close the optional log file."""
+        if self._log_fh is not None:
+            try:
+                self._log_fh.flush()
+                self._log_fh.close()
+            except OSError:
+                pass
+            self._log_fh = None
+
+    def build_report(
+        self,
+        *,
+        baseline: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Assemble the post-run ``convergence`` section.
+
+        ``baseline`` — when provided — is spliced in verbatim under
+        ``human_baseline``; the caller owns the lookup against SynthBench
+        so this module stays free of optional-dep imports.
+        """
+        with self._lock:
+            per_question: dict[str, Any] = {}
+            for key, state in self._states.items():
+                curve = _downsample_curve(state.per_n_jsd, DEFAULT_CURVE_POINTS)
+                per_question[key] = {
+                    "final_n": self._n,
+                    "converged_at": state.converged_at,
+                    "curve": [{"n": n, "jsd": round(jsd, 6)} for n, jsd in curve],
+                    "support_size": len(state.cumulative),
+                }
+            overall = self._overall_converged_at_locked()
+            report: dict[str, Any] = {
+                "final_n": self._n,
+                "check_every": self._check_every,
+                "epsilon": self._epsilon,
+                "min_n": self._min_n,
+                "m_consecutive": self._m,
+                "auto_stopped": self._auto_stopped,
+                "overall_converged_at": overall,
+                "tracked_questions": list(self._keys),
+                "per_question": per_question,
+                "human_baseline": baseline,
+            }
+            return report
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _run_check_locked(self) -> ConvergenceCheck:
+        per_q: dict[str, dict[str, float]] = {}
+        for key, state in self._states.items():
+            if sum(state.last_batch.values()) == 0:
+                jsd = 0.0
+            else:
+                # Compare the post-batch cumulative distribution against
+                # just the last K observations. ``cumulative`` contains
+                # the batch itself, which is the definition from the
+                # acceptance criteria.
+                p = {k: float(v) for k, v in state.cumulative.items()}
+                q = {k: float(v) for k, v in state.last_batch.items()}
+                jsd = jensen_shannon_divergence(p, q)
+            state.per_n_jsd.append((self._n, jsd))
+            state.rolling_jsd.append(jsd)
+            rolling = _rolling_average(state.rolling_jsd, self._m)
+            # First n at which the rolling mean crosses below epsilon and
+            # stays there for M consecutive checks is our converged_at.
+            if (
+                state.converged_at is None
+                and len(state.rolling_jsd) >= self._m
+                and all(j < self._epsilon for j in state.rolling_jsd[-self._m :])
+                and self._n >= self._min_n
+            ):
+                state.converged_at = self._n
+            per_q[key] = {
+                "jsd_last_batch": round(jsd, 6),
+                "jsd_rolling_avg_3": round(rolling, 6),
+            }
+        check = ConvergenceCheck(n_completed=self._n, per_question=per_q)
+        self._checks.append(check)
+        return check
+
+    def _is_converged_locked(self) -> bool:
+        # All tracked questions must have a converged_at by now.
+        if not self._states:
+            return False
+        return all(state.converged_at is not None for state in self._states.values())
+
+    def _overall_converged_at_locked(self) -> int | None:
+        values = [s.converged_at for s in self._states.values() if s.converged_at is not None]
+        if not values:
+            return None
+        if len(values) != len(self._states):
+            # Not every question converged — don't report an overall value.
+            return None
+        return max(values)
+
+    def _emit_log(self, check: ConvergenceCheck) -> None:
+        payload = {
+            "n_completed": check.n_completed,
+            "per_question": check.per_question,
+        }
+        line = json.dumps(payload, sort_keys=True, default=str)
+        if self._log_fh is not None:
+            try:
+                self._log_fh.write(line + "\n")
+            except OSError as exc:
+                logger.warning("convergence log write failed: %s", exc)
+        else:
+            print(line, file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _rolling_average(values: list[float], window: int) -> float:
+    if not values:
+        return 0.0
+    tail = values[-window:]
+    return sum(tail) / len(tail)
+
+
+def _downsample_curve(points: list[tuple[int, float]], target: int) -> list[tuple[int, float]]:
+    """Return at most ``target`` evenly-spaced samples, keeping endpoints."""
+    if target <= 0 or not points:
+        return []
+    if len(points) <= target:
+        return list(points)
+    step = (len(points) - 1) / (target - 1)
+    selected: list[tuple[int, float]] = []
+    seen: set[int] = set()
+    for i in range(target):
+        idx = round(i * step)
+        idx = max(0, min(len(points) - 1, idx))
+        if idx in seen:
+            continue
+        seen.add(idx)
+        selected.append(points[idx])
+    return selected
+
+
+# ---------------------------------------------------------------------------
+# Synthbench baseline (soft dependency)
+# ---------------------------------------------------------------------------
+
+
+class SynthbenchUnavailableError(RuntimeError):
+    """Raised when --convergence-baseline is requested but synthbench is missing."""
+
+
+def load_synthbench_baseline(spec: str) -> dict[str, Any]:
+    """Resolve a ``dataset:question_key`` baseline against synthbench.
+
+    The bead lists synthbench as a *soft* dependency — we install it via
+    the ``synthpanel[convergence]`` extras and import lazily so the core
+    path never breaks when users haven't opted in. When the dependency
+    is missing we raise :class:`SynthbenchUnavailableError` with an
+    actionable install hint so the CLI can surface it verbatim.
+
+    ``spec`` accepts either ``"dataset:question_key"`` (preferred) or
+    ``"dataset"`` when the dataset exposes a single default question.
+    """
+    try:
+        import synthbench  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover - exercised via patched import
+        raise SynthbenchUnavailableError(
+            "synthbench is required for --convergence-baseline. Install it with: pip install 'synthpanel[convergence]'"
+        ) from exc
+
+    dataset, _, question_key = spec.partition(":")
+    dataset = dataset.strip()
+    question_key = question_key.strip() or None
+    if not dataset:
+        raise ValueError(f"invalid baseline spec: {spec!r}")
+
+    # Try the documented interface first; fall back to any attribute
+    # synthbench chooses to expose so sb-ygp7 can rename without
+    # breaking this call site.
+    loader = None
+    for candidate in ("load_convergence_baseline", "load_baseline", "convergence_baseline"):
+        loader = getattr(synthbench, candidate, None)
+        if loader is None and hasattr(synthbench, "convergence"):
+            loader = getattr(synthbench.convergence, candidate, None)
+        if loader is not None:
+            break
+    if loader is None:
+        raise SynthbenchUnavailableError(
+            "synthbench is installed but does not expose a convergence baseline loader. "
+            "Upgrade synthbench to a version that ships sb-ygp7 (convergence bootstrap)."
+        )
+
+    try:
+        data = loader(dataset=dataset, question_key=question_key) if question_key else loader(dataset=dataset)
+    except TypeError:
+        # Older loader signatures may accept positional args only.
+        data = loader(dataset, question_key) if question_key else loader(dataset)
+
+    if not isinstance(data, dict):
+        raise SynthbenchUnavailableError(f"synthbench baseline loader returned {type(data).__name__}, expected dict")
+    result = dict(data)
+    result.setdefault("dataset", dataset)
+    if question_key is not None:
+        result.setdefault("question_key", question_key)
+    return result

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -18,6 +18,7 @@ from enum import Enum
 from typing import Any
 
 from synth_panel.conditions import evaluate_condition, normalize_follow_up
+from synth_panel.convergence import ConvergenceTracker, extract_categorical_responses
 from synth_panel.cost import ZERO_USAGE, TokenUsage, UsageTracker
 from synth_panel.instrument import END_SENTINEL, Instrument, Round
 from synth_panel.llm.client import LLMClient
@@ -528,6 +529,7 @@ def run_panel_parallel(
     temperature: float | None = None,
     top_p: float | None = None,
     persona_models: dict[str, str] | None = None,
+    convergence_tracker: ConvergenceTracker | None = None,
 ) -> tuple[list[PanelistResult], WorkerRegistry, dict[str, Session]]:
     """Run all panelists in parallel and return ordered results.
 
@@ -552,6 +554,12 @@ def run_panel_parallel(
             an ``extraction`` key alongside the raw ``response``.
         persona_models: Optional mapping of persona name → model override.
             Resolution order: persona_models[name] > model (global default).
+        convergence_tracker: Optional :class:`ConvergenceTracker`. When
+            supplied, each completing panelist's categorical responses are
+            recorded; if the tracker signals auto-stop, pending futures are
+            cancelled and ``run_panel_parallel`` returns only the panelists
+            that had already finished. Errored panelists are still surfaced
+            — they never contribute to the running distributions.
 
     Returns:
         Tuple of (ordered results matching persona order, registry,
@@ -581,6 +589,15 @@ def run_panel_parallel(
     results: list[PanelistResult | None] = [None] * len(personas)
     out_sessions: dict[str, Session] = {}
     session_lock = threading.Lock()
+
+    # sp-yaru: build a per-run list of the bounded questions so the tracker
+    # and the orchestrator agree on indices. Done outside the executor
+    # so no worker pays the inspection cost.
+    tracked_questions: list[tuple[int, str, dict[str, Any]]] = []
+    if convergence_tracker is not None:
+        tracked_questions = [
+            (i, k, q) for i, k, q in _inspect_bounded_questions(questions) if k in set(convergence_tracker.tracked_keys)
+        ]
 
     with ThreadPoolExecutor(max_workers=effective_workers) as executor:
         future_to_index = {}
@@ -626,8 +643,37 @@ def run_panel_parallel(
                     model=model,
                 )
 
-    # All slots should be filled; cast away None
+            if convergence_tracker is not None and results[idx] is not None:
+                completed_result = results[idx]
+                assert completed_result is not None  # help mypy; checked above
+                if completed_result.error is None:
+                    categorical = extract_categorical_responses(completed_result, tracked_questions)
+                    try:
+                        should_stop = convergence_tracker.record(categorical)
+                    except Exception as track_exc:  # pragma: no cover - defensive
+                        logger.warning("convergence tracker record failed: %s", track_exc)
+                        should_stop = False
+                    if should_stop:
+                        logger.info(
+                            "auto-stop: convergence reached at n=%d; cancelling pending futures",
+                            convergence_tracker.overall_converged_at or 0,
+                        )
+                        for pending_future in future_to_index:
+                            if not pending_future.done():
+                                pending_future.cancel()
+                        break
+
+    # All slots should be filled (unless auto-stop cancelled some); drop Nones
     return [r for r in results if r is not None], registry, out_sessions
+
+
+def _inspect_bounded_questions(
+    questions: list[dict[str, Any]],
+) -> list[tuple[int, str, dict[str, Any]]]:
+    """Local wrapper so the orchestrator can share tracker tagging."""
+    from synth_panel.convergence import identify_tracked_questions
+
+    return identify_tracked_questions(questions)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_convergence_metric.py
+++ b/tests/test_convergence_metric.py
@@ -1,0 +1,262 @@
+"""Tests for live convergence telemetry (sp-yaru).
+
+Exercises the ConvergenceTracker directly (no LLM stack required) plus
+the boundaries where the tracker integrates with CLI output and the
+optional synthbench baseline dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from synth_panel.convergence import (
+    DEFAULT_EPSILON,
+    ConvergenceTracker,
+    SynthbenchUnavailableError,
+    extract_categorical_responses,
+    identify_tracked_questions,
+    jensen_shannon_divergence,
+    load_synthbench_baseline,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _panelist(category_by_key: dict[str, str], tracked_keys: list[str]) -> Any:
+    """Build a PanelistResult-shaped stub.
+
+    ``category_by_key`` maps a question key to the extracted category
+    label; anything missing becomes a text response the tracker will
+    skip. Order of ``tracked_keys`` determines the main-question order.
+    """
+    responses = []
+    for key in tracked_keys:
+        if key in category_by_key:
+            responses.append(
+                {
+                    "question": key,
+                    "response": {"choice": category_by_key[key]},
+                    "structured": True,
+                }
+            )
+        else:
+            responses.append({"question": key, "response": "free text"})
+    return SimpleNamespace(responses=responses, error=None)
+
+
+def _pick_one_question(key: str) -> dict[str, Any]:
+    return {
+        "text": f"Question {key}?",
+        "key": key,
+        "extraction_schema": "pick_one",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Acceptance-criteria-6 tests
+# ---------------------------------------------------------------------------
+
+
+def test_rolling_jsd_computed_after_k_panelists(capsys):
+    """Distribution checks fire exactly every K completing panelists."""
+    questions = [_pick_one_question("pricing")]
+    tracked = identify_tracked_questions(questions)
+    assert [k for _i, k, _q in tracked] == ["pricing"]
+
+    tracker = ConvergenceTracker(tracked, check_every=5, epsilon=0.02, min_n=0, m_consecutive=2)
+    for _ in range(4):
+        tracker.record({"pricing": "A"})
+    # Below K threshold — no check emitted yet.
+    err_out = capsys.readouterr().err
+    assert err_out == ""
+    tracker.record({"pricing": "B"})
+
+    err_out = capsys.readouterr().err.strip().splitlines()
+    assert len(err_out) == 1
+    payload = json.loads(err_out[0])
+    assert payload["n_completed"] == 5
+    assert "pricing" in payload["per_question"]
+    reading = payload["per_question"]["pricing"]
+    assert "jsd_last_batch" in reading
+    assert "jsd_rolling_avg_3" in reading
+    # JSD should be bounded in [0, 1].
+    assert 0.0 <= reading["jsd_last_batch"] <= 1.0
+
+
+def test_auto_stop_triggers_when_threshold_met():
+    """Uniform distribution → rolling JSD → 0 → auto-stop fires."""
+    questions = [_pick_one_question("choice")]
+    tracked = identify_tracked_questions(questions)
+    tracker = ConvergenceTracker(
+        tracked,
+        check_every=5,
+        epsilon=0.05,
+        min_n=10,
+        m_consecutive=2,
+        auto_stop=True,
+    )
+    stopped_at: int | None = None
+    for i in range(100):
+        # Deterministic cycle through 4 categories → perfectly uniform.
+        cat = ["A", "B", "C", "D"][i % 4]
+        if tracker.record({"choice": cat}):
+            stopped_at = i + 1
+            break
+
+    assert stopped_at is not None, "tracker did not auto-stop on a stable uniform distribution"
+    assert stopped_at >= 10, "auto-stop fired before min_n"
+    assert tracker.auto_stopped is True
+    assert tracker.overall_converged_at is not None
+    assert tracker.overall_converged_at <= stopped_at
+
+
+def test_auto_stop_respects_min_n():
+    """A tiny min_n floor blocks premature auto-stop even when JSD is 0."""
+    questions = [_pick_one_question("q")]
+    tracked = identify_tracked_questions(questions)
+    tracker = ConvergenceTracker(
+        tracked,
+        check_every=2,
+        epsilon=DEFAULT_EPSILON,
+        min_n=50,
+        m_consecutive=2,
+        auto_stop=True,
+    )
+    # Twenty identical records — JSD = 0 immediately, but min_n=50 should
+    # keep auto_stop from firing.
+    for _ in range(20):
+        stopped = tracker.record({"q": "always-A"})
+        assert stopped is False
+    assert tracker.auto_stopped is False
+
+
+def test_convergence_report_shape():
+    """build_report returns the documented shape from the bead."""
+    questions = [_pick_one_question("a"), _pick_one_question("b")]
+    tracked = identify_tracked_questions(questions)
+    tracker = ConvergenceTracker(
+        tracked,
+        check_every=3,
+        epsilon=0.02,
+        min_n=0,
+        m_consecutive=2,
+    )
+    # Feed enough panelists to trigger at least a couple of checks so
+    # converged_at has a chance to latch on question "a".
+    for i in range(15):
+        tracker.record({"a": "steady", "b": ["x", "y"][i % 2]})
+
+    report = tracker.build_report()
+    assert set(report.keys()) >= {
+        "final_n",
+        "check_every",
+        "epsilon",
+        "min_n",
+        "m_consecutive",
+        "auto_stopped",
+        "overall_converged_at",
+        "tracked_questions",
+        "per_question",
+        "human_baseline",
+    }
+    assert report["final_n"] == 15
+    assert report["check_every"] == 3
+    assert report["tracked_questions"] == ["a", "b"]
+    for qkey in ("a", "b"):
+        qrep = report["per_question"][qkey]
+        assert qrep["final_n"] == 15
+        assert isinstance(qrep["curve"], list)
+        assert all(set(p.keys()) == {"n", "jsd"} for p in qrep["curve"])
+        # Converged_at is either None or an integer <= final_n.
+        ca = qrep["converged_at"]
+        assert ca is None or (isinstance(ca, int) and ca <= 15)
+
+
+def test_convergence_baseline_loaded_when_synthbench_available(monkeypatch):
+    """When synthbench exposes a loader, the payload is returned verbatim."""
+    fake_baseline = {"converged_at": 410, "curve": [{"n": 10, "jsd": 0.4}]}
+
+    class _FakeSynthbench:
+        @staticmethod
+        def load_convergence_baseline(dataset: str, question_key: str | None = None) -> dict:
+            assert dataset == "gss"
+            assert question_key == "happiness"
+            return dict(fake_baseline)
+
+    monkeypatch.setitem(sys.modules, "synthbench", _FakeSynthbench())
+
+    result = load_synthbench_baseline("gss:happiness")
+    assert result["converged_at"] == 410
+    assert result["dataset"] == "gss"
+    assert result["question_key"] == "happiness"
+    assert result["curve"] == fake_baseline["curve"]
+
+
+def test_convergence_baseline_clear_error_when_synthbench_missing(monkeypatch):
+    """Missing synthbench raises a typed error with install instructions."""
+    # Force ``import synthbench`` to fail even if the user has it
+    # installed in their dev env.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocking_import(name: str, *args: object, **kwargs: object) -> Any:
+        if name == "synthbench" or name.startswith("synthbench."):
+            raise ImportError("No module named 'synthbench'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _blocking_import)
+    # Clear any cached synthbench import from previous tests.
+    for mod in list(sys.modules):
+        if mod == "synthbench" or mod.startswith("synthbench."):
+            monkeypatch.delitem(sys.modules, mod, raising=False)
+
+    with pytest.raises(SynthbenchUnavailableError) as exc_info:
+        load_synthbench_baseline("gss:happiness")
+    msg = str(exc_info.value)
+    assert "synthpanel[convergence]" in msg
+    assert "pip install" in msg
+
+
+# ---------------------------------------------------------------------------
+# Support behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_jensen_shannon_divergence_bounds():
+    assert jensen_shannon_divergence({"a": 1}, {"a": 1}) == 0.0
+    # Disjoint supports hit the JSD upper bound (1.0 in base-2).
+    assert jensen_shannon_divergence({"a": 1}, {"b": 1}) == pytest.approx(1.0)
+    # Empty → 0 (no-signal default).
+    assert jensen_shannon_divergence({}, {"a": 1}) == 0.0
+
+
+def test_identify_tracked_questions_ignores_free_text():
+    questions = [
+        {"text": "Free form?", "key": "free"},
+        _pick_one_question("bounded"),
+        {"text": "Enum?", "key": "enum", "response_schema": {"type": "enum", "options": ["x", "y"]}},
+    ]
+    tracked = identify_tracked_questions(questions)
+    keys = [k for _i, k, _q in tracked]
+    assert "free" not in keys
+    assert "bounded" in keys
+    assert "enum" in keys
+
+
+def test_extract_categorical_skips_errored_responses():
+    tracked = identify_tracked_questions([_pick_one_question("q")])
+    pr = SimpleNamespace(
+        responses=[
+            {"question": "q", "response": "err", "error": True},
+        ],
+        error=None,
+    )
+    assert extract_categorical_responses(pr, tracked) == {}


### PR DESCRIPTION
## Summary
- Emit live Jensen-Shannon divergence telemetry across the panel as responses stream in
- Add an auto-stop trigger when convergence stabilizes, so larger panels don't over-sample once signal saturates
- New `docs/convergence.md` explains the metric, CLI flags, and interpretation guidance

## Source
- Polecat: slit
- Issue: sp-yaru
- MR: sp-wisp-1e3
- Branch: polecat/slit-moa7xx06

## Test plan
- [ ] CI passes (new coverage in test_convergence_metric.py)
- [ ] Auto-stop fires on a convergent-signal fixture panel; does not fire on a divergent-signal fixture

## Conflict note
Touches cli/commands.py, cli/parser.py, orchestrator.py, README.md, pyproject.toml — overlaps with open CLI/runtime stack (#222, #223, #225). Rebase likely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)