### PR TITLE
fix(cost): resolve deepseek-v3 and gemini-flash-lite aliases (sp-9gcm)

### DIFF
--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -129,6 +129,18 @@ GEMINI_FLASH_PRICING = ModelPricing(
     cache_read_cost_per_million=0.04,
 )
 
+# Gemini 2.5 Flash-Lite (OpenRouter: ``google/gemini-2.5-flash-lite``).
+# Published Google rates: $0.10/M input, $0.40/M output, $0.025/M cache read.
+# cache_creation approximated at input rate (Google bills cache writes close to
+# input rate). sp-9gcm: previously fell through the ``gemini`` substring to
+# GEMINI_FLASH_PRICING, overstating the local-table estimate by ~41%.
+GEMINI_FLASH_LITE_PRICING = ModelPricing(
+    input_cost_per_million=0.10,
+    output_cost_per_million=0.40,
+    cache_creation_cost_per_million=0.10,
+    cache_read_cost_per_million=0.025,
+)
+
 GEMINI_PRO_PRICING = ModelPricing(
     input_cost_per_million=1.25,
     output_cost_per_million=10.00,
@@ -270,6 +282,11 @@ _PRICING_TABLE: dict[str, ModelPricing] = {
     "sonnet": SONNET_PRICING,
     "opus": OPUS_PRICING,
     "gemini-2.5-pro": GEMINI_PRO_PRICING,
+    # sp-9gcm: ``flash-lite`` (distinctive substring) must precede the bare
+    # ``gemini`` key so Lite models don't inherit full-flash rates (~41%
+    # overstatement). Matches both bare ``gemini-flash-lite`` and the
+    # OpenRouter form ``gemini-2.5-flash-lite``.
+    "flash-lite": GEMINI_FLASH_LITE_PRICING,
     "gemini": GEMINI_FLASH_PRICING,
     "gpt-5-mini": GPT_5_MINI_PRICING,
     "gpt-4.1-mini": GPT_4_1_MINI_PRICING,
@@ -281,6 +298,11 @@ _PRICING_TABLE: dict[str, ModelPricing] = {
     "deepseek-v3.2-speciale": DEEPSEEK_V3_2_SPECIALE_PRICING,
     "deepseek-v3.2-exp": DEEPSEEK_V3_2_EXP_PRICING,
     "deepseek-v3.2": DEEPSEEK_V3_2_PRICING,
+    # ``deepseek-v3`` (sp-9gcm): OpenRouter's short route that resolves to the
+    # v3.2 family. Placed after v3.2-* keys so the specific variants still win
+    # when present; catches bare ``deepseek-v3`` and any future ``deepseek-v3.x``
+    # before they fall through to DEFAULT_PRICING.
+    "deepseek-v3": DEEPSEEK_V3_2_PRICING,
     "deepseek-chat": DEEPSEEK_CHAT_PRICING,
     # Qwen entries — ``qwen3.6-plus`` before ``qwen3-plus`` (the former
     # contains the latter only by coincidence, but keep specific-first

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -9,6 +9,7 @@ from synth_panel.cost import (
     DEEPSEEK_V3_2_EXP_PRICING,
     DEEPSEEK_V3_2_PRICING,
     DEEPSEEK_V3_2_SPECIALE_PRICING,
+    GEMINI_FLASH_LITE_PRICING,
     GEMINI_FLASH_PRICING,
     GEMINI_PRO_PRICING,
     GPT_4_1_MINI_PRICING,
@@ -144,12 +145,36 @@ class TestPricingLookup:
             ("openrouter/qwen/qwen3.6-plus", QWEN3_6_PLUS_PRICING),
             ("qwen3.6-plus", QWEN3_6_PLUS_PRICING),
             ("openrouter/qwen/qwen3-max", QWEN3_MAX_PRICING),
+            # sp-9gcm: bare ``deepseek-v3`` (OpenRouter's short route that
+            # resolves to v3.2) must hit the v3.2 entry, not DEFAULT_PRICING.
+            ("deepseek-v3", DEEPSEEK_V3_2_PRICING),
+            ("openrouter/deepseek/deepseek-v3", DEEPSEEK_V3_2_PRICING),
+            # sp-9gcm: ``gemini-flash-lite`` must win over the generic
+            # ``gemini`` substring (which used to overstate cost by ~41%).
+            ("gemini-flash-lite", GEMINI_FLASH_LITE_PRICING),
+            ("openrouter/google/gemini-2.5-flash-lite", GEMINI_FLASH_LITE_PRICING),
         ],
     )
     def test_openrouter_common_models(self, model, expected):
         p, est = lookup_pricing(model)
         assert p is expected
         assert est is False
+
+    def test_deepseek_v3_bare_not_default(self):
+        """sp-9gcm regression: ``deepseek-v3`` must not fall through to
+        DEFAULT_PRICING (SONNET rates), which would overstate cost ~15x."""
+        p, est = lookup_pricing("deepseek-v3")
+        assert p is DEEPSEEK_V3_2_PRICING
+        assert p is not SONNET_PRICING
+        assert est is False
+
+    def test_gemini_flash_lite_precedence_over_gemini(self):
+        """sp-9gcm regression: ``gemini-flash-lite`` must win over the bare
+        ``gemini`` key — order in _PRICING_TABLE matters, same pattern as
+        ``gpt-4o-mini`` vs ``gpt-4o``."""
+        p, _ = lookup_pricing("gemini-flash-lite")
+        assert p is GEMINI_FLASH_LITE_PRICING
+        assert p is not GEMINI_FLASH_PRICING
 
     def test_deepseek_v3_2_variant_precedence(self):
         """sp-oshf: ``-speciale`` and ``-exp`` suffixes must win over the bare


### PR DESCRIPTION
## Summary
- Resolve `deepseek-v3` and `gemini-flash-lite` aliases to their canonical pricing entries so cost estimates stop falling back to DEFAULT_PRICING on these common short-names

## Source
- Polecat: rictus
- Issue: sp-9gcm
- MR: sp-wisp-2b5
- Branch: polecat/rictus-moahsn3r

## Test plan
- [ ] CI passes (updated coverage in test_cost.py)
- [ ] Both aliases resolve to the documented upstream rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)