### PR TITLE
fix(synthesis): route --synthesis-strategy=auto overflow to map-reduce (sp-exu6)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -60,6 +60,7 @@ from synth_panel.runtime import AgentRuntime
 from synth_panel.synthesis import (
     STRATEGY_MAP_REDUCE,
     STRATEGY_SINGLE,
+    MapChunkOverflowError,
     select_strategy,
     synthesize_panel,
     synthesize_panel_mapreduce,
@@ -1210,17 +1211,27 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # synthesis_temperature overrides panelist temperature for synthesis
         effective_synth_temp = synthesis_temperature if synthesis_temperature is not None else temperature
         effective_synth_model = synthesis_model or model
-        # sp-avmm: pre-flight size check — refuse to make the API call when
-        # the estimated prompt exceeds the synthesis model's context window.
-        # Still applies under map-reduce because each map-phase call also
-        # has to fit; select_strategy will additionally pick map-reduce when
-        # single-call overflow is the only way to fit.
-        overflow = detect_synthesis_context_overflow(
+        # sp-exu6: resolve the strategy FIRST. The single-pass overflow
+        # pre-flight only applies when the resolved strategy is ``single``
+        # — otherwise ``--synthesis-strategy=auto`` would reject large
+        # panels instead of routing them through map-reduce (sp-avmm ×
+        # sp-9rzu interaction). Map-reduce has its own per-map overflow
+        # guard inside ``synthesize_panel_mapreduce``.
+        resolved_strategy = select_strategy(
+            requested_strategy,
+            effective_synth_model,
             panelist_results,
             questions,
-            synthesis_model=effective_synth_model,
-            custom_prompt=custom_prompt,
+            prompt=custom_prompt,
         )
+        overflow = None
+        if resolved_strategy == STRATEGY_SINGLE:
+            overflow = detect_synthesis_context_overflow(
+                panelist_results,
+                questions,
+                synthesis_model=effective_synth_model,
+                custom_prompt=custom_prompt,
+            )
         if overflow is not None:
             actionable = format_synthesis_overflow_message(overflow)
             print(
@@ -1240,13 +1251,6 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             )
             run_invalid = True
         else:
-            resolved_strategy = select_strategy(
-                requested_strategy,
-                effective_synth_model,
-                panelist_results,
-                questions,
-                prompt=custom_prompt,
-            )
             try:
                 if resolved_strategy == STRATEGY_MAP_REDUCE:
                     synthesis_result = synthesize_panel_mapreduce(
@@ -1272,6 +1276,29 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                         temperature=effective_synth_temp,
                         top_p=top_p,
                     )
+            except MapChunkOverflowError as exc:
+                # sp-exu6: per-map chunk overflow — distinct from the
+                # single-pass pre-flight (sp-avmm) so consumers can tell
+                # "this one question is too big" apart from "the whole
+                # panel is too big".
+                logger.error("map-reduce per-chunk overflow: %s", exc)
+                print(
+                    f"Error: synthesis pre-flight rejected: {exc}",
+                    file=sys.stderr,
+                )
+                synthesis_error_payload = build_synthesis_error_payload(
+                    None,
+                    error_type="synthesis_map_chunk_overflow",
+                    message=str(exc),
+                    suggested_fix=(
+                        "A single question's responses exceed the synthesis "
+                        "model's context window. Rerun with --synthesis-model "
+                        "gemini-2.5-flash-lite (1M context) or gemini-2.5-pro "
+                        "(1M context), or reduce panel size."
+                    ),
+                    diagnostic=exc.diagnostic,
+                )
+                run_invalid = True
             except Exception as exc:
                 # sp-avmm: fail loud — previously this was a WARN log and the
                 # run exited 0 with synthesis=null. That silent-skip made

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -360,6 +360,20 @@ _DEFAULT_CONTEXT_WINDOW = 128_000
 _CONTEXT_HEADROOM = 8_000
 
 
+class MapChunkOverflowError(RuntimeError):
+    """A single map-phase chunk would not fit in the synthesis model's context.
+
+    Raised from :func:`synthesize_panel_mapreduce` when any per-question
+    map call's pessimistic token estimate exceeds the resolved model's
+    context window (less headroom). Carries a diagnostic dict that names
+    the offending question so callers can report it.
+    """
+
+    def __init__(self, message: str, *, diagnostic: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.diagnostic = diagnostic
+
+
 def resolve_context_window(model: str) -> int:
     """Return the context-window size (in tokens) for *model*.
 
@@ -556,6 +570,35 @@ def synthesize_panel_mapreduce(
 
     n = len(questions)
     workers = max_workers if max_workers is not None else min(max(n, 1), 8)
+
+    # sp-exu6: per-map-call overflow pre-flight. Each map call only sees
+    # responses for its own question, so the budget is much smaller than
+    # the full-panel synthesis. Still, a single question with very long
+    # responses (or a large cluster-metadata block) could overflow — catch
+    # that here rather than letting the provider API reject it mid-fanout.
+    context_limit = resolve_context_window(resolved_model) - _CONTEXT_HEADROOM
+    for idx in range(n):
+        q = questions[idx]
+        q_text = _question_text(q)
+        filtered = [_filter_panelist_to_question(pr, q_text) for pr in panelist_results]
+        est = estimate_single_pass_tokens(filtered, [q], prompt=map_prompt)
+        if est > context_limit:
+            raise MapChunkOverflowError(
+                (
+                    f"map-reduce per-chunk overflow: question {idx} "
+                    f"(~{est} tokens) exceeds {resolved_model}'s effective "
+                    f"limit ({context_limit} tokens). Rerun with a "
+                    "larger-context synthesis model (e.g. "
+                    "gemini-2.5-flash-lite, 1M ctx) or trim the panel."
+                ),
+                diagnostic={
+                    "question_index": idx,
+                    "question_text": q_text,
+                    "estimated_tokens": est,
+                    "effective_limit": context_limit,
+                    "synthesis_model": resolved_model,
+                },
+            )
 
     def _run_one_map(idx: int) -> tuple[int, SynthesisResult]:
         q = questions[idx]

--- a/tests/test_synthesis_failure.py
+++ b/tests/test_synthesis_failure.py
@@ -103,7 +103,11 @@ class TestCliNonEnsembleSynthesisFailure:
     @patch("synth_panel.cli.commands.LLMClient")
     def test_preflight_rejects_oversized_input(self, _mock_client, mock_run, mock_synth, capsys, tmp_path):
         """When the estimated prompt overflows the synthesis model's context,
-        the run must fail BEFORE synthesize_panel is called."""
+        the run must fail BEFORE synthesize_panel is called.
+
+        sp-exu6: must pass ``--synthesis-strategy=single`` explicitly.
+        Under ``auto`` (the new default behavior after sp-exu6), overflow
+        would instead route to map-reduce."""
         from synth_panel.orchestrator import PanelistResult, WorkerRegistry
 
         # Build one giant panelist response that comfortably overflows
@@ -132,6 +136,8 @@ class TestCliNonEnsembleSynthesisFailure:
                 _write_instrument(tmp_path / "survey.yaml"),
                 "--synthesis-model",
                 "haiku",
+                "--synthesis-strategy",
+                "single",
             ]
         )
         assert code == 2

--- a/tests/test_synthesis_strategy_interaction.py
+++ b/tests/test_synthesis_strategy_interaction.py
@@ -1,0 +1,371 @@
+"""sp-exu6: --synthesis-strategy=auto must route overflow to map-reduce.
+
+Covers the sp-avmm x sp-9rzu interaction that previously caused
+``--synthesis-strategy=auto`` to fail loud on oversized panels instead of
+routing them through map-reduce. The bug was the order of operations in
+``cmd_panel_run``: the overflow pre-flight ran BEFORE strategy selection,
+so any panel too large for a single pass was rejected regardless of
+whether map-reduce could have handled it.
+
+Acceptance criteria:
+
+1. ``select_strategy`` runs first; the single-pass pre-flight only fires
+   when the resolved strategy is ``single``.
+2. ``auto`` routes overflow to ``map-reduce``.
+3. Map-reduce has its own per-map overflow guard.
+4. ``--synthesis-strategy=single`` preserves the loud sp-avmm rejection.
+5. ``--synthesis-strategy=map-reduce`` bypasses the whole-panel overflow
+   guard (per-map guard still applies).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synth_panel.cost import ZERO_USAGE
+from synth_panel.llm.models import CompletionResponse, ToolInvocationBlock
+from synth_panel.llm.models import TokenUsage as LLMTokenUsage
+from synth_panel.main import main
+from synth_panel.orchestrator import PanelistResult
+from synth_panel.synthesis import (
+    MapChunkOverflowError,
+    SynthesisResult,
+    synthesize_panel_mapreduce,
+)
+
+# --- helpers --------------------------------------------------------------
+
+
+def _write_personas(path, n: int = 2) -> str:
+    names = [f"Panelist{i}" for i in range(n)]
+    body = "personas:\n" + "\n".join(f"  - name: {name}" for name in names) + "\n"
+    path.write_text(body)
+    return str(path)
+
+
+def _write_instrument(path, question: str = "Q1") -> str:
+    path.write_text(f"instrument:\n  questions:\n    - text: {question}\n")
+    return str(path)
+
+
+def _tool_response(marker: str) -> CompletionResponse:
+    return CompletionResponse(
+        id=f"synth-{marker}",
+        model="claude-haiku-4-5",
+        content=[
+            ToolInvocationBlock(
+                id=f"tc-{marker}",
+                name="synthesize",
+                input={
+                    "summary": f"summary-{marker}",
+                    "themes": [f"theme-{marker}"],
+                    "agreements": [f"agree-{marker}"],
+                    "disagreements": [f"disagree-{marker}"],
+                    "surprises": [f"surprise-{marker}"],
+                    "recommendation": f"rec-{marker}",
+                },
+            )
+        ],
+        usage=LLMTokenUsage(input_tokens=100, output_tokens=50),
+    )
+
+
+# --- acceptance tests -----------------------------------------------------
+
+
+class TestAutoRoutesOverflowToMapReduce:
+    @patch("synth_panel.cli.commands.synthesize_panel_mapreduce")
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_auto_falls_over_to_map_reduce_when_single_overflows(
+        self, _mock_client, mock_run, mock_synth_single, mock_synth_mr, capsys, tmp_path
+    ):
+        """sp-exu6 AC 1, 2, 6: auto + overflow → map-reduce (not hard fail)."""
+        from synth_panel.cost import CostEstimate, TokenUsage
+        from synth_panel.orchestrator import WorkerRegistry
+
+        # Large enough to overflow single-pass haiku (200k - 8k headroom).
+        giant = "A" * 800_000
+        huge_results = [
+            PanelistResult(
+                persona_name=f"Panelist{i}",
+                responses=[{"question": "Q1", "response": giant}],
+                usage=ZERO_USAGE,
+                model="haiku",
+            )
+            for i in range(2)
+        ]
+        mock_run.return_value = (huge_results, WorkerRegistry(), {})
+        # map-reduce succeeds — the point of the test is that we reach it.
+        mock_synth_mr.return_value = SynthesisResult(
+            summary="ok",
+            themes=[],
+            agreements=[],
+            disagreements=[],
+            surprises=[],
+            recommendation="",
+            usage=TokenUsage(),
+            cost=CostEstimate(),
+            strategy="map-reduce",
+        )
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                _write_personas(tmp_path / "personas.yaml"),
+                "--instrument",
+                _write_instrument(tmp_path / "survey.yaml"),
+                "--synthesis-model",
+                "haiku",
+                "--synthesis-strategy",
+                "auto",
+            ]
+        )
+
+        # Must NOT reject pre-flight; must route to map-reduce instead.
+        assert code == 0, "auto must route overflow to map-reduce, not fail"
+        mock_synth_single.assert_not_called()
+        mock_synth_mr.assert_called_once()
+
+
+class TestSingleStillRejectsOnOverflow:
+    @patch("synth_panel.cli.commands.synthesize_panel_mapreduce")
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_single_still_rejects_on_overflow(
+        self, _mock_client, mock_run, mock_synth_single, mock_synth_mr, capsys, tmp_path
+    ):
+        """sp-exu6 AC 4: explicit single preserves the sp-avmm pre-flight."""
+        from synth_panel.orchestrator import WorkerRegistry
+
+        giant = "A" * 800_000
+        huge_results = [
+            PanelistResult(
+                persona_name=f"Panelist{i}",
+                responses=[{"question": "Q1", "response": giant}],
+                usage=ZERO_USAGE,
+                model="haiku",
+            )
+            for i in range(2)
+        ]
+        mock_run.return_value = (huge_results, WorkerRegistry(), {})
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                _write_personas(tmp_path / "personas.yaml"),
+                "--instrument",
+                _write_instrument(tmp_path / "survey.yaml"),
+                "--synthesis-model",
+                "haiku",
+                "--synthesis-strategy",
+                "single",
+            ]
+        )
+
+        assert code == 2
+        captured = capsys.readouterr()
+        assert "pre-flight" in captured.err.lower() or "exceeds" in captured.err.lower()
+        mock_synth_single.assert_not_called()
+        mock_synth_mr.assert_not_called()
+
+        payload = json.loads(captured.out)
+        err = payload["synthesis_error"]
+        assert err["error_type"] == "synthesis_context_overflow"
+
+
+class TestMapReduceSkipsPanelLevelOverflow:
+    @patch("synth_panel.cli.commands.synthesize_panel_mapreduce")
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_map_reduce_bypasses_panel_level_overflow(
+        self, _mock_client, mock_run, mock_synth_single, mock_synth_mr, capsys, tmp_path
+    ):
+        """sp-exu6 AC 5: explicit map-reduce skips the whole-panel pre-flight."""
+        from synth_panel.cost import CostEstimate, TokenUsage
+        from synth_panel.orchestrator import WorkerRegistry
+
+        giant = "A" * 800_000
+        huge_results = [
+            PanelistResult(
+                persona_name=f"Panelist{i}",
+                responses=[{"question": "Q1", "response": giant}],
+                usage=ZERO_USAGE,
+                model="haiku",
+            )
+            for i in range(2)
+        ]
+        mock_run.return_value = (huge_results, WorkerRegistry(), {})
+        mock_synth_mr.return_value = SynthesisResult(
+            summary="ok",
+            themes=[],
+            agreements=[],
+            disagreements=[],
+            surprises=[],
+            recommendation="",
+            usage=TokenUsage(),
+            cost=CostEstimate(),
+            strategy="map-reduce",
+        )
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                _write_personas(tmp_path / "personas.yaml"),
+                "--instrument",
+                _write_instrument(tmp_path / "survey.yaml"),
+                "--synthesis-model",
+                "haiku",
+                "--synthesis-strategy",
+                "map-reduce",
+            ]
+        )
+
+        assert code == 0
+        mock_synth_single.assert_not_called()
+        mock_synth_mr.assert_called_once()
+
+
+class TestMapReducePerChunkOverflowCheck:
+    def test_map_reduce_per_chunk_overflow_check_unit(self):
+        """sp-exu6 AC 3: per-map guard fires when a single question overflows.
+
+        Constructs a 1-question panel whose filtered per-map chunk itself
+        exceeds haiku's 200k context. ``synthesize_panel_mapreduce`` must
+        raise ``MapChunkOverflowError`` before issuing any LLM call.
+        """
+        giant = "A" * 800_000
+        fat_panelists = [
+            PanelistResult(
+                persona_name=f"Panelist{i}",
+                responses=[{"question": "Q1", "response": giant}],
+                usage=ZERO_USAGE,
+            )
+            for i in range(2)
+        ]
+        client = MagicMock()
+
+        with pytest.raises(MapChunkOverflowError) as excinfo:
+            synthesize_panel_mapreduce(
+                client,
+                fat_panelists,
+                [{"text": "Q1"}],
+                model="haiku",
+                max_workers=1,
+            )
+
+        diag = excinfo.value.diagnostic
+        assert diag["question_index"] == 0
+        assert diag["estimated_tokens"] > diag["effective_limit"]
+        # Must short-circuit before any LLM call.
+        client.send.assert_not_called()
+
+    def test_map_reduce_per_chunk_ok_for_small_chunks(self):
+        """Per-chunk guard does NOT fire when each chunk fits — the bug
+        being guarded against is a single oversized question, not merely
+        many small ones."""
+        # 2 questions × 2 panelists, short answers — fits comfortably.
+        panelists = [
+            PanelistResult(
+                persona_name=f"Panelist{i}",
+                responses=[
+                    {"question": "Q1", "response": "short answer one"},
+                    {"question": "Q2", "response": "short answer two"},
+                ],
+                usage=ZERO_USAGE,
+            )
+            for i in range(2)
+        ]
+        # 2 map calls + 1 reduce call
+        responses = [_tool_response(f"map-{i}") for i in range(2)]
+        responses.append(_tool_response("reduce"))
+        client = MagicMock()
+        client.send.side_effect = responses
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            [{"text": "Q1"}, {"text": "Q2"}],
+            model="haiku",
+            max_workers=1,
+        )
+        assert result.summary == "summary-reduce"
+        # 2 maps + 1 reduce
+        assert client.send.call_count == 3
+
+
+class TestCliMapChunkOverflowErrorShape:
+    @patch("synth_panel.cli.commands.synthesize_panel_mapreduce")
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_per_chunk_overflow_becomes_structured_payload(
+        self, _mock_client, mock_run, mock_synth_single, mock_synth_mr, capsys, tmp_path
+    ):
+        """A raised MapChunkOverflowError becomes a structured
+        ``synthesis_map_chunk_overflow`` error in the CLI envelope."""
+        from synth_panel.orchestrator import WorkerRegistry
+
+        mock_run.return_value = (
+            [
+                PanelistResult(
+                    persona_name="P",
+                    responses=[{"question": "Q1", "response": "short"}],
+                    usage=ZERO_USAGE,
+                    model="haiku",
+                )
+            ],
+            WorkerRegistry(),
+            {},
+        )
+        mock_synth_mr.side_effect = MapChunkOverflowError(
+            "per-chunk overflow: question 0 too big",
+            diagnostic={
+                "question_index": 0,
+                "question_text": "Q1",
+                "estimated_tokens": 999_999,
+                "effective_limit": 192_000,
+                "synthesis_model": "haiku",
+            },
+        )
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                _write_personas(tmp_path / "personas.yaml"),
+                "--instrument",
+                _write_instrument(tmp_path / "survey.yaml"),
+                "--synthesis-model",
+                "haiku",
+                "--synthesis-strategy",
+                "map-reduce",
+            ]
+        )
+
+        assert code == 2
+        payload = json.loads(capsys.readouterr().out)
+        err = payload["synthesis_error"]
+        assert err["error_type"] == "synthesis_map_chunk_overflow"
+        assert err["diagnostic"]["question_index"] == 0


### PR DESCRIPTION
## Summary
- When `--synthesis-strategy=auto` pre-flight token estimate exceeds the synthesis model's context window, route the run through map-reduce (from #223) instead of failing with a context-overflow error mid-run
- Adds interaction test covering the auto → map-reduce handoff alongside the existing failure-mode coverage

## Source
- Polecat: nux
- Issue: sp-exu6
- MR: sp-wisp-311
- Branch: polecat/nux-moahs7lc

## Test plan
- [ ] CI passes (new coverage in test_synthesis_strategy_interaction.py)
- [ ] Oversize panel with `--synthesis-strategy=auto` picks map-reduce, not single-call overflow

## Conflict note
Touches cli/commands.py, synthesis.py, test_synthesis_failure.py — overlaps with open synthesis-related PR (#228). Light rebase may be needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)