### PR TITLE
fix(synthesis): sub-chunk within question + opt-in auto-escalate on overflow (sp-4g6a)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1345,6 +1345,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                         temperature=effective_synth_temp,
                         top_p=top_p,
                         personas=personas,
+                        auto_escalate=getattr(args, "synthesis_auto_escalate", False),
                     )
                 else:
                     synthesis_result = synthesize_panel(

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -216,6 +216,19 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     panel_run_parser.add_argument(
+        "--synthesis-auto-escalate",
+        action="store_true",
+        default=False,
+        help=(
+            "sp-4g6a: when a single question's responses overflow the "
+            "synthesis model's context in --synthesis-strategy=map-reduce, "
+            "auto-retry that question's map call on a larger-context model "
+            "(gemini-2.5-flash-lite, 1M ctx) and emit a warning. Default "
+            "behaviour (off) partitions panelists into sub-batches and "
+            "performs an inner reduce, preserving single-model semantics."
+        ),
+    )
+    panel_run_parser.add_argument(
         "--temperature",
         type=float,
         default=None,

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -311,6 +311,26 @@ _MAP_PROMPT_TEMPLATE = (
     "Cite panelist names when useful. Be specific and substantive."
 )
 
+# sp-4g6a: inner reduce used when a single question's responses overflow the
+# synthesis model's context and we partition the panelists into sub-batches.
+# Each batch's map-phase summary becomes the "panelist response" here, and
+# this reduce combines them into ONE question-level summary. The outer
+# cross-question reduce then consumes that summary as usual.
+_INNER_REDUCE_PROMPT_TEMPLATE = (
+    "You are combining partial summaries of panelist responses to ONE "
+    "specific question. An earlier pass split the panel into batches — "
+    "each batch was summarized separately. Your job is to merge those "
+    "batch summaries into a single coherent per-question synthesis, "
+    "preserving the usual rubric (summary / themes / agreements / "
+    "disagreements / surprises / recommendation) but scoped to this one "
+    "question.\n\n"
+    "Do not re-summarize each batch individually; combine them. When a "
+    "theme or tension recurs across batches, surface it. When batches "
+    "disagree, flag the disagreement. Leave recommendation empty if "
+    "nothing actionable emerges."
+)
+
+
 _REDUCE_PROMPT_TEMPLATE = (
     "You are producing the final cross-question synthesis of a focus group "
     "panel. Per-question summaries have already been produced by an earlier "
@@ -358,6 +378,11 @@ _CONTEXT_WINDOWS: dict[str, int] = {
 }
 _DEFAULT_CONTEXT_WINDOW = 128_000
 _CONTEXT_HEADROOM = 8_000
+
+# sp-4g6a: target for --synthesis-auto-escalate. Chosen because it is the
+# cheapest 1M-context model available through the default provider set.
+# Operators can still pick gemini-2.5-pro manually via --synthesis-model.
+_ESCALATION_MODEL = "gemini-2.5-flash-lite"
 
 
 class MapChunkOverflowError(RuntimeError):
@@ -519,6 +544,152 @@ def _build_synthetic_reduce_panelists(
     return synthetic
 
 
+def _partition_panelists_for_context(
+    panelist_results: list[Any],
+    question: dict[str, Any] | str,
+    map_prompt: str,
+    context_limit: int,
+) -> list[list[Any]] | None:
+    """Greedy partition of *panelist_results* into batches fitting *context_limit*.
+
+    Walks panelists in order and grows the current batch while its estimated
+    single-pass token count stays below the limit. Starts a new batch when
+    adding the next panelist would overflow. Returns ``None`` when a single
+    panelist's response already exceeds the limit — sub-chunking cannot help
+    in that case and the caller must escalate the model or error.
+    """
+    batches: list[list[Any]] = []
+    current: list[Any] = []
+    for pr in panelist_results:
+        candidate = [*current, pr]
+        est = estimate_single_pass_tokens(candidate, [question], prompt=map_prompt)
+        if est <= context_limit:
+            current = candidate
+            continue
+        if not current:
+            # A single panelist's response does not fit — sub-chunking is
+            # structurally unable to resolve this. Caller handles.
+            return None
+        batches.append(current)
+        current = [pr]
+    if current:
+        batches.append(current)
+    return batches
+
+
+def _sub_chunk_question_synthesis(
+    client: LLMClient,
+    filtered_panelists: list[Any],
+    question: dict[str, Any] | str,
+    map_prompt: str,
+    *,
+    model: str,
+    panelist_model: str | None,
+    context_limit: int,
+    temperature: float | None,
+    top_p: float | None,
+    question_index: int | None = None,
+) -> tuple[SynthesisResult, int]:
+    """Synthesize one overflowing question by partitioning panelists (sp-4g6a).
+
+    Splits the filtered panelists into batches that each fit within
+    *context_limit*, runs one :func:`synthesize_panel` per batch with the
+    supplied *map_prompt*, then performs an inner reduce that combines the
+    batch summaries into a single per-question :class:`SynthesisResult`.
+    The returned result's ``usage`` / ``cost`` / ``is_fallback`` aggregate
+    every underlying call (batch maps + inner reduce) so outer roll-ups
+    stay accurate.
+
+    Returns ``(result, batch_count)``. Raises :class:`MapChunkOverflowError`
+    when partitioning fails — i.e. when a single panelist's response
+    cannot fit the context limit even alone.
+    """
+    batches = _partition_panelists_for_context(filtered_panelists, question, map_prompt, context_limit)
+    if batches is None:
+        q_text = _question_text(question)
+        # Estimate tokens for a single panelist so the diagnostic can report
+        # what the sub-chunker saw as unsplittable.
+        worst_est = 0
+        for pr in filtered_panelists:
+            est = estimate_single_pass_tokens([pr], [question], prompt=map_prompt)
+            if est > worst_est:
+                worst_est = est
+        diag: dict[str, Any] = {
+            "question_text": q_text,
+            "estimated_tokens": worst_est,
+            "effective_limit": context_limit,
+            "synthesis_model": model,
+            "reason": "single_panelist_overflow",
+        }
+        if question_index is not None:
+            diag["question_index"] = question_index
+        raise MapChunkOverflowError(
+            (
+                f"map-reduce sub-chunk failed for question '{q_text[:60]}': "
+                f"a single panelist's response (~{worst_est} tokens) exceeds "
+                f"the effective limit ({context_limit} tokens). Rerun with a "
+                "larger-context synthesis model (e.g. --synthesis-auto-escalate "
+                "or --synthesis-model gemini-2.5-flash-lite)."
+            ),
+            diagnostic=diag,
+        )
+
+    batch_results: list[SynthesisResult] = []
+    for batch in batches:
+        res = synthesize_panel(
+            client,
+            batch,
+            [question],
+            model=model,
+            panelist_model=panelist_model,
+            custom_prompt=map_prompt,
+            panelist_cost=None,
+            temperature=temperature,
+            top_p=top_p,
+        )
+        batch_results.append(res)
+
+    # Inner reduce: wrap each batch summary as a synthetic panelist and run
+    # the standard synthesis pipeline with a reduce-style prompt.
+    synthetic = _build_synthetic_reduce_panelists(batch_results, [question] * len(batch_results))
+    inner = synthesize_panel(
+        client,
+        synthetic,
+        [question],
+        model=model,
+        panelist_model=panelist_model,
+        custom_prompt=_INNER_REDUCE_PROMPT_TEMPLATE,
+        panelist_cost=None,
+        temperature=temperature,
+        top_p=top_p,
+    )
+
+    # Aggregate usage / cost across every batch call + the inner reduce
+    # so the outer map_breakdown entry for this question reflects the
+    # full work done.
+    total_usage: TokenUsage = inner.usage
+    total_cost: CostEstimate = inner.cost
+    for br in batch_results:
+        total_usage = total_usage + br.usage
+        total_cost = total_cost + br.cost
+    any_fallback = inner.is_fallback or any(br.is_fallback for br in batch_results)
+
+    aggregated = SynthesisResult(
+        summary=inner.summary,
+        themes=inner.themes,
+        agreements=inner.agreements,
+        disagreements=inner.disagreements,
+        surprises=inner.surprises,
+        recommendation=inner.recommendation,
+        usage=total_usage,
+        cost=total_cost,
+        model=model,
+        is_fallback=any_fallback,
+        error=inner.error,
+    )
+    return aggregated, len(batches)
+
+
 def synthesize_panel_mapreduce(
     client: LLMClient,
     panelist_results: list[Any],
@@ -531,6 +702,7 @@ def synthesize_panel_mapreduce(
     top_p: float | None = None,
     personas: list[dict[str, Any]] | None = None,
     max_workers: int | None = None,
+    auto_escalate: bool = False,
 ) -> SynthesisResult:
     """Map-reduce synthesis for large panels (sp-kkzz).
 
@@ -553,6 +725,20 @@ def synthesize_panel_mapreduce(
     Custom map / reduce prompts are intentionally NOT accepted here —
     ``--synthesis-prompt`` forces ``strategy=single`` upstream. Adding
     map/reduce prompt overrides is tracked as future work.
+
+    Per-chunk overflow handling (sp-4g6a):
+
+    * By default, when a single question's responses exceed the model's
+      context window, the panelists for that question are partitioned
+      into sub-batches that each fit, every batch is summarized, and an
+      inner reduce combines the batch summaries into a single per-question
+      summary. This preserves single-model semantics and keeps the
+      overall pipeline shape identical.
+    * When ``auto_escalate=True`` and the resolved synthesis model has a
+      smaller context window than the escalation target, an overflowing
+      question's map call is instead retried on a larger-context model
+      (default: ``gemini-2.5-flash-lite``, 1M ctx) with a visible warning.
+      Sub-chunking still runs if the escalated window is also insufficient.
     """
     resolved_model = model or panelist_model or _DEFAULT_MODEL
     if not questions:
@@ -574,60 +760,114 @@ def synthesize_panel_mapreduce(
     # sp-exu6: per-map-call overflow pre-flight. Each map call only sees
     # responses for its own question, so the budget is much smaller than
     # the full-panel synthesis. Still, a single question with very long
-    # responses (or a large cluster-metadata block) could overflow — catch
-    # that here rather than letting the provider API reject it mid-fanout.
-    context_limit = resolve_context_window(resolved_model) - _CONTEXT_HEADROOM
+    # responses (or a large cluster-metadata block) could overflow.
+    #
+    # sp-4g6a: when it does, we no longer raise immediately. Build a
+    # per-question plan:
+    #
+    # * "direct"     → fits; run one map call on ``resolved_model``.
+    # * "escalate"   → does not fit ``resolved_model`` but fits a larger-
+    #                  context escalation target, and the caller opted in
+    #                  via ``auto_escalate=True``. Run one map call on the
+    #                  escalated model (with a visible warning).
+    # * "sub_chunk"  → doesn't fit (even after any escalation). Partition
+    #                  panelists into batches that each fit, and run an
+    #                  inner reduce to produce one per-question summary.
+    #
+    # The plan is resolved up front so we can surface escalation warnings
+    # in deterministic question order before any API calls fan out.
+    base_limit = resolve_context_window(resolved_model) - _CONTEXT_HEADROOM
+    escalated_limit = resolve_context_window(_ESCALATION_MODEL) - _CONTEXT_HEADROOM
+    escalation_available = auto_escalate and escalated_limit > base_limit
+
+    plans: list[dict[str, Any]] = []
     for idx in range(n):
         q = questions[idx]
         q_text = _question_text(q)
         filtered = [_filter_panelist_to_question(pr, q_text) for pr in panelist_results]
         est = estimate_single_pass_tokens(filtered, [q], prompt=map_prompt)
-        if est > context_limit:
-            raise MapChunkOverflowError(
-                (
-                    f"map-reduce per-chunk overflow: question {idx} "
-                    f"(~{est} tokens) exceeds {resolved_model}'s effective "
-                    f"limit ({context_limit} tokens). Rerun with a "
-                    "larger-context synthesis model (e.g. "
-                    "gemini-2.5-flash-lite, 1M ctx) or trim the panel."
-                ),
-                diagnostic={
-                    "question_index": idx,
-                    "question_text": q_text,
-                    "estimated_tokens": est,
-                    "effective_limit": context_limit,
-                    "synthesis_model": resolved_model,
-                },
+        if est <= base_limit:
+            plans.append({"mode": "direct", "model": resolved_model, "filtered": filtered, "est": est})
+            continue
+        if escalation_available and est <= escalated_limit:
+            print(
+                f"warning: auto-escalated synthesis from {resolved_model} "
+                f"to {_ESCALATION_MODEL} for question {idx} "
+                f"(~{est} tokens > {base_limit} effective limit).",
+                file=sys.stderr,
             )
+            plans.append(
+                {
+                    "mode": "escalate",
+                    "model": _ESCALATION_MODEL,
+                    "filtered": filtered,
+                    "est": est,
+                    "original_model": resolved_model,
+                }
+            )
+            continue
+        # Sub-chunk. Use the escalated model's limit when available so we
+        # can pack larger batches; otherwise stay on the resolved model.
+        sub_model = _ESCALATION_MODEL if escalation_available else resolved_model
+        sub_limit = escalated_limit if escalation_available else base_limit
+        plans.append(
+            {
+                "mode": "sub_chunk",
+                "model": sub_model,
+                "filtered": filtered,
+                "est": est,
+                "context_limit": sub_limit,
+            }
+        )
 
-    def _run_one_map(idx: int) -> tuple[int, SynthesisResult]:
+    def _run_one_map(idx: int) -> tuple[int, SynthesisResult, dict[str, Any]]:
+        plan = plans[idx]
         q = questions[idx]
-        q_text = _question_text(q)
-        filtered = [_filter_panelist_to_question(pr, q_text) for pr in panelist_results]
+        filtered = plan["filtered"]
+        meta: dict[str, Any] = {"mode": plan["mode"], "model": plan["model"]}
+        if plan["mode"] == "sub_chunk":
+            res, batch_count = _sub_chunk_question_synthesis(
+                client,
+                filtered,
+                q,
+                map_prompt,
+                model=plan["model"],
+                panelist_model=panelist_model,
+                context_limit=plan["context_limit"],
+                temperature=temperature,
+                top_p=top_p,
+                question_index=idx,
+            )
+            meta["batch_count"] = batch_count
+            return idx, res, meta
         res = synthesize_panel(
             client,
             filtered,
             [q],
-            model=resolved_model,
+            model=plan["model"],
             panelist_model=panelist_model,
             custom_prompt=map_prompt,
             panelist_cost=None,
             temperature=temperature,
             top_p=top_p,
         )
-        return idx, res
+        return idx, res, meta
 
     map_results: list[SynthesisResult | None] = [None] * n
+    map_meta: list[dict[str, Any] | None] = [None] * n
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = [executor.submit(_run_one_map, i) for i in range(n)]
         for fut in as_completed(futures):
-            idx, res = fut.result()
+            idx, res, meta = fut.result()
             map_results[idx] = res
+            map_meta[idx] = meta
 
     # Narrow to non-None — ThreadPoolExecutor either fills every slot or
     # raises. Keep the assert so mypy/readers see the invariant.
     assert all(r is not None for r in map_results)
+    assert all(m is not None for m in map_meta)
     completed_maps: list[SynthesisResult] = [r for r in map_results if r is not None]
+    completed_meta: list[dict[str, Any]] = [m for m in map_meta if m is not None]
 
     # Reduce phase
     synthetic_panelists = _build_synthetic_reduce_panelists(completed_maps, questions)
@@ -647,17 +887,26 @@ def synthesize_panel_mapreduce(
     total_usage: TokenUsage = ZERO_USAGE
     total_cost: CostEstimate = CostEstimate()
     map_breakdown: list[dict[str, Any]] = []
-    for i, res in enumerate(completed_maps):
+    for i, (res, meta) in enumerate(zip(completed_maps, completed_meta)):
         total_usage = total_usage + res.usage
         total_cost = total_cost + res.cost
-        map_breakdown.append(
-            {
-                "question_index": i,
-                "tokens": res.usage.total_tokens,
-                "cost_usd": round(res.cost.total_cost, 6),
-                "is_fallback": res.is_fallback,
-            }
-        )
+        entry: dict[str, Any] = {
+            "question_index": i,
+            "tokens": res.usage.total_tokens,
+            "cost_usd": round(res.cost.total_cost, 6),
+            "is_fallback": res.is_fallback,
+        }
+        # sp-4g6a: surface per-question overflow handling in the breakdown
+        # so operators can tell at a glance which questions needed a
+        # different treatment and why.
+        if meta["mode"] == "sub_chunk":
+            entry["sub_chunked"] = True
+            entry["batch_count"] = meta.get("batch_count")
+            entry["model"] = meta["model"]
+        elif meta["mode"] == "escalate":
+            entry["escalated_model"] = meta["model"]
+            entry["model"] = meta["model"]
+        map_breakdown.append(entry)
     total_usage = total_usage + reduce_result.usage
     total_cost = total_cost + reduce_result.cost
     reduce_breakdown: dict[str, Any] = {

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -558,11 +558,12 @@ def _partition_panelists_for_context(
     panelist's response already exceeds the limit — sub-chunking cannot help
     in that case and the caller must escalate the model or error.
     """
+    q_dict: dict[str, Any] = {"text": question} if isinstance(question, str) else question
     batches: list[list[Any]] = []
     current: list[Any] = []
     for pr in panelist_results:
         candidate = [*current, pr]
-        est = estimate_single_pass_tokens(candidate, [question], prompt=map_prompt)
+        est = estimate_single_pass_tokens(candidate, [q_dict], prompt=map_prompt)
         if est <= context_limit:
             current = candidate
             continue
@@ -604,14 +605,18 @@ def _sub_chunk_question_synthesis(
     when partitioning fails — i.e. when a single panelist's response
     cannot fit the context limit even alone.
     """
-    batches = _partition_panelists_for_context(filtered_panelists, question, map_prompt, context_limit)
+    # Normalize the question to a dict once so every downstream call sees a
+    # consistent shape (estimate_single_pass_tokens + synthesize_panel both
+    # expect list[dict[str, Any]]).
+    q_dict: dict[str, Any] = {"text": question} if isinstance(question, str) else question
+    batches = _partition_panelists_for_context(filtered_panelists, q_dict, map_prompt, context_limit)
     if batches is None:
-        q_text = _question_text(question)
+        q_text = _question_text(q_dict)
         # Estimate tokens for a single panelist so the diagnostic can report
         # what the sub-chunker saw as unsplittable.
         worst_est = 0
         for pr in filtered_panelists:
-            est = estimate_single_pass_tokens([pr], [question], prompt=map_prompt)
+            est = estimate_single_pass_tokens([pr], [q_dict], prompt=map_prompt)
             if est > worst_est:
                 worst_est = est
         diag: dict[str, Any] = {
@@ -639,7 +644,7 @@ def _sub_chunk_question_synthesis(
         res = synthesize_panel(
             client,
             batch,
-            [question],
+            [q_dict],
             model=model,
             panelist_model=panelist_model,
             custom_prompt=map_prompt,
@@ -651,11 +656,11 @@ def _sub_chunk_question_synthesis(
 
     # Inner reduce: wrap each batch summary as a synthetic panelist and run
     # the standard synthesis pipeline with a reduce-style prompt.
-    synthetic = _build_synthetic_reduce_panelists(batch_results, [question] * len(batch_results))
+    synthetic = _build_synthetic_reduce_panelists(batch_results, [q_dict] * len(batch_results))
     inner = synthesize_panel(
         client,
         synthetic,
-        [question],
+        [q_dict],
         model=model,
         panelist_model=panelist_model,
         custom_prompt=_INNER_REDUCE_PROMPT_TEMPLATE,

--- a/tests/test_synthesis_strategy_interaction.py
+++ b/tests/test_synthesis_strategy_interaction.py
@@ -246,13 +246,15 @@ class TestMapReduceSkipsPanelLevelOverflow:
 
 class TestMapReducePerChunkOverflowCheck:
     def test_map_reduce_per_chunk_overflow_check_unit(self):
-        """sp-exu6 AC 3: per-map guard fires when a single question overflows.
+        """sp-exu6 AC 3 / sp-4g6a: per-map guard fires when a single
+        panelist's response overflows the synthesis model's context.
 
-        Constructs a 1-question panel whose filtered per-map chunk itself
-        exceeds haiku's 200k context. ``synthesize_panel_mapreduce`` must
-        raise ``MapChunkOverflowError`` before issuing any LLM call.
+        With sp-4g6a, map-reduce attempts sub-chunking before giving up,
+        so the overflow must be large enough that even a single panelist's
+        response cannot fit. Then the sub-chunker raises
+        ``MapChunkOverflowError`` with ``reason=single_panelist_overflow``.
         """
-        giant = "A" * 800_000
+        giant = "A" * 800_000  # ~200k tokens per panelist — exceeds haiku limit alone
         fat_panelists = [
             PanelistResult(
                 persona_name=f"Panelist{i}",
@@ -275,6 +277,7 @@ class TestMapReducePerChunkOverflowCheck:
         diag = excinfo.value.diagnostic
         assert diag["question_index"] == 0
         assert diag["estimated_tokens"] > diag["effective_limit"]
+        assert diag.get("reason") == "single_panelist_overflow"
         # Must short-circuit before any LLM call.
         client.send.assert_not_called()
 

--- a/tests/test_synthesis_subchunk.py
+++ b/tests/test_synthesis_subchunk.py
@@ -1,0 +1,416 @@
+"""Tests for sp-4g6a: per-question sub-chunk + auto-escalate on overflow."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from synth_panel.cost import ZERO_USAGE
+from synth_panel.llm.models import (
+    CompletionResponse,
+    TokenUsage,
+    ToolInvocationBlock,
+)
+from synth_panel.orchestrator import PanelistResult
+from synth_panel.synthesis import (
+    _ESCALATION_MODEL,
+    _MAP_PROMPT_TEMPLATE,
+    STRATEGY_MAP_REDUCE,
+    MapChunkOverflowError,
+    SynthesisResult,
+    _partition_panelists_for_context,
+    _sub_chunk_question_synthesis,
+    synthesize_panel_mapreduce,
+)
+
+# --- Fixtures ---
+
+
+def _tool_response(marker: str, input_tokens: int = 100, output_tokens: int = 50) -> CompletionResponse:
+    data = {
+        "summary": f"summary-{marker}",
+        "themes": [f"theme-{marker}"],
+        "agreements": [f"agree-{marker}"],
+        "disagreements": [f"disagree-{marker}"],
+        "surprises": [f"surprise-{marker}"],
+        "recommendation": f"rec-{marker}",
+    }
+    return CompletionResponse(
+        id=f"synth-{marker}",
+        model="claude-sonnet-4-6",
+        content=[ToolInvocationBlock(id="tc1", name="synthesize", input=data)],
+        usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+    )
+
+
+class _SequenceClient:
+    """Thread-safe mock LLM client returning pre-seeded responses in order."""
+
+    def __init__(self, responses: list[CompletionResponse]):
+        self._responses = list(responses)
+        self._idx = 0
+        self.call_count = 0
+        self._lock = threading.Lock()
+        self.sent_requests: list = []
+
+    def send(self, request, **kwargs):
+        with self._lock:
+            resp = self._responses[self._idx]
+            self._idx += 1
+            self.call_count += 1
+            self.sent_requests.append(request)
+        return resp
+
+
+def _fat_panelists(n: int, question_text: str, chars_per_response: int) -> list[PanelistResult]:
+    """Fabricate n panelists whose single-question response is `chars_per_response` long."""
+    blob = "x" * chars_per_response
+    return [
+        PanelistResult(
+            persona_name=f"Panelist{i}",
+            responses=[{"question": question_text, "response": blob}],
+            usage=ZERO_USAGE,
+        )
+        for i in range(n)
+    ]
+
+
+_Q_OVERFLOW = [{"text": "What drives you mad about the product?"}]
+
+
+# --- (A) Sub-chunking ---
+
+
+class TestPartition:
+    def test_greedy_partition_splits_when_overflow(self):
+        """Partition splits panelists into batches each fitting the limit."""
+        # 10 panelists, 80k chars each. Each ≈ 20k tokens. Limit 60k tokens
+        # (after the 2k scaffold floor) — expect ~3 panelists per batch.
+        panelists = _fat_panelists(10, _Q_OVERFLOW[0]["text"], 80_000)
+        batches = _partition_panelists_for_context(
+            panelists, _Q_OVERFLOW[0], _MAP_PROMPT_TEMPLATE, context_limit=60_000
+        )
+        assert batches is not None
+        assert sum(len(b) for b in batches) == 10
+        assert len(batches) >= 2
+        # No single batch exceeds the limit
+        from synth_panel.synthesis import estimate_single_pass_tokens
+
+        for b in batches:
+            assert estimate_single_pass_tokens(b, _Q_OVERFLOW, prompt=_MAP_PROMPT_TEMPLATE) <= 60_000
+
+    def test_partition_returns_none_when_single_panelist_overflows(self):
+        """A single panelist whose response exceeds the limit signals failure."""
+        panelists = _fat_panelists(3, _Q_OVERFLOW[0]["text"], 500_000)  # ~125k tokens each
+        batches = _partition_panelists_for_context(
+            panelists, _Q_OVERFLOW[0], _MAP_PROMPT_TEMPLATE, context_limit=20_000
+        )
+        assert batches is None
+
+
+class TestSubChunkWithinQuestion:
+    def test_sub_chunk_within_question_when_overflow(self):
+        """When a question overflows, sub-chunking yields a valid per-question summary.
+
+        End-to-end: 20 fat panelists, long responses, sonnet (200k ctx). Each
+        panelist's response is ~40k tokens, so the 20-panelist call would
+        estimate at ~800k tokens >> 192k limit. Sub-chunker must partition
+        into multiple batches, map each, and inner-reduce.
+        """
+        panelists = _fat_panelists(20, _Q_OVERFLOW[0]["text"], 160_000)
+        context_limit = 200_000 - 8_000
+        expected_batches = _partition_panelists_for_context(
+            panelists, _Q_OVERFLOW[0], _MAP_PROMPT_TEMPLATE, context_limit
+        )
+        assert expected_batches is not None and len(expected_batches) >= 2
+        n_batches = len(expected_batches)
+
+        responses = [_tool_response(f"batch-{i}") for i in range(n_batches)]
+        responses.append(_tool_response("inner-reduce"))
+        client = _SequenceClient(responses)
+
+        result, batch_count = _sub_chunk_question_synthesis(
+            client,
+            panelists,
+            _Q_OVERFLOW[0],
+            _MAP_PROMPT_TEMPLATE,
+            model="sonnet",
+            panelist_model=None,
+            context_limit=context_limit,
+            temperature=None,
+            top_p=None,
+        )
+
+        assert isinstance(result, SynthesisResult)
+        assert batch_count == n_batches
+        assert result.summary == "summary-inner-reduce"
+        # Total calls = batch_count + 1 (inner reduce)
+        assert client.call_count == batch_count + 1
+
+    def test_reduce_phase_consumes_batch_summaries_correctly(self):
+        """Inner reduce sees every batch summary and nothing else.
+
+        We use a MagicMock client and inspect each call's user content.
+        """
+        panelists = _fat_panelists(10, _Q_OVERFLOW[0]["text"], 160_000)
+        context_limit = 200_000 - 8_000
+        expected_batches = _partition_panelists_for_context(
+            panelists, _Q_OVERFLOW[0], _MAP_PROMPT_TEMPLATE, context_limit
+        )
+        assert expected_batches is not None
+        n_batches = len(expected_batches)
+
+        responses = [_tool_response(f"batch-{i}") for i in range(n_batches)]
+        responses.append(_tool_response("INNER"))
+        client = MagicMock()
+        client.send.side_effect = responses
+
+        _sub_chunk_question_synthesis(
+            client,
+            panelists,
+            _Q_OVERFLOW[0],
+            _MAP_PROMPT_TEMPLATE,
+            model="sonnet",
+            panelist_model=None,
+            context_limit=context_limit,
+            temperature=None,
+            top_p=None,
+        )
+
+        # Last call is the inner reduce
+        inner_request = client.send.call_args_list[-1].args[0]
+        inner_text = inner_request.messages[0].content[0].text
+        # Inner reduce prompt appears
+        assert "combining partial summaries" in inner_text
+        # Every preceding batch's summary flows in as a synthetic panelist
+        n_batch_calls = len(client.send.call_args_list) - 1
+        for i in range(n_batch_calls):
+            assert f"summary-batch-{i}" in inner_text
+
+    def test_sub_chunk_aggregates_cost_and_tokens(self):
+        """Returned result totals usage/cost across every batch + inner reduce."""
+        panelists = _fat_panelists(10, _Q_OVERFLOW[0]["text"], 160_000)
+        context_limit = 200_000 - 8_000
+        expected = _partition_panelists_for_context(panelists, _Q_OVERFLOW[0], _MAP_PROMPT_TEMPLATE, context_limit)
+        assert expected is not None
+        n_batches = len(expected)
+
+        responses = [_tool_response(f"batch-{i}", input_tokens=100, output_tokens=10) for i in range(n_batches)]
+        responses.append(_tool_response("inner", input_tokens=500, output_tokens=200))
+        client = _SequenceClient(responses)
+
+        result, batch_count = _sub_chunk_question_synthesis(
+            client,
+            panelists,
+            _Q_OVERFLOW[0],
+            _MAP_PROMPT_TEMPLATE,
+            model="sonnet",
+            panelist_model=None,
+            context_limit=context_limit,
+            temperature=None,
+            top_p=None,
+        )
+        # batch_count * 110 + 700 inner
+        assert result.usage.total_tokens == (batch_count * 110) + 700
+        assert batch_count == n_batches
+
+    def test_single_panelist_overflow_raises(self):
+        """When even one panelist's response exceeds the limit, sub-chunk raises."""
+        panelists = _fat_panelists(3, _Q_OVERFLOW[0]["text"], 800_000)
+        client = _SequenceClient([])
+
+        with pytest.raises(MapChunkOverflowError) as excinfo:
+            _sub_chunk_question_synthesis(
+                client,
+                panelists,
+                _Q_OVERFLOW[0],
+                _MAP_PROMPT_TEMPLATE,
+                model="sonnet",
+                panelist_model=None,
+                context_limit=50_000,
+                temperature=None,
+                top_p=None,
+            )
+        assert excinfo.value.diagnostic.get("reason") == "single_panelist_overflow"
+
+
+# --- (A) integrated into map-reduce ---
+
+
+class TestMapReduceAutoSubChunks:
+    def test_map_reduce_sub_chunks_overflowing_question_by_default(self):
+        """synthesize_panel_mapreduce handles per-chunk overflow via sub-chunking."""
+        # 1 overflowing question + 1 fitting question. Verify pipeline succeeds.
+        panelists = [
+            PanelistResult(
+                persona_name=f"Panelist{i}",
+                responses=[
+                    {"question": "Big open-ended", "response": "x" * 160_000},
+                    {"question": "Small", "response": "quick"},
+                ],
+                usage=ZERO_USAGE,
+            )
+            for i in range(12)
+        ]
+        questions = [{"text": "Big open-ended"}, {"text": "Small"}]
+        # Expect: many batch calls for Q0 + 1 inner reduce for Q0, 1 map for Q1, 1 outer reduce.
+        # Seed plenty.
+        responses = [_tool_response(f"call-{i}") for i in range(20)]
+        client = _SequenceClient(responses)
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            questions,
+            model="sonnet",
+            max_workers=1,
+        )
+        assert result.strategy == STRATEGY_MAP_REDUCE
+        assert result.per_question_synthesis is not None
+        assert 0 in result.per_question_synthesis
+        assert 1 in result.per_question_synthesis
+
+        # The overflowing question's map_breakdown entry should be sub_chunked.
+        assert result.map_cost_breakdown is not None
+        q0_entry = result.map_cost_breakdown[0]
+        assert q0_entry.get("sub_chunked") is True
+        assert q0_entry.get("batch_count", 0) >= 2
+        # Q1 was small, no sub-chunking.
+        q1_entry = result.map_cost_breakdown[1]
+        assert q1_entry.get("sub_chunked") is not True
+
+
+# --- (B) auto-escalate ---
+
+
+class TestAutoEscalate:
+    def test_auto_escalate_respects_flag(self, capsys):
+        """auto_escalate=True swaps model to the 1M-ctx target and warns."""
+        # Question that overflows sonnet (200k) but fits gemini-flash-lite (1M).
+        # 20 panelists, 120k chars each ≈ 30k tokens each → ~600k tokens total,
+        # under 1M-8k effective escalated limit.
+        panelists = _fat_panelists(20, "Overflowing Q", 120_000)
+        questions = [{"text": "Overflowing Q"}]
+
+        responses = [_tool_response("escalated-map"), _tool_response("outer-reduce")]
+        client = _SequenceClient(responses)
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            questions,
+            model="sonnet",
+            max_workers=1,
+            auto_escalate=True,
+        )
+
+        # Warning appeared on stderr mentioning both models.
+        captured = capsys.readouterr()
+        assert "auto-escalated" in captured.err
+        assert _ESCALATION_MODEL in captured.err
+
+        # Breakdown records the escalation.
+        assert result.map_cost_breakdown is not None
+        entry = result.map_cost_breakdown[0]
+        assert entry.get("escalated_model") == _ESCALATION_MODEL
+        # Only 2 calls: one escalated map, one outer reduce — no sub-chunking.
+        assert client.call_count == 2
+
+    def test_auto_escalate_false_uses_sub_chunk(self, capsys):
+        """Flag off preserves the deterministic sub-chunk path (no escalation warning)."""
+        panelists = _fat_panelists(12, "Overflowing Q", 120_000)
+        questions = [{"text": "Overflowing Q"}]
+        responses = [_tool_response(f"call-{i}") for i in range(15)]
+        client = _SequenceClient(responses)
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            questions,
+            model="sonnet",
+            max_workers=1,
+            auto_escalate=False,
+        )
+
+        captured = capsys.readouterr()
+        assert "auto-escalated" not in captured.err
+        assert result.map_cost_breakdown is not None
+        assert result.map_cost_breakdown[0].get("sub_chunked") is True
+        assert result.map_cost_breakdown[0].get("escalated_model") is None
+
+    def test_auto_escalate_falls_back_to_sub_chunk_when_even_escalated_overflows(self, capsys):
+        """If escalated model's context is also insufficient, still sub-chunk."""
+        # Very long responses per panelist: 800k chars ≈ 200k tokens each.
+        # With 20 panelists that's ~4M tokens > 1M even escalated → must
+        # sub-chunk using the escalated model's 1M window.
+        panelists = _fat_panelists(20, "Overflowing Q", 800_000)
+        questions = [{"text": "Overflowing Q"}]
+        responses = [_tool_response(f"call-{i}") for i in range(30)]
+        client = _SequenceClient(responses)
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            questions,
+            model="sonnet",
+            max_workers=1,
+            auto_escalate=True,
+        )
+        entry = result.map_cost_breakdown[0]
+        # Sub-chunked, on the escalated model.
+        assert entry.get("sub_chunked") is True
+        assert entry.get("model") == _ESCALATION_MODEL
+
+
+# --- End-to-end at simulated large-n ---
+
+
+class TestLargeN:
+    def test_simulated_n150_long_form_instrument(self):
+        """n=150 panelists x 5 long-form questions succeeds under sub-chunking.
+
+        Simulates the conditions of the real audit that caught sp-4g6a:
+        n~100 on product-feedback overflowed haiku's 192k effective limit.
+        Here we exaggerate per-panelist response length so sub-chunking
+        is definitely triggered, then assert the pipeline produces a
+        non-fallback SynthesisResult.
+        """
+        q_texts = [
+            "What frustrates you most?",
+            "What would you change first?",
+            "How does this compare to alternatives?",
+            "What would make you recommend this?",
+            "What have we missed?",
+        ]
+        questions = [{"text": t} for t in q_texts]
+        panelists = [
+            PanelistResult(
+                persona_name=f"P{i}",
+                responses=[{"question": t, "response": "x" * 30_000} for t in q_texts],
+                usage=ZERO_USAGE,
+            )
+            for i in range(150)
+        ]
+
+        # Be generous with pre-seeded responses: multiple batches per question
+        # × 5 questions + 5 inner reduces + 1 outer reduce. Upper-bound ~200.
+        responses = [_tool_response(f"c{i}") for i in range(400)]
+        client = _SequenceClient(responses)
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            questions,
+            model="haiku",
+            max_workers=1,
+        )
+        assert result.strategy == STRATEGY_MAP_REDUCE
+        assert not result.is_fallback
+        assert result.per_question_synthesis is not None
+        assert set(result.per_question_synthesis.keys()) == {0, 1, 2, 3, 4}
+        # Every question on haiku (200k) with ~30k-token responses × 150
+        # panelists must have sub-chunked.
+        for entry in result.map_cost_breakdown:
+            assert entry.get("sub_chunked") is True


### PR DESCRIPTION
## Summary
- Sub-chunk responses within a single question when the per-question synthesis call still overflows (the residual case #230's auto→map-reduce handoff doesn't cover)
- Add opt-in `--synthesis-auto-escalate` flag so runs can further degrade to sub-chunk mode without user intervention

## Source
- Polecat: furiosa
- Issue: sp-4g6a
- MR: sp-wisp-qp8
- Branch: polecat/furiosa-moalf2j4

## Test plan
- [ ] CI passes (new coverage in test_synthesis_subchunk.py; updates to test_synthesis_strategy_interaction.py)
- [ ] Panel with a single-question overflow fixture completes via sub-chunk when auto-escalate is enabled

## Conflict note
Touches cli/commands.py, cli/parser.py, synthesis.py, test_synthesis_strategy_interaction.py — direct overlap with PR #230 (sp-exu6) and #231 (sp-g270). Rebase required after siblings land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)