### PR TITLE
docs(specs): Q-phase question lists for 3 QRSPI initiatives

### DIFF
--- a/specs/sp-inline-calibration/questions.md
+++ b/specs/sp-inline-calibration/questions.md
@@ -1,0 +1,62 @@
+# Q-phase: Cross-project calibration signal flow
+
+*Ticket hidden per QRSPI discipline. These questions drive objective code-mapping only; do not invent design direction from them.*
+
+## Problem (shared with R polecats)
+
+SynthBench computes distributional comparisons (JSD, Kendall's tau, convergence curves) between synthpanel output and real human survey data. Map the current data flow end-to-end: how does synthpanel output reach SynthBench, what transformations happen on each side, where does the comparison result live, and who reads it.
+
+## Research dimensions
+
+### 1. SynthBench's ingestion of synthpanel output
+
+- How does SynthBench discover a synthpanel panel result today? Is there a provider adapter? A file-watcher? A manual invocation?
+- `src/synthbench/providers/synthpanel.py` exists — what does it expose, and what's its call contract?
+- What subset of the panel-result JSON does SynthBench read? Which fields are load-bearing for the metric computation?
+- Is the provider pattern idempotent / re-runnable on the same panel result? Cached?
+
+### 2. SynthBench's dataset adapters + Question abstraction
+
+- `Question` in `src/synthbench/datasets/base.py` carries `human_distribution` — how is that distribution keyed (option names? ordinal indexes? enum tokens?)
+- How does SynthBench match a synthpanel output question to a SynthBench dataset question? By key, text similarity, explicit mapping, manual alignment?
+- Which of the nine datasets have redistribution-full status vs gated vs aggregates-only? What does that mean for inline consumption?
+- Is there any "question registry" that synthpanel could reference by name to say "this question is the same as GSS's SPKATH"?
+
+### 3. Metric computation and output shape
+
+- Where is JSD computed (`src/synthbench/metrics/distributional.py`)? What's its input contract — two distribution dicts, a pair of Questions, paired arrays?
+- What's the output shape of a full SynthBench run against a synthpanel provider — single JSD per question, a table, a leaderboard entry, a published artifact?
+- What's the lifecycle of a computed calibration metric? In-memory only, persisted to disk, uploaded to R2, published to the leaderboard site?
+- Are there any lightweight / cheap versions of the metric suitable for inline use (e.g. per-question single-number JSD vs full report)?
+
+### 4. Cross-package dependency posture
+
+- Does synthpanel already import synthbench anywhere, or is the provider one-way (synthbench → synthpanel)?
+- What's synthpanel's extras mechanism (`pyproject.toml` → `[project.optional-dependencies]`)? Are there precedents for optional extras that pull in a specific sibling package?
+- What's SynthBench's current install size / dependency tree? Would requiring it inline affect synthpanel's PyPI install experience?
+- How does the existing `--convergence-baseline` flag (sp-yaru) intend to consume SynthBench? Is that path already built or speculative?
+
+### 5. Inline-consumption access patterns in the codebase
+
+- What does synthpanel currently do with per-question output that could attach a metric? (e.g. `per_model_results[*].results[i]` is the row level; `per_question_synthesis` is the map-reduce per-question summary.)
+- Is there a natural "per question" structure today, or is the output flattened across questions?
+- Where in the output JSON shape would additional metric data land without breaking backward compatibility? Which sibling keys are already present (`metadata`, `synthesis`, `convergence`, `warnings`)?
+- How does sp-yaru's `convergence` section get populated — live during the run or post-hoc? What's its data shape?
+
+### 6. User-facing surfaces for calibration signal
+
+- What CLI subcommands exist today that explicitly reference validation / calibration / ground-truth? (`synthpanel analyze`, `synthpanel panel inspect`, others?)
+- Does the MCP server expose any "compare against baseline" tool? What's its contract?
+- How is the existing `cost_is_estimated: true/false` / `warnings: [...]` pattern documented? Is that a template for other sanity-check signals?
+- What does the current `panel run` stderr output look like during a run? Is there a natural spot to surface an on-run calibration number, or is the output strictly post-run?
+
+### 7. Dataset coverage vs synthpanel question types
+
+- Which of synthpanel's 8 bundled instruments (product-feedback, market-research, feature-prioritization, pricing-discovery, landing-page-comprehension, churn-diagnosis, name-test, general-survey) have *any* topical overlap with any SynthBench dataset question?
+- Conversely, for each SynthBench dataset, what kinds of synthpanel instruments would naturally ask questions that have a human distribution to compare against?
+- Is the overlap primarily on bounded / enum questions (where distributions make sense), or free-text questions (where comparison is harder)?
+- What's the precedent for free-text→categorical extraction in the codebase (the `--extract-schema` flag, `src/synth_panel/structured/*`)? Is that already plumbed into something SynthBench-adjacent?
+
+## Deliverable
+
+`specs/sp-inline-calibration/research/<dim>.md` per dimension, written objectively. Research phase synthesized into `research-map.md` for the human D-phase gate.

--- a/specs/sp-pack-registry/questions.md
+++ b/specs/sp-pack-registry/questions.md
@@ -1,0 +1,63 @@
+# Q-phase: Persona + instrument pack distribution
+
+*Ticket hidden per QRSPI discipline. These questions drive objective code-mapping only; do not invent design direction from them.*
+
+## Problem (shared with R polecats)
+
+Users author persona packs and instruments as YAML files today. Map how packs currently enter a user's environment (authoring, sharing, installing, validating, upgrading), what lifecycle invariants already exist, and what comparable content-distribution patterns exist in the Python ecosystem and adjacent tools.
+
+## Research dimensions
+
+### 1. Pack lifecycle today — authoring to consumption
+
+- How does a user create a new persona pack today? What are the steps from blank editor to runnable-in-`panel run`?
+- How does a user create a new instrument? Any differences in lifecycle vs personas?
+- How does a user pass a pack to a teammate or to a second machine? Copy the YAML? Include it in a repo? Email?
+- Are there any existing `pack` subcommands for discovery (list, show, search, browse)? What do they accept as input?
+- Are there any `pack import/export/install/uninstall/save` commands? Where do saved packs live on disk?
+
+### 2. Bundled pack delivery mechanism
+
+- How do the 9 bundled packs reach a user's machine? Package data in the wheel? Downloaded? Inlined?
+- How does the code discover bundled packs at runtime (directory scan, explicit registry, entry points)?
+- What's the update mechanism today — upgrade `synthpanel` and new packs appear?
+- How are bundled packs namespaced vs user-authored packs vs mayor's `extra_*` packs? What's the collision-resolution behavior (sp-g270 is partially related)?
+
+### 3. Pack validation and versioning
+
+- Is there a schema for persona packs? For instruments? Where is it defined? What does it enforce?
+- How are pack versions tracked today? Is there a `version:` field? How does it interact with `synthpanel`'s own version?
+- How are breaking changes to persona / instrument schemas handled in the codebase? Any migration tooling?
+- If two packs have the same name, what wins? What's the deterministic order?
+
+### 4. User-saved pack persistence
+
+- What user-owned storage does `synthpanel` use (`~/.synthpanel/*`, XDG_DATA_HOME, other)?
+- How is the location selected, overridden, and documented?
+- What's the permission / privacy model — are saved packs world-readable, user-only, other?
+- How do tests avoid collision with real user state (env-var overrides, tempdir fixtures)?
+
+### 5. Adjacent Python-ecosystem distribution patterns
+
+- How do comparable tools distribute user-authored content: `pre-commit` hooks, `cookiecutter` templates, `dbt` packages, `jinja` templates, `jupyter-contrib-extensions`, `homeassistant` integrations, `opensearch-dashboards` plugins?
+- Which use a git-URL install model (`pip install git+…`), a registry server (PyPI, npm, custom), a GitHub-topic-based discovery model, a static-index file, or other?
+- What is `pip install synthpanel-pack-foo` style namespace distribution like for those tools? Does anyone do it?
+- What's the submission / review / moderation model in each? Any failure patterns documented?
+
+### 6. SynthBench cross-link
+
+- SynthBench computes calibration metrics on synthpanel output against real human datasets. Is there already any per-pack signal flowing between the two projects?
+- Could a pack carry a "calibration fingerprint" (hash + score) computed from a SynthBench run? What would that require from both sides?
+- Is there any existing pack-level quality signal in the repo (test coverage, example runs, provenance metadata)?
+- How does SynthBench reference persona / instrument packs today — by name, by hash, by path?
+
+### 7. Authoring friction evidence from the existing corpus
+
+- Audit mayor/ and the bundled packs for duplication, drift, re-invention patterns: same persona archetype spelled differently across packs? Same instrument question under different keys?
+- What's the rough LOC / persona-count / file-count distribution of existing authored packs?
+- What's the most common authoring error path (missing field, invalid YAML, name collision, wrong top-level shape)? What error messages do users see?
+- Where do people paste pack YAML today (gist, slack, PR, local file) when sharing informally?
+
+## Deliverable
+
+`specs/sp-pack-registry/research/<dim>.md` per dimension, written objectively. Research phase synthesized into `research-map.md` for the human D-phase gate.

--- a/specs/sp-viz-layer/questions.md
+++ b/specs/sp-viz-layer/questions.md
@@ -1,0 +1,62 @@
+# Q-phase: Panel-result consumption paths
+
+*Ticket hidden per QRSPI discipline. These questions drive objective code-mapping only; do not invent design direction from them.*
+
+## Problem (shared with R polecats)
+
+Panel results land as JSON files today. Non-terminal humans — PMs, stakeholders, execs — aren't the primary consumers of those files. Map what paths panel results currently travel from creation to consumption, and what the surrounding ecosystem already provides for transforming structured output into human-facing artifacts.
+
+## Research dimensions
+
+### 1. Panel-result JSON shape and schema
+
+- Where is the panel-result JSON schema defined? Is it documented, versioned, or inferred from callers?
+- What are the distinct top-level and nested sections a consumer can read? What shape does each take (scalar, list, dict, tree)?
+- Which fields are canonical (always present) vs optional vs strategy-dependent (e.g. single vs map-reduce)?
+- Is the schema stable? Are there deprecations, renames, or versioned variants in flight?
+
+### 2. Existing downstream consumers of panel results
+
+- What code reads `panel-result.json` today — inside `synthpanel`, inside SynthBench, inside any mayor/agent workflow?
+- What subsets do those consumers use? (e.g. just `total_cost`, just `per_model_results`, just `synthesis`)
+- Are there any existing transform/extract utilities (e.g. `analyze`, `inspect`, `synthesize`) that already produce human-readable summaries, and what format do they emit?
+- What command-line flags, API functions, or MCP tools already accept a saved panel result as input?
+
+### 3. Existing rendering / templating infrastructure in-repo
+
+- Does the repo already pull in Jinja, any HTML templating, Markdown renderers, or static-site generators? Where, for what?
+- How are site/* artifacts generated today (`render_site.py` post sp-ssrw)? Is that pipeline reusable for non-site outputs?
+- What styling / layout conventions exist (tailwind, CSS files, theme colors)? Are they in the package or only in the marketing site?
+- What's the rough size budget of the package on PyPI today, and which optional extras already fence off heavy dependencies?
+
+### 4. Adjacent OSS tooling in the same ICP
+
+- How do comparable OSS tools (Great Expectations, Prefect, Dagster, W&B local, MLflow, evidently, lm-eval-harness, HELM, Jupyter, nbconvert, quarto, papermill) present run results to non-engineers?
+- Which of those tools ship a CLI-only path, a report-generator subcommand, a rendered HTML artifact, a notebook integration, or a live server?
+- What packaging patterns do they use for the report-generation bits — core dep, optional extra, separate package?
+- What explicit "no web UI" or "no dashboard" positioning exists elsewhere, and how is the substitute surfaced?
+
+### 5. Stakeholder-output primitives already in the codebase
+
+- Does any existing subcommand emit formatted text (tables, markdown, boxed-text CLI output, progress bars, summaries)? List them with their output shape.
+- Is there a CLI print-helper abstraction? A structured "emit" layer? A reporter class? A formatter registry?
+- Are there any existing `--format` / `--output-format` flags across subcommands? What do they accept (text / json / ndjson / other)? Are they consistent?
+- What fields in panel output are intentionally human-readable vs machine-readable (e.g. pre-formatted dollar strings vs raw numbers)?
+
+### 6. Non-CLI invocation surfaces
+
+- The MCP server exposes 12 tools — do any of them return a rendered representation, or only structured data?
+- Does the Python SDK provide a `render()` / `report()` / `summarize()` method anywhere? What shapes are returned?
+- Are there existing consumers in mayor/ or related repos that build their own rendering on top of panel JSON? Describe the patterns they use (pandas DataFrame, jinja, plain string-formatting, other).
+- What are stakeholder handoff patterns founders / PMs / researchers use in practice today (per README, docs, blog posts, community channels)?
+
+### 7. Boundary conditions for any future rendering path
+
+- What's the largest panel-result JSON size observed in the self-audit artifacts (`mayor/results/synthpanel-self-audit/`)? At what n does it cross 1 MB, 10 MB?
+- Which sections of the output are safe to render verbatim vs need summarization (e.g. raw panelist text vs per-model cost)?
+- Are there any privacy / redaction concerns with rendering panel results — PII in personas, BYOK credentials anywhere in the output?
+- What's the current provenance / audit trail per panel (config_hash, timestamps, model versions) and how would a rendered report preserve it?
+
+## Deliverable
+
+`specs/sp-viz-layer/research/<dim>.md` per dimension, written objectively — what exists, not what *should* exist. Research phase synthesized into `research-map.md` for the human D-phase gate.


### PR DESCRIPTION
## Summary

Manual QRSPI per founder direction. Authors ticket-blind Q-phase question lists for three hotspots surfaced in the dogfooded n=100 v2 synthpanel self-audit:

- `specs/sp-viz-layer/questions.md` — non-CLI stakeholder consumption
- `specs/sp-pack-registry/questions.md` — community pack distribution
- `specs/sp-inline-calibration/questions.md` — inline SynthBench metric

Each question list is written to force objective codebase mapping during the R phase without leaking design direction. Research-dimension sections become parallel R-phase tasks; R outputs land at `specs/<slug>/research/<dim>.md` and synthesize into `research-map.md` for the human D-phase gate.

Related beads: sp-nj58 (viz), sp-5roa (registry), sp-0ku0 (calibration).

## Test plan

- [x] Spec artifacts committed, no code changes
- [x] Format / lint N/A for docs-only