### PR TITLE
docs(specs): R-phase research + research-maps for 3 QRSPI initiatives

### DIFF
--- a/specs/sp-inline-calibration/questions.md
+++ b/specs/sp-inline-calibration/questions.md
@@ -1,0 +1,62 @@
+# Q-phase: Cross-project calibration signal flow
+
+*Ticket hidden per QRSPI discipline. These questions drive objective code-mapping only; do not invent design direction from them.*
+
+## Problem (shared with R polecats)
+
+SynthBench computes distributional comparisons (JSD, Kendall's tau, convergence curves) between synthpanel output and real human survey data. Map the current data flow end-to-end: how does synthpanel output reach SynthBench, what transformations happen on each side, where does the comparison result live, and who reads it.
+
+## Research dimensions
+
+### 1. SynthBench's ingestion of synthpanel output
+
+- How does SynthBench discover a synthpanel panel result today? Is there a provider adapter? A file-watcher? A manual invocation?
+- `src/synthbench/providers/synthpanel.py` exists — what does it expose, and what's its call contract?
+- What subset of the panel-result JSON does SynthBench read? Which fields are load-bearing for the metric computation?
+- Is the provider pattern idempotent / re-runnable on the same panel result? Cached?
+
+### 2. SynthBench's dataset adapters + Question abstraction
+
+- `Question` in `src/synthbench/datasets/base.py` carries `human_distribution` — how is that distribution keyed (option names? ordinal indexes? enum tokens?)
+- How does SynthBench match a synthpanel output question to a SynthBench dataset question? By key, text similarity, explicit mapping, manual alignment?
+- Which of the nine datasets have redistribution-full status vs gated vs aggregates-only? What does that mean for inline consumption?
+- Is there any "question registry" that synthpanel could reference by name to say "this question is the same as GSS's SPKATH"?
+
+### 3. Metric computation and output shape
+
+- Where is JSD computed (`src/synthbench/metrics/distributional.py`)? What's its input contract — two distribution dicts, a pair of Questions, paired arrays?
+- What's the output shape of a full SynthBench run against a synthpanel provider — single JSD per question, a table, a leaderboard entry, a published artifact?
+- What's the lifecycle of a computed calibration metric? In-memory only, persisted to disk, uploaded to R2, published to the leaderboard site?
+- Are there any lightweight / cheap versions of the metric suitable for inline use (e.g. per-question single-number JSD vs full report)?
+
+### 4. Cross-package dependency posture
+
+- Does synthpanel already import synthbench anywhere, or is the provider one-way (synthbench → synthpanel)?
+- What's synthpanel's extras mechanism (`pyproject.toml` → `[project.optional-dependencies]`)? Are there precedents for optional extras that pull in a specific sibling package?
+- What's SynthBench's current install size / dependency tree? Would requiring it inline affect synthpanel's PyPI install experience?
+- How does the existing `--convergence-baseline` flag (sp-yaru) intend to consume SynthBench? Is that path already built or speculative?
+
+### 5. Inline-consumption access patterns in the codebase
+
+- What does synthpanel currently do with per-question output that could attach a metric? (e.g. `per_model_results[*].results[i]` is the row level; `per_question_synthesis` is the map-reduce per-question summary.)
+- Is there a natural "per question" structure today, or is the output flattened across questions?
+- Where in the output JSON shape would additional metric data land without breaking backward compatibility? Which sibling keys are already present (`metadata`, `synthesis`, `convergence`, `warnings`)?
+- How does sp-yaru's `convergence` section get populated — live during the run or post-hoc? What's its data shape?
+
+### 6. User-facing surfaces for calibration signal
+
+- What CLI subcommands exist today that explicitly reference validation / calibration / ground-truth? (`synthpanel analyze`, `synthpanel panel inspect`, others?)
+- Does the MCP server expose any "compare against baseline" tool? What's its contract?
+- How is the existing `cost_is_estimated: true/false` / `warnings: [...]` pattern documented? Is that a template for other sanity-check signals?
+- What does the current `panel run` stderr output look like during a run? Is there a natural spot to surface an on-run calibration number, or is the output strictly post-run?
+
+### 7. Dataset coverage vs synthpanel question types
+
+- Which of synthpanel's 8 bundled instruments (product-feedback, market-research, feature-prioritization, pricing-discovery, landing-page-comprehension, churn-diagnosis, name-test, general-survey) have *any* topical overlap with any SynthBench dataset question?
+- Conversely, for each SynthBench dataset, what kinds of synthpanel instruments would naturally ask questions that have a human distribution to compare against?
+- Is the overlap primarily on bounded / enum questions (where distributions make sense), or free-text questions (where comparison is harder)?
+- What's the precedent for free-text→categorical extraction in the codebase (the `--extract-schema` flag, `src/synth_panel/structured/*`)? Is that already plumbed into something SynthBench-adjacent?
+
+## Deliverable
+
+`specs/sp-inline-calibration/research/<dim>.md` per dimension, written objectively. Research phase synthesized into `research-map.md` for the human D-phase gate.

--- a/specs/sp-inline-calibration/research-map.md
+++ b/specs/sp-inline-calibration/research-map.md
@@ -1,0 +1,105 @@
+# Research Map — sp-inline-calibration
+
+Synthesis of two research dimensions for the D-phase gate. Ticket now revealed: **sp-0ku0 — inline SynthBench calibration score in panel output.**
+
+## What the codebase currently provides
+
+**SynthBench → synthpanel flow is wired.** `SynthPanelProvider` at `src/synthbench/providers/synthpanel.py:287-400` consumes synthpanel JSON output via two paths: direct API (`synth_panel.llm.client.LLMClient` import + `ThreadPoolExecutor`) and CLI subprocess fallback. Provider reads only `data["rounds"][0]["results"][*].responses[i].response` per panelist per question; metadata fields (cost, usage) are optional.
+
+**Question abstraction is option-string-keyed.** `Question` dataclass (`src/synthbench/datasets/base.py:34-50`) carries `options: list[str]` and `human_distribution: dict[str, float]` keyed by option text. Distributions normalized in `__post_init__` if sum deviates by >1%. No ordinal-index or enum-token layer; option text is the key.
+
+**Question matching is explicit by dataset structure.** SynthBench orchestrates: loads `Question` from the adapter, passes `question.text + question.options` to the provider. No fuzzy matching, no synthpanel→synthbench question-key registry. Integration assumes synthpanel is invoked only by SynthBench's provider.
+
+**JSD is simple and well-typed.** `metrics/distributional.py:6-34`:
+```python
+def jensen_shannon_divergence(p, q) -> float:
+    # union supports, pad missing with 0.0, scipy.spatial.distance.jensenshannon base=2 squared
+```
+Returns single float in [0.0, 1.0]. Disjoint supports handled. Normalized internally.
+
+**Synthpanel → SynthBench is one-way.** `synthpanel/pyproject.toml:46-48` declares `[convergence]` extra requiring `synthbench>=0.1`. Lazy import in `src/synth_panel/convergence.py:554-608::load_synthbench_baseline()` — imports inside the function, raises `SynthbenchUnavailableError` if missing. CLI flag `--convergence-baseline DATASET:QUESTION` (sp-yaru) is the current opt-in surface.
+
+**Convergence output structure exists and is sibling-safe.** `convergence` top-level section added by sp-yaru, populated by `ConvergenceTracker.build_report()`. Contains `final_n`, `overall_converged_at`, `tracked_questions`, `per_question: {key: {converged_at, curve, support_size}}`, and `human_baseline` spliced verbatim from the loaded SynthBench payload.
+
+**Nine SynthBench datasets with redistribution tiers:**
+- `full` (per-question distributions publishable): **gss, ntia**
+- `gated` (authenticated R2 bucket): wvs, michigan, pewtech, eurobarometer, opinionsqa, globalopinionqa, subpop
+- Not in current inventory: `aggregates_only`, `citation_only` (reserved for future)
+
+**Only GSS and NTIA are redistribution-safe for inline surfaces**. Others require authenticated access or aggregate-only consumption.
+
+## Instrument ↔ dataset coverage (reality check)
+
+Comparing synthpanel's 8 bundled instruments to SynthBench's 9 datasets:
+
+**All 8 synthpanel instruments are 100% free-text today.** Every question declares `response_schema: {type: text}`. No Likert, enum, or yes-no. Branching instruments route on post-hoc theme extraction by the synthesizer, not pre-defined options.
+
+**All 9 SynthBench datasets are bounded.** Enum (opinionsqa, pewtech, eurobarometer, ntia, subpop, wvs, gss, michigan), Likert (globalopinionqa, wvs, gss, 0-10 scales), or binary (ntia).
+
+**Overlap matrix is sparse:**
+
+| Instrument | Datasets with MED overlap | Datasets with LOW or none |
+|---|---|---|
+| **general-survey** | pewtech, opinionsqa, globalopinionqa, michigan, wvs, gss, subpop | eurobarometer (LOW), ntia (LOW) |
+| product-feedback (NPS) | pewtech, globalopinionqa | others |
+| churn-diagnosis | globalopinionqa, pewtech, michigan, wvs, subpop | opinionsqa, eurobarometer (all LOW) |
+| market-research | wvs | others LOW |
+| feature-prioritization | pewtech (LOW) | all others: none |
+| pricing-discovery | — | all: none |
+| landing-page-comprehension | — | all: none |
+| name-test | — | all: very weak |
+
+**Easy comparisons (no transformation):**
+1. `general-survey × {pewtech, opinionsqa, globalopinionqa}` — free-text opinion Q extracted as enum via `PICK_ONE_SCHEMA` → JSD vs enum distribution
+2. `product-feedback NPS × globalopinionqa` — extract 0-10 integer → Likert distribution, compare directly
+
+**Moderate (light transformation):** `product-feedback feature-satisfaction × pewtech`, `churn-diagnosis × michigan` — require sentiment/category mapping.
+
+**Hard or impossible:** pricing-discovery, landing-page-comprehension, name-test, feature-prioritization — SynthBench has no corresponding ground-truth distributions.
+
+## Observable seams (integration points)
+
+1. **`load_synthbench_baseline(spec)` is already implemented.** Returns baseline payload dict (human distribution + convergence metadata). Currently spliced under `convergence.human_baseline`.
+
+2. **Per-question metric attachment is a near-miss.** `convergence.per_question[key]` already exists with JSD-based curves. Adding `convergence.per_question[key].human_jsd` (model-distribution vs human-distribution single number) is additive; wires into existing `_run_check_locked()` in `convergence.py`.
+
+3. **Baseline question registry does not exist.** If instruments tagged questions with SynthBench keys (e.g., `--- synthbench-key: gss:SPKATH`), `load_synthbench_baseline()` could accept a full mapping payload rather than one question at a time. Enables bulk calibration without manual alignment.
+
+4. **`synthesis.per_question_synthesis`** — map-reduce intermediate summaries keyed by question index. Empty today (not consumed). A sibling `synthesis.per_question_calibration` is the natural home for calibration metrics if we surface them in the synthesis block rather than a convergence sibling.
+
+5. **`extract_schema` path** — `src/synth_panel/structured/` already transforms free-text responses into structured data via tool-use. The last-mile pipeline from free-text → enum/likert → distribution → JSD already exists component-wise; wiring is the question.
+
+6. **MCP server tool surface** — `run_panel` today returns structured panel data. An adjacent `compare_against_synthbench(panel_result, dataset, question_key)` tool is a pure-function add-on.
+
+## Design-space tensions (for D-phase discussion)
+
+**Inline-during-run vs post-hoc tension.** (a) `--calibrate-against DATASET:QUESTION` during `panel run` couples calibration to the run and pays live cost; (b) `synthpanel calibrate RESULT.json --against DATASET` as post-hoc subcommand decouples but requires a second invocation. Both have legitimate use cases.
+
+**Automatic vs explicit alignment tension.** Synthpanel has no `--synthbench-key` tagging convention today. Two forks: (i) require instruments to tag questions with SynthBench keys (schema change, instrument migration cost), or (ii) provide a `--calibrate-against DATASET:QUESTION` flag where user specifies alignment per panel.
+
+**Which datasets are practical for inline.** Only `gss` and `ntia` are redistribution-full. Inline calibration on `gated` datasets requires either an authenticated cache or a user's own local copy. Realistic inline UX likely focuses on GSS for the first wedge.
+
+**Output-shape tension.** Single JSD number per question? A full curve? A narrative? The product signal (from panelist audit Q4) asked for "the number surfaced right next to the panel result" — suggests a scalar or small struct, not a narrative. But aligning that to the existing `convergence` block vs carving a new `calibration` block is a real choice.
+
+**Dataset coverage reality-check.** 5 of 8 instruments have **no overlap** with any SynthBench dataset. Inline calibration's value is constrained by how often users hit the overlap zone (general-survey is the best-covered; pricing/landing-page/name-test are empty quadrants). Feature may have narrower audience than the panelist ask suggested.
+
+**Coupling tension.** The `[convergence]` extra already exists. Does inline calibration live there (keeping the fence) or graduate into core? Adjacent question: if GSS is the only practical inline source, does calibration belong behind its own `[calibration]` extra or under `[convergence]`?
+
+**Bounded-question requirement.** All synthpanel bundled instruments are free-text today. Practical inline calibration requires either (a) instrument authors adding `response_schema` with enum/likert types, or (b) runtime extraction via `--extract-schema` that produces bounded distributions. Either is a real pipeline. Neither is free.
+
+## What the research does not answer
+
+- Whether surfacing calibration inline is more valuable as a research-validity signal (tight integration, few datasets) or as a marketing-visible number (broader coverage, shallower signal)
+- How much adoption friction the `--synthbench-key` tagging convention adds for instrument authors
+- Whether the first-wedge target is `general-survey × pewtech` (most-overlapping pair) or `product-feedback × globalopinionqa` (easiest NPS conversion)
+- Whether inline calibration should drive future instrument authoring (new bundled instruments with known-good SynthBench analogues)
+- The latency cost of running a SynthBench calibration pass inline vs post-hoc on typical panel sizes (n=50 to n=10k)
+
+## Files
+
+- `research/synthbench-flow-map.md`
+- `research/instrument-dataset-coverage.md`
+
+## Ready for D-phase gate
+
+No design direction proposed. The path from panelist response to JSD number is visible in code today; the architectural choice is *where* to plug it in, *which* audience to optimize for, and *which* dataset coverage to treat as the realistic wedge. Human brain-surgery gate next.

--- a/specs/sp-inline-calibration/research/instrument-dataset-coverage.md
+++ b/specs/sp-inline-calibration/research/instrument-dataset-coverage.md
@@ -1,0 +1,116 @@
+# Instrument ↔ Dataset Coverage — Research Summary
+
+## 1. Synthpanel Bundled Instruments
+
+| Instrument | Description | Questions | Question types |
+|---|---|---:|---|
+| product-feedback | NPS + feature satisfaction + open improvement | 5 | 5 free-text |
+| market-research | Competitive preference, purchase intent, pricing sensitivity | 5 | 5 free-text |
+| pricing-discovery | Branching probe on pain / pricing / competitors | ~9 | ~3 routing bounded, 6 free-text |
+| feature-prioritization | Branching on trade-offs / must-haves / scope | ~9 | ~3 routing, 6 free-text |
+| churn-diagnosis | Branching on value / friction / competitive | ~9 | ~3 routing, 6 free-text |
+| landing-page-comprehension | Branching on jargon / audience / CTA | ~9 | ~3 routing, 6 free-text |
+| name-test | Branching on meaning / pronounceability / memorability | ~9 | ~3 routing, 6 free-text |
+| general-survey | Tech / work / daily habits opinion | 5 | 5 free-text |
+
+**Key finding:** All 8 instruments are **100% free-text** (`type: text` in `response_schema`). None declare bounded response_schema (Likert, enum, yes-no) today. Branching instruments route on themes extracted post-hoc by the synthesizer, not on pre-defined enum options.
+
+## 2. SynthBench Datasets
+
+| Dataset | Description | Policy | ~Count | Shape |
+|---|---|---|---:|---|
+| opinionsqa | 1,498 Pew ATP questions (waves 26-92) | gated | 1,498 | Enum 3-5 options |
+| globalopinionqa | 2,556 questions × 138 countries | gated | 2,556 | Likert 0-10, agree/disagree |
+| subpop | 3,362 questions × 22 US subpopulations | gated | 3,362 | Enum/Likert aggregated per subpop |
+| pewtech | Tech-focused ATP (waves 86-113) | gated | ~200-300 | Enum (tech adoption, privacy, AI) |
+| eurobarometer | Consumer modules (EU quarterly/flash) | gated | ~50-100+ | Enum (satisfaction, likelihood, agreement) |
+| michigan | UMich Survey of Consumers (13 core monthly) | gated | 13 | Enum 3-option (Good/Pro-Con/Bad) |
+| ntia | NTIA Internet Use Survey (binary) | full | ~100+ | Binary Yes/No |
+| wvs | WVS Wave 7 (64 countries) | gated | 290+ | Enum/Likert values |
+| gss | General Social Survey (1972-present) | full | 500+ | Enum/Likert social attitudes |
+
+## 3. Topical Overlap Matrix
+
+| Synthpanel instrument | SynthBench overlap | Strength | Notes |
+|---|---|---|---|
+| product-feedback (NPS) | pewtech, globalopinionqa | **MED** | NPS 0-10 → Likert; feature satisfaction → tech opinion enum |
+| market-research | pewtech, opinionsqa | LOW | SynthBench minimal on pricing/purchase-intent |
+| pricing-discovery | — | **none** | SynthBench is opinion-focused; no willingness-to-pay questions |
+| feature-prioritization | pewtech, opinionsqa | LOW | SynthBench rarely asks feature ranking |
+| churn-diagnosis | pewtech, globalopinionqa, michigan | MED | michigan "switch" proxy; pewtech tech satisfaction |
+| landing-page-comprehension | — | **none** | SynthBench is pure opinion; synthpanel targets comprehension |
+| name-test | globalopinionqa, opinionsqa | very weak | Opinions not brand perception |
+| general-survey | pewtech, opinionsqa, globalopinionqa, michigan | **STRONG** | Tech attitudes, business/economic outlook, broad opinion |
+
+## 4. Question Type Classification
+
+**SynthBench questions are BOUNDED:**
+- **Enum:** OpinionsQA, PewTech, Eurobarometer, NTIA, SubPOP, WVS, GSS, Michigan (3-5 discrete options, fully labeled)
+- **Likert:** GlobalOpinionQA, WVS, GSS (0-10 or agreement scales)
+- **Binary:** NTIA Internet Use (Yes/No)
+
+**Synthpanel questions are ALL FREE-TEXT:** no bounded response_schema in bundled instruments. Routing in branching instruments uses synthesizer's post-hoc `themes` extraction, not pre-defined enum options.
+
+## 5. Distributional Comparison Feasibility
+
+### Easy (no transformation)
+
+1. **general-survey ↔ pewtech / opinionsqa / globalopinionqa.** Both have open-opinion questions. Extraction schema can categorize synthpanel free responses: `pick_one`, `ranking`, or `likert`. Example: "What trend are you most optimistic about?" → extract enum (technology / economy / health / none) → compare to WVS/OpinionsQA political-economic outlook distributions.
+2. **product-feedback NPS ↔ pewtech / globalopinionqa.** Extract NPS score 0-10 from "On a scale of 0-10" text → Likert. Compare directly to globalopinionqa 0-10 scales. JSD on {0-3: dissatisfied, 4-6: neutral, 7-8: satisfied, 9-10: promoters}.
+
+### Moderate (light transformation)
+
+1. **churn-diagnosis ↔ michigan.** Synthpanel "What was broken?" → extract as problem category. Michigan "Good time to buy?" → {Good, Pro-Con, Bad}. Map synthpanel categories to michigan sentiment.
+2. **product-feedback feature-satisfaction ↔ pewtech.** Synthpanel "How satisfied with core functionality?" → extract satisfaction level or feature category. PewTech "Adopt this technology?" → enum. Binary/ternary satisfaction bridge.
+
+### Difficult (heavy extraction required)
+
+1. **pricing-discovery ↔ no dataset match.** SynthBench has no willingness-to-pay or pricing-sensitivity questions. Would require free-text price-point extraction → binning (e.g., "$0-50/mo", "$50-200/mo", "$200+") → cannot compare to any dataset.
+2. **landing-page-comprehension ↔ no match.** Synthpanel targets comprehension/clarity; SynthBench is opinion/attitude.
+3. **name-test ↔ no match.** Brand perception not in SynthBench public-opinion datasets.
+4. **feature-prioritization ↔ no match.** SynthBench lacks feature ranking questions.
+
+## 6. Response Schema Inventory
+
+All 8 instruments declare `response_schema` on every question — but every one is `type: text`. No enum/Likert/yes-no schema defined anywhere in bundled instruments.
+
+**Implications:**
+- Distributional comparison requires **post-hoc extraction** via synthpanel's `structured/` module
+- `--extract-schema` or inline `StructuredOutputConfig(schema=LIKERT_SCHEMA)` converts free text → bounded distribution
+- Ground-truth key: `Question.human_distribution` in SynthBench
+- Synthetic key: extracted enum/likert distribution from synthpanel response
+
+## 7. Coverage Matrix
+
+| Instrument | opinionsqa | globalopinionqa | pewtech | michigan | eurobarometer | ntia | wvs | gss | subpop |
+|---|---|---|---|---|---|---|---|---|---|
+| product-feedback NPS | MED | MED | LOW | LOW | LOW | — | LOW | — | LOW |
+| market-research | LOW | LOW | LOW | LOW | LOW | — | MED | — | LOW |
+| pricing-discovery | — | — | — | — | — | — | — | — | — |
+| feature-prioritization | — | — | LOW | — | — | — | — | — | — |
+| churn-diagnosis | LOW | MED | MED | MED | LOW | — | MED | — | MED |
+| landing-page-comprehension | — | — | — | — | — | — | — | — | — |
+| name-test | — | LOW | — | — | — | — | — | — | — |
+| general-survey | MED | MED | MED | MED | LOW | LOW | MED | MED | MED |
+
+## 8. Key Transformation Patterns
+
+Where `--extract-schema` fits naturally:
+1. **Free-text NPS justification** → LIKERT_SCHEMA (extract 0-10 or map satisfaction sentiment)
+2. **Open "what went wrong?"** → PICK_ONE_SCHEMA (extract problem category: value / friction / UX / price / competitor)
+3. **"Which feature?"** → RANKING_SCHEMA (extract top-3 from feature list)
+4. **"Do you agree?"** → YES_NO_SCHEMA (binary extraction from prose)
+
+**Canonical pairing for inline calibration:**
+- Synthpanel question with `response_schema: {type: text}`
+- Extraction config `StructuredOutputConfig(schema=LIKERT_SCHEMA)` or `YES_NO_SCHEMA`
+- Output `{rating: 7, reasoning: "..."}` → JSD vs SynthBench's `human_distribution: {7: 0.15, 8: 0.28, ...}`
+
+## Coverage map summary
+
+**Sparse but targeted:**
+- **3 of 8 instruments** (product-feedback, general-survey, churn-diagnosis) have **weak-to-moderate** topical overlap with SynthBench datasets (primarily pewtech, opinionsqa, globalopinionqa, michigan)
+- **5 of 8 instruments** (pricing-discovery, landing-page-comprehension, name-test, feature-prioritization, market-research) have **no meaningful overlap** — they probe product/UX specifics; SynthBench covers public opinion
+- All overlap requires **free-text → categorical extraction** via bundled schemas
+- **Easiest inline calibration:** general-survey + globalopinionqa/pewtech + LIKERT/PICK_ONE extraction
+- **Highest ROI for ground truth:** map general-survey tech-attitude questions to pewtech adoption/privacy/AI questions; LIKERT_SCHEMA extraction → JSD vs pewtech actual distribution

--- a/specs/sp-inline-calibration/research/synthbench-flow-map.md
+++ b/specs/sp-inline-calibration/research/synthbench-flow-map.md
@@ -1,0 +1,228 @@
+# SynthBench ↔ SynthPanel Data Flow — Research Summary
+
+## 1. SynthBench's Ingestion of Synthpanel Output
+
+### Provider contract
+
+`SynthPanelProvider` (`src/synthbench/providers/synthpanel.py:287-400`) implements two execution paths:
+
+- **Direct API path** (`_HAS_SYNTH_PANEL_API=True`): imports `synth_panel.llm.client.LLMClient`, uses `ThreadPoolExecutor` for concurrency. Zero subprocess overhead (~1s/call saved).
+- **CLI fallback**: `synthpanel` binary via subprocess when API import fails.
+
+Config:
+- `model` (str): alias or canonical name
+- `temperature` (float | None)
+- `profile` (str | None)
+- `prompt_template` (str | None)
+
+### Data consumed
+
+From `synthpanel panel run --output-format json`:
+```
+data["rounds"][0]["results"][*].responses[i].response  → raw text
+data["rounds"][0]["results"][*].usage                  → token metadata
+data["rounds"][0]["results"][*].error                  → panelist-level error flag
+data.model / data.total_cost / data.panelist_cost     → metadata
+```
+
+Provider extracts: (1) raw `.response` text per panelist × question; (2) selected option via letter parser (`_parse_letter()`) or substring match; (3) refusal count when parse fails; (4) aggregated token usage.
+
+**Key subset:** provider reads only `responses[].response` field per panelist per question. Metadata fields (cost/usage) are optional, used for attribution/debugging.
+
+### Idempotency
+
+**Re-runnable, no cache.** Each `get_distribution()` or `batch_get_distribution()` call re-invokes synthpanel. No checkpointing. By design.
+
+## 2. Question Representation & Distribution Keying
+
+### `Question` dataclass (`src/synthbench/datasets/base.py:34-50`)
+
+```python
+@dataclass
+class Question:
+    key: str                                    # Stable question identifier
+    text: str                                   # Full survey question text
+    options: list[str]                          # Answer choices as strings
+    human_distribution: dict[str, float]        # Option → probability mass
+    survey: str = ""                            # Dataset + wave
+    topic: str = ""                             # Topical label
+```
+
+### Keying
+
+**Human distribution keyed by option string, not ordinal index or enum token.**
+
+```json
+{"Very satisfied": 0.35, "Somewhat satisfied": 0.42, "Neutral": 0.15, "Dissatisfied": 0.08}
+```
+
+Distributions normalized in `__post_init__` if sum deviates from 1.0 by >1%. `options` list defines canonical ordering; probabilities aligned by string match. No separate enum/token layer — option text **is** the key.
+
+## 3. Question Matching
+
+**Explicit by dataset structure.** Not text similarity, not manual alignment.
+
+Flow:
+1. `Dataset.load(n=n)` returns `list[Question]` with pre-set `key`, `text`, `options`, `human_distribution`
+2. Provider called with `question.text` + `question.options` directly
+3. Provider returns `Distribution` aligned to `question.options` ordering
+
+**No fuzzy-matching, no registry of synthpanel-output-question-name → SynthBench-key.** Integration assumes: SynthBench orchestrates (picks dataset, loads questions, calls provider); SynthPanel is invoked *only* by SynthBench's provider; `Question.key` is internal to dataset adapter, not exposed to synthpanel.
+
+## 4. Metric Computation
+
+### JSD (`src/synthbench/metrics/distributional.py:6-34`)
+
+```python
+def jensen_shannon_divergence(p: dict[str, float], q: dict[str, float]) -> float:
+    keys = sorted(set(p) | set(q))
+    p_vec = np.array([p.get(k, 0.0) for k in keys])
+    q_vec = np.array([q.get(k, 0.0) for k in keys])
+    jsd = jensenshannon(p_vec, q_vec, base=2) ** 2
+    return float(jsd)
+```
+
+### Input contract
+
+- `p`, `q` = dicts mapping option string → probability
+- **Disjoint supports handled** — missing keys padded with 0.0
+- Both normalized internally
+
+### Output
+
+- Single `float` in [0.0, 1.0]
+- 0 = identical, 1 = maximally divergent
+- Returned per question in `QuestionResult.jsd` (runner.py:180-200)
+
+### Run-level
+
+`BenchmarkResult` (runner.py):
+```python
+BenchmarkResult(
+    provider_name: str,
+    dataset_name: str,
+    questions: list[QuestionResult],
+    config: dict,
+    elapsed_seconds: float,
+)
+```
+
+Each `QuestionResult`:
+```python
+jsd: float
+kendall_tau: float
+parity: float  # composite metric
+human_distribution: dict[str, float]
+model_distribution: dict[str, float]
+n_samples: int
+model_refusal_rate: float
+```
+
+## 5. Cross-Package Dependency Posture
+
+**One-way: SynthBench → synthpanel.** Provider calls synthpanel; synthpanel does NOT import SynthBench in core paths.
+
+**Optional extras** (`synthpanel/pyproject.toml:46-48`):
+```toml
+[project.optional-dependencies]
+convergence = ["synthbench>=0.1"]
+```
+
+**Lazy import** (`src/synth_panel/convergence.py:554-608`): `load_synthbench_baseline(spec: str)` attempts `import synthbench` inside the function; raises `SynthbenchUnavailableError` with install instructions if missing. Calls synthbench's exported loader (tries `load_convergence_baseline`, `load_baseline`, `convergence_baseline` attribute). Returns baseline payload dict (human distribution + convergence metadata).
+
+**CLI flag** (`--convergence-baseline "gss:happiness"`): opt-in, only triggered if user explicitly requests.
+
+**No circular dependency.** Synthpanel core CLI works without synthbench. SynthBench includes synthpanel as a provider. Synthpanel imports synthbench lazily, at CLI time not import time.
+
+## 6. Nine Datasets & Redistribution Tiers
+
+All in `src/synthbench/datasets/__init__.py:DATASETS`:
+
+| Dataset | Policy | License URL | Citation |
+|---|---|---|---|
+| **gss** | `full` | gss.norc.org | NORC General Social Survey |
+| **ntia** | `full` | ntia.gov (public domain, 17 USC 105) | US Gov Internet Use Survey |
+| **wvs** | `gated` | worldvaluessurvey.org | WVS Wave 7 |
+| **michigan** | `gated` | sca.isr.umich.edu | UMich Survey of Consumers |
+| **pewtech** | `gated` | pewresearch.org | Pew Research Internet & Tech |
+| **eurobarometer** | `gated` | gesis.org | EC / GESIS Consumer Modules |
+| **opinionsqa** | `gated` | codalab.org | (no explicit license URL) |
+| **globalopinionqa** | `gated` | CC BY-NC-SA 4.0 | Durmus et al. 2023, Anthropic |
+| **subpop** | `gated` | huggingface.co/datasets/jjssuh/subpop | Suh et al., ACL 2025 |
+
+### Tier definitions (`base.py:72-100`)
+
+- **`full`**: per-question distributions publishable on static site (public domain or explicit permissive license)
+- **`gated`**: per-question artifacts ship to authenticated R2 bucket; public sees sign-in gate
+- **`aggregates_only`** (default): only aggregate scores public; no per-question
+- **`citation_only`**: only metadata (text, options); metrics suppressed
+
+## 7. SynthBench CLI Surface
+
+### `synthbench run` (cli.py:41-279)
+
+```bash
+synthbench run --provider raw-anthropic --model haiku --dataset opinionsqa --n 100 --samples 30 --output results/
+synthbench run --provider synthpanel --model sonnet --dataset gss --submit --wait
+```
+
+Key calibration flags:
+- `--provider {raw-anthropic,raw-openai,raw-gemini,openrouter,ollama,synthpanel,http}`
+- `--model`, `--dataset`, `--samples`, `--suite {smoke,core,full}`, `--topic {political,consumer,neutral}`
+- `--baselines-dir PATH`
+- `--demographics` (AGE, POLIDEOLOGY, ...)
+- `--full-evaluation`, `--submit`, `--wait`
+
+**Output:** JSON per-question JSD / Kendall's τ / parity / model refusal rate / token usage.
+
+**No dedicated `synthbench report` subcommand.** Results land in `--output` directory as JSON.
+
+## 8. Inline-Consumption Integration Points (synthpanel side)
+
+### Current convergence output structure (sp-0h9x, sp-yaru)
+
+```json
+{
+  "rounds": [...],
+  "model": "...",
+  "total_cost": "...",
+  "metadata": {...},
+  "synthesis": {...},
+  "convergence": {
+    "final_n": 500,
+    "epsilon": 0.02,
+    "auto_stopped": false,
+    "overall_converged_at": 250,
+    "tracked_questions": ["q1", "q2"],
+    "per_question": {
+      "q1": {"converged_at": 200, "curve": [{"n": 50, "jsd": 0.15}, ...], "support_size": 4}
+    },
+    "human_baseline": {...}   // spliced from SynthBench if --convergence-baseline set
+  },
+  "per_model_results": [...],
+  "cost_breakdown": {...},
+  "warnings": [...]
+}
+```
+
+### Convergence flow (sp-yaru)
+
+1. **Question filtering** (`convergence.py:163-176`): `identify_tracked_questions()` drops free-text, keeps bounded (Likert / yes-no / pick-one / enum / ranking). Returns `[(index, key, question_dict)]`.
+2. **Live recording** (`convergence.py:373-399`): each completed panelist feeds into `convergence_tracker.record()`. Extracts categorical value via `extract_category()`. Updates running Counter. Every K (default 20), computes rolling JSD. Auto-stop when JSD < epsilon for M consecutive checks.
+3. **Post-run report** (`convergence.py:411-445`): `build_report(baseline=...)` returns dict with per-question curves, converged-at thresholds, overall flag. Baseline payload spliced verbatim under `human_baseline`.
+
+### Backward compat
+
+`convergence` is sibling to existing keys. Parsers ignoring unknown keys unaffected. No breaking changes.
+
+## Seams Observed
+
+Natural integration points for inline calibration:
+
+1. **Per-question JSD attachment** — synthpanel already loads SynthBench baseline via `--convergence-baseline`. Could emit `per_question[key].human_jsd` during run. No data-model changes needed; wire additional metric computation in `_run_check_locked()`.
+2. **Baseline question registry** — SynthBench datasets have stable keys (`"gss:spkath"`). Synthpanel instruments could tag questions with synthbench keys. `load_synthbench_baseline()` could load a full mapping payload, enabling per-question human distributions without manual alignment.
+3. **Output schema versioning** — `convergence` is opt-in; could become default when inline calibration is. `per_question_metrics` sibling could house JSD + refusal + token attribution per question without enlarging `convergence`.
+4. **CLI integration** — `synthpanel panel run --calibrate-against {gss,opinionsqa}` shorthand for `--convergence-baseline gss:*`. `synthpanel panel inspect --calibration` rendering.
+5. **MCP attachment** — `compare_against_synthbench(result_id, dataset, question_key)` tool in MCP server.
+
+Only current seam is `load_synthbench_baseline()`; no reverse direction needed beyond the optional `convergence` extra already declared.

--- a/specs/sp-pack-registry/questions.md
+++ b/specs/sp-pack-registry/questions.md
@@ -1,0 +1,63 @@
+# Q-phase: Persona + instrument pack distribution
+
+*Ticket hidden per QRSPI discipline. These questions drive objective code-mapping only; do not invent design direction from them.*
+
+## Problem (shared with R polecats)
+
+Users author persona packs and instruments as YAML files today. Map how packs currently enter a user's environment (authoring, sharing, installing, validating, upgrading), what lifecycle invariants already exist, and what comparable content-distribution patterns exist in the Python ecosystem and adjacent tools.
+
+## Research dimensions
+
+### 1. Pack lifecycle today — authoring to consumption
+
+- How does a user create a new persona pack today? What are the steps from blank editor to runnable-in-`panel run`?
+- How does a user create a new instrument? Any differences in lifecycle vs personas?
+- How does a user pass a pack to a teammate or to a second machine? Copy the YAML? Include it in a repo? Email?
+- Are there any existing `pack` subcommands for discovery (list, show, search, browse)? What do they accept as input?
+- Are there any `pack import/export/install/uninstall/save` commands? Where do saved packs live on disk?
+
+### 2. Bundled pack delivery mechanism
+
+- How do the 9 bundled packs reach a user's machine? Package data in the wheel? Downloaded? Inlined?
+- How does the code discover bundled packs at runtime (directory scan, explicit registry, entry points)?
+- What's the update mechanism today — upgrade `synthpanel` and new packs appear?
+- How are bundled packs namespaced vs user-authored packs vs mayor's `extra_*` packs? What's the collision-resolution behavior (sp-g270 is partially related)?
+
+### 3. Pack validation and versioning
+
+- Is there a schema for persona packs? For instruments? Where is it defined? What does it enforce?
+- How are pack versions tracked today? Is there a `version:` field? How does it interact with `synthpanel`'s own version?
+- How are breaking changes to persona / instrument schemas handled in the codebase? Any migration tooling?
+- If two packs have the same name, what wins? What's the deterministic order?
+
+### 4. User-saved pack persistence
+
+- What user-owned storage does `synthpanel` use (`~/.synthpanel/*`, XDG_DATA_HOME, other)?
+- How is the location selected, overridden, and documented?
+- What's the permission / privacy model — are saved packs world-readable, user-only, other?
+- How do tests avoid collision with real user state (env-var overrides, tempdir fixtures)?
+
+### 5. Adjacent Python-ecosystem distribution patterns
+
+- How do comparable tools distribute user-authored content: `pre-commit` hooks, `cookiecutter` templates, `dbt` packages, `jinja` templates, `jupyter-contrib-extensions`, `homeassistant` integrations, `opensearch-dashboards` plugins?
+- Which use a git-URL install model (`pip install git+…`), a registry server (PyPI, npm, custom), a GitHub-topic-based discovery model, a static-index file, or other?
+- What is `pip install synthpanel-pack-foo` style namespace distribution like for those tools? Does anyone do it?
+- What's the submission / review / moderation model in each? Any failure patterns documented?
+
+### 6. SynthBench cross-link
+
+- SynthBench computes calibration metrics on synthpanel output against real human datasets. Is there already any per-pack signal flowing between the two projects?
+- Could a pack carry a "calibration fingerprint" (hash + score) computed from a SynthBench run? What would that require from both sides?
+- Is there any existing pack-level quality signal in the repo (test coverage, example runs, provenance metadata)?
+- How does SynthBench reference persona / instrument packs today — by name, by hash, by path?
+
+### 7. Authoring friction evidence from the existing corpus
+
+- Audit mayor/ and the bundled packs for duplication, drift, re-invention patterns: same persona archetype spelled differently across packs? Same instrument question under different keys?
+- What's the rough LOC / persona-count / file-count distribution of existing authored packs?
+- What's the most common authoring error path (missing field, invalid YAML, name collision, wrong top-level shape)? What error messages do users see?
+- Where do people paste pack YAML today (gist, slack, PR, local file) when sharing informally?
+
+## Deliverable
+
+`specs/sp-pack-registry/research/<dim>.md` per dimension, written objectively. Research phase synthesized into `research-map.md` for the human D-phase gate.

--- a/specs/sp-pack-registry/research-map.md
+++ b/specs/sp-pack-registry/research-map.md
@@ -1,0 +1,85 @@
+# Research Map — sp-pack-registry
+
+Synthesis of three research dimensions for the D-phase gate. Ticket now revealed: **sp-5roa — community persona + instrument pack registry.**
+
+## What the codebase currently provides
+
+**Pack delivery is wheel-packaged + directory-scanned.** 9 bundled persona packs + 8 instrument packs ship as `*.yaml` resources under `synth_panel.packs` / `synth_panel.packs.instruments`. Discovery via `importlib.resources.files()` + filename-stem pack ID. Update mechanism: `pip install --upgrade synthpanel`.
+
+**User-saved packs live at `~/.synthpanel/persona_packs/`** (overridable by `SYNTH_PANEL_DATA_DIR`). User-saved shadows bundled by pack ID (no warning). 5 pack subcommands: `list`, `import`, `export`, `show`, `generate`. Instruments have `install` (with pre-install validation) but no `import/export/generate` equivalents yet.
+
+**Persona schema is implicit, code-enforced:** `validate_persona_pack()` at `mcp/data.py:204-241` requires `personas` list non-empty + each persona dict with `name`. Optional fields (`age`, `occupation`, `background`, `personality_traits`) unvalidated beyond type. **No `version:` field for persona packs.** Instruments require `version:` in manifest (schema version 1/2/3, all bundled are v1, unrelated to synthpanel version). No migration tooling for either.
+
+**Actual corpus shows authoring-friction patterns.** Audit of 19 pack files (9 bundled + 10 custom) = 172 personas, 2,149 LOC:
+- **~40 personas duplicated byte-identically** across packs (e.g., Abdul Rahman appears in both `job-seekers.yaml` and `extra_50_traitprint.yaml`)
+- `extra_50_*` packs are wholesale copies of bundled equivalents with zero net-new content — authored as scale-up workarounds, not extensions
+- Only genuine authored content in `contrarian_*` (single stress-test persona) and `icp_*` (5 product-specific personas)
+- Stylistic drift in `personality_traits`: bundled packs use atomic 2-3 word strings; custom ICP packs use compound complex phrases; both pass validation
+- `personality_traits` silently lowercases via `str(t).strip().lower()` — undocumented normalization rule
+
+**Validation error path is minimal.** Generic messages: `"personas must be a list"`, `"persona at index {i} is missing required field 'name'"`. No user-facing schema documentation. Schema discovery = reading Python source.
+
+**No informal sharing channels documented.** No README section on pack distribution, no community-channel references, no blog posts on authoring. Inferred pathway: local YAML → `pack import` → email/slack/PR the exported YAML.
+
+## How comparable ecosystems solve this
+
+**Three dominant patterns across 11 audited tools:**
+
+1. **Decentralized Git-URL + manifest** (pre-commit, cookiecutter): zero infrastructure, repositories are namespaces, maximum discovery friction, author owns everything. Abandoned repos persist indefinitely. No moderation. Scales for small specialized ecosystems.
+
+2. **Centralized curated registry + distributed hosting** (HACS for Home Assistant, conda-forge): manifest-based registration via PR to a `default` list or staged-recipes repo. Curates community contributions. Explicit submission + review process. Transparent community governance scales better than opaque single-maintainer (dbt Hub's undocumented submission is documented as a failure mode). Version compatibility flags prevent broken installs.
+
+3. **PyPI namespace + entry-point auto-discovery** (pytest plugins, Sphinx extensions): leverages existing infra, zero user config, but inherits PyPI's flat-namespace vulnerabilities (typosquatting, character-normalization collisions). Entry-point name conflicts resolve non-deterministically. Abandoned packages clutter indefinitely.
+
+**Failure patterns shared across all centralized registries:**
+- Opaque submission/governance creates author friction and maintainer burnout
+- Abandoned content persistence without cleanup mechanism
+- Moderation scaling requires documented review criteria + appeals
+- Security review is typically delegated or omitted
+
+**Cross-cutting governance lessons:** document submission/review/maintenance explicitly; transparency builds trust even with strict processes. Avoid flat namespaces for plugin namespacing. Pair entry-point auto-discovery with explicit allow-listing or plugin-load logging.
+
+## Observable seams (current extensibility)
+
+1. **`_bundled_packs()` directory scan** (`mcp/data.py:83-102`) — any `*.yaml` in `synth_panel.packs` is discovered. A community-pack directory on disk would plug in via the same mechanism if packaged as a namespace package or via a separate entry point.
+2. **`$SYNTH_PANEL_DATA_DIR` override** — single env-var configuration. A registry install-path could reuse this or extend with a subdirectory (`~/.synthpanel/registry-packs/`).
+3. **Pack ID shadowing with no warning** — `data.py:162-173` check silently. Adding a collision warning is a focused change that also benefits sp-g270's existing work on merge-level collisions.
+4. **`pack import`** — already handles file → saved-pack flow. Extending to accept URLs (`pack import https://...` or `pack import gh:user/repo`) is an additive flag on an existing command.
+5. **`pack generate`** — already produces a pack via LLM with structured output. A "submit this to a registry" action is adjacent.
+6. **Instrument manifest has `version`, persona pack doesn't** — asymmetry worth resolving before any registry would need to track versions.
+
+## Design-space tensions (for D-phase discussion)
+
+**Centralization tension.** Decentralized git-URL (cookiecutter style) is zero-infra but fragments discovery; centralized registry is moderatable but becomes a governance surface. Precedent in Gas Town favors minimal centralization, but a registry's value is primarily discoverability.
+
+**Where the registry lives** — synthpanel.dev static site vs GitHub Pages vs a dedicated repo (`synthpanel/registry` or `synthpanel-packs/index`) vs a third-party tap pattern. Each has different implications for author submission friction, moderation surface, and cross-machine reproducibility.
+
+**Versioning semantics.** Persona packs currently have no version field; adding one is a schema change. Options: (a) ignore versioning, let authors re-submit (pre-commit style), (b) add optional `version:` field, (c) adopt the instrument manifest pattern wholesale for consistency. Registry needs *some* version signal for users to pin or upgrade.
+
+**Calibration score integration** — research (sp-inline-calibration) overlaps here. If packs carry a SynthBench calibration fingerprint (hash + score), the registry page becomes a quality-signal surface. This is potentially the strongest differentiator vs peer registries but depends on calibration tooling landing first.
+
+**Submission/review tension.** Community-driven transparent governance (conda-forge pattern) is high-trust but requires maintainer time. PR-to-default-list (HACS pattern) reduces moderation burden but requires a clear manifest schema + repository structure convention. Publish-and-pray (PyPI-style) has lowest author friction but highest supply-chain risk.
+
+**Security surface.** Persona packs are YAML — safe to load via `yaml.safe_load`. But packs executed as panel personas carry *behavioral* content (prompt content shaping what LLMs emit) that can be adversarial without being executable code. Community packs could be used to inject prompt-injection attacks into downstream consumers' panels. Moderation considerations extend beyond executable-code safety.
+
+**Branding tension.** A community marketplace with DataViking/synthpanel attribution raises brand exposure. HACS-style centralization puts maintenance of the manifest registry on synthpanel maintainers; pure decentralization (cookiecutter-style) fragments but lets the community self-identify.
+
+**Sharing-the-authoring-corpus tension.** The audit shows ~40 duplicate personas across existing packs — evidence that scale-out via copy-paste is the current authoring workflow. A registry could reduce duplication if the discovery surface made reuse easier than copying. But if the registry is too far from the current `pack import` workflow, duplication continues.
+
+## What the research does not answer
+
+- Whether there is observable community demand (Slack, Discord, GitHub issues) for a shared pack registry today, or whether this remains a synthetic-panelist ask
+- How much friction is acceptable for authors submitting to a registry vs authors sharing via gist/email
+- Whether calibration scores should gate registry inclusion or be informational
+- What the moderation team capacity looks like relative to expected submission volume
+- Whether the registry is for personas, instruments, or both (they have different authoring friction profiles)
+
+## Files
+
+- `research/pack-lifecycle-and-delivery.md`
+- `research/python-ecosystem-patterns.md`
+- `research/authoring-friction-evidence.md`
+
+## Ready for D-phase gate
+
+No design direction proposed. Observable friction, observable seams, observable tensions. Human brain-surgery on direction is the next gate.

--- a/specs/sp-pack-registry/research/authoring-friction-evidence.md
+++ b/specs/sp-pack-registry/research/authoring-friction-evidence.md
@@ -1,0 +1,140 @@
+# Pack Authoring Friction — Evidence Inventory
+
+Systematic audit of 19 pack files (9 bundled + 10 custom) totaling 172 personas and 2,149 LOC.
+
+## 1. Corpus Distribution
+
+**Bundled (n=9):** 84 personas across 1,138 LOC. Range 63–248 LOC; 4–20 personas.
+- Largest: product-research.yaml (248 LOC, 20 personas)
+- Smallest: startup-founder.yaml (63 LOC, 4 personas)
+
+**Custom (n=10):** 88 personas across 1,011 LOC. Range 24–183 LOC; 1–20 personas.
+- Largest: extra_50_synthpanel.yaml (183 LOC, 20 personas)
+- Smallest: contrarian_synthbench.yaml (29 LOC, 1 persona)
+
+**Combined:** 2,149 LOC, 172 personas. Median pack ~100 LOC, ~8 personas.
+
+## 2. Duplication and Drift
+
+**Exact duplications (byte-identical):**
+
+| Persona | Bundled Pack | Custom Pack | Notes |
+|---|---|---|---|
+| Abdul Rahman | job-seekers.yaml:130 | extra_50_traitprint.yaml:130 | OSS maintainer, age 32 |
+| Ahmad Qureshi | ai-eval-buyers.yaml:105 | extra_50_synthbench.yaml:75 | ML research engineer |
+| Aisha Nwosu | job-seekers.yaml:22 | extra_50_traitprint.yaml:13 | apprentice, age 19 |
+| Alejandro Ruiz | ai-eval-buyers.yaml:165 | extra_50_synthbench.yaml:120 | ops engineer |
+| Andreas Weber | product-research.yaml:191 | extra_50_synthpanel.yaml:140 | growth marketer |
+| Beatrice Laurent | product-research.yaml:106 | extra_50_synthpanel.yaml:164 | VP product, healthcare SaaS |
+| Carla Mendes | ai-eval-buyers.yaml:10 | extra_50_synthbench.yaml:10 | ML engineer |
+| (~40 total personas appear in 2+ packs) | | | |
+
+**Pattern:** `extra_50_*` packs are **wholesale copies** of specific bundled packs, not augmentations. No drift detected — when names match, content is byte-identical.
+
+**No same-archetype-different-spelling found.**
+
+## 3. YAML Structural Patterns
+
+**Universal (all 19 packs):**
+```yaml
+name: <string>
+description: <string>
+personas:
+  - name: <string>
+    age: <integer>
+    occupation: <string>
+    background: <string>  # multiline ">" folded
+    personality_traits: <list[string]>
+```
+
+**Uniformity:** 100% — all 172 personas have exactly these 5 fields. No missing optional fields, no extra undeclared keys.
+
+**Stylistic variance in `personality_traits`:**
+- Bundled packs: atomic 2-3 word strings. Example `["PM buyer", "discovery-constrained", "speed-seeker"]` (product-research.yaml:17-20)
+- Custom ICP packs: compound complex phrases. Example `["methodologically trained, values validity over speed"]` (icp_synthpanel.yaml:17-22)
+- Contrarian pack: longest traits, heavily qualified. Example `"thinks 'zero-config sampling mode' incentivizes bad research"` (contrarian_synthpanel.yaml:28)
+
+**Schema enforcement:** `mcp/data.py:204-241` — no published schema file; inline Python validation only.
+
+## 4. Validation Error Paths
+
+**Required fields:** `name` (non-empty string) per persona. `personas` must be list, non-empty.
+
+**Optional fields (not validated beyond presence):** `age`, `occupation`, `background`, `personality_traits`.
+
+**`personality_traits` normalization:** string (CSV) → list of lowercase strings (data.py:232-233: `traits = [str(t).strip().lower() for t in traits if str(t).strip()]`). **Silently downcases compound statements.** "Methodologically Trained" → "methodologically trained". No user guidance; icp packs use downcased traits anyway.
+
+**User-facing messages:**
+
+| Scenario | Message | File:line |
+|---|---|---|
+| Missing `name` | `persona at index {i} is missing required field 'name'` | mcp/data.py:223 |
+| `personas` not list | `personas must be a list` | :214 |
+| Empty personas | `personas list must not be empty` | :216 |
+| Persona not dict | `persona at index {i} must be a dict` | :221 |
+| Invalid YAML | (yaml.safe_load generic error) | commands.py:2119 |
+| File not found | `Error loading file: {exc}` | :2121 |
+| `personality_traits` wrong type | `personality_traits must be a list or comma-separated string` | data.py:235 |
+
+**Path traversal protection:** `_validate_pack_id()` (data.py:32-35) rejects IDs with `/` or `..`.
+
+**SDK validation** (`sdk.py:293-300`): mirrors CLI; enforces `name` + count ≤ `MAX_PERSONAS = 200`.
+
+## 5. Extra Packs — Relationship to Bundled
+
+| Extra Pack | Bundled Equivalent | Overlap |
+|---|---|---|
+| extra_50_synthpanel.yaml | product-research.yaml | 20/20 byte-identical |
+| extra_50_synthbench.yaml | ai-eval-buyers.yaml | 20/20 byte-identical |
+| extra_50_traitprint.yaml | job-seekers.yaml | 15/15 byte-identical |
+| extra_100_topup.yaml | (none directly) | 10 mixed from ICP + contrarian archetypes |
+
+**Net-new content in `extra_50_*`:** Zero. These exist solely to scale bundled personas to n=50/100 for audits. Naming implies augmentation; reality is duplication.
+
+**Contrarian + ICP packs (different pattern):** genuine authored content. Single stress-test persona (Dr. Anya Volkov) in `contrarian_*`; five custom ICP personas in `icp_*`.
+
+## 6. Informal Sharing Channels
+
+**None documented.**
+
+Searches across `docs/`, READMEs, CONTRIB guides — no mention of "share a persona pack", "pack distribution", "community packs".
+
+Existing docs (`docs/ensemble.md`, `docs/convergence.md`) show `--personas file.yaml` with implicit local authorship. `docs/agent-integration-landscape.md` references "registry presence" only in MCP/Composio context, not pack registries.
+
+**Inferred informal sharing pathway** (from code, not explicit): user authors local YAML → `pack import` → saves to `~/.synthpanel/persona_packs/` → `pack export` to stdout → email/Slack/PR to share.
+
+## 7. Schema Definition
+
+**Implicit, code-enforced. No declarative schema file.**
+
+Loci:
+- Persona schema: `mcp/data.py:204-241` `validate_persona_pack()`
+- Pack manifest: `mcp/data.py:57-69` `_extract_manifest()`. Expected keys per `_MANIFEST_FIELDS = ("name", "version", "description", "author")`. Graceful degradation to empty string if missing.
+- Instrument schema: `mcp/data.py:306-327` (similar inline, not scoped here)
+
+**No JSON Schema, GraphQL, or Pydantic model.** No `.schema.yaml` or docstring type hints for the YAML structure.
+
+**Validation triggers:**
+| Path | Location | When |
+|---|---|---|
+| CLI import | commands.py:2114-2144 | `pack import <file>` |
+| SDK runtime | sdk.py:313-324 | `run_panel(personas=..., pack_id=...)` |
+| MCP save | data.py:244-260 | `save_persona_pack()` |
+| MCP load | data.py:178-197 | `get_persona_pack(pack_id)` — **no validation; assumes valid** |
+
+## Friction-Hotspot Inventory
+
+1. **Duplication without net-new content.** `extra_50_*` packs exist as copies, not extensions. 40+ personas appear in 2+ packs.
+2. **Implicit schema with no user-facing documentation.** No README section defining required/optional fields. Authoring friction surfaces only as terse runtime errors.
+3. **`personality_traits` format ambiguity.** Atomic vs compound stylistic choice undocumented; both pass validation. Inconsistency hurts downstream analysis.
+4. **No version/upgrade semantics for personas.** Schema evolution has no migration path. Breaking changes would silently fail validation.
+5. **No naming-convention or namespace-collision detection.** Silent shadowing. `data.py:162` checks `if pack_id in seen` without warning.
+6. **No informal sharing mechanism or registry.** Custom packs (ICP, contrarian) live in mayor/results/ but have no upstream-facing distribution.
+7. **`extra_100_topup.yaml` has unclear provenance.** Description doesn't clarify source. Pack name suggests generic but content is domain-specific.
+8. **Validation at import/save only, not at load.** Manual edits to user-saved packs that break schema surface only at panel run, not at load.
+9. **No test coverage for cross-pack integrity.** Tests import/export individual packs; no check for duplication, collision, or drift. No lint command to detect issues before shipping.
+10. **`personality_traits` silently downcases.** May obscure capitalization-sensitive meaning. Rule undocumented.
+
+## Summary
+
+Authoring friction exists primarily around **duplication without extension**, **implicit schema**, **no versioning path**, and **no discovery/registry mechanism**. The 19-pack corpus shows 172 personas, but at least 40 are duplicates across packs, indicating scale-out via copy-paste is the current workflow.

--- a/specs/sp-pack-registry/research/pack-lifecycle-and-delivery.md
+++ b/specs/sp-pack-registry/research/pack-lifecycle-and-delivery.md
@@ -1,0 +1,147 @@
+# Pack Lifecycle and Delivery — Research Summary
+
+## 1. Persona Pack Lifecycle — Authoring to Consumption
+
+Four authoring paths:
+
+1. **Manual YAML authoring** — create `name` + `personas: [{name, age, occupation, background, personality_traits}]`. Example format: `src/synth_panel/packs/developer.yaml:1-83`.
+2. **`pack import`** (`cli/commands.py:2114-2144`): `synthpanel pack import file.yaml [--name] [--id]` → saved to `$SYNTH_PANEL_DATA_DIR/persona_packs/<pack_id>.yaml` (default `~/.synthpanel/persona_packs/`).
+3. **`pack generate`** (`cli/commands.py:2188-2286`): LLM-driven synthesis via structured output. Fields enforced: `name`, `age`, `occupation`, `background`, `personality_traits`. Validated via `validate_persona_pack()` (data.py:204-241).
+4. **SDK `save_persona_pack(name, personas, pack_id=None)`** (data.py:244-260). Auto-generates `pack-{8-char hex}` if no ID.
+
+**Validation (data.py:204-241):**
+- `personas` must be list, non-empty
+- Each persona must be dict with required `name` (non-empty string)
+- Optional: `age`, `occupation`, `background`, `personality_traits`
+- `personality_traits` normalized to lowercase list (accepts CSV string or list)
+- Raises `PackValidationError` on violation
+
+**Usage in panel run:** user passes `--personas pack-id` or `--personas path.yaml`. Handler `_load_personas()` (`commands.py:461-478`) resolves as file path first, then pack ID (user-saved first, bundled fallback).
+
+## 2. Instrument Pack Lifecycle
+
+1. **Manual YAML authoring** — top-level manifest (`name`, `version` required) + instrument (`version: 1|2|3`, `rounds: [...]`). Example: `src/synth_panel/packs/instruments/product-feedback.yaml:1-47`.
+2. **`instruments install`** (`cli/commands.py:2322-2372`): validates via `parse_instrument()` before saving to `$SYNTH_PANEL_DATA_DIR/packs/instruments/<name>.yaml`.
+3. **SDK `save_instrument_pack(name, content)`** (data.py:330-348).
+
+**Key difference vs personas:** instruments require explicit pre-install validation (line 2356-2363); personas only validate field presence/types. No `instruments import/export/generate` subcommands exist.
+
+## 3. Bundled Pack Delivery
+
+**Mechanism:** Packaged data in the wheel via `pyproject.toml` `[tool.setuptools.package-data]`:
+```toml
+"synth_panel.packs" = ["*.yaml"]
+"synth_panel.packs.instruments" = ["*.yaml"]
+```
+
+**Discovery:** `_bundled_packs()` / `_bundled_instrument_packs()` (`mcp/data.py:83-124`) scans via `importlib.resources.files("synth_panel.packs")`. Directory scan for `.yaml` files; silently skips unparseable (line 98: `except Exception: continue`). Pack ID = filename stem.
+
+**Inventory:** 9 persona packs (developer, enterprise-buyer, general-consumer, healthcare-patient, startup-founder, job-seekers, recruiters-talent, product-research, ai-eval-buyers) + 8 instrument packs.
+
+**Update mechanism:** pip upgrade synthpanel → new packs appear on next `_bundled_packs()` call.
+
+## 4. Namespacing and Collision Resolution
+
+**Hierarchy (`list_persona_packs()` data.py:132-175):**
+- User-saved packs listed first (take precedence on ID collision)
+- Bundled packs listed only if not shadowed
+
+**Collision behavior** (`test_mcp_data.py:137-147` `test_user_pack_overrides_bundled`):
+- `get_persona_pack("developer")` checks `~/.synthpanel/persona_packs/developer.yaml` first
+- Falls back to bundled only if file doesn't exist
+- **No warning or error.** User override silently wins.
+
+**No formal namespace for mayor's extra packs.** sp-g270 related but not implemented as a proper namespace.
+
+## 5. User-Saved Pack Persistence
+
+**Default location:** `~/.synthpanel/` via `_data_dir()` (`mcp/data.py:38-54`):
+```python
+Path(os.environ.get("SYNTH_PANEL_DATA_DIR", "~/.synthpanel")).expanduser()
+```
+
+**Structure:**
+```
+~/.synthpanel/
+  persona_packs/<pack_id>.yaml
+  packs/instruments/<instrument_id>.yaml
+  results/<result_id>.json
+```
+
+**Override:** `SYNTH_PANEL_DATA_DIR` env var.
+
+**Permission model:** No explicit mode setting; inherits umask. Linux typical: 644 user-writable. No documented privacy guarantees or world-read prevention.
+
+**Test isolation (`test_mcp_data.py:12-15`):**
+```python
+@pytest.fixture(autouse=True)
+def _data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+```
+Autouse fixture applies to all tests in module.
+
+## 6. Pack Subcommands
+
+| Command | Args | Output | Handler |
+|---|---|---|---|
+| `pack list` | — | text or JSON list | 2096-2111 |
+| `pack import` | `file [--name] [--id]` | confirmation string | 2114-2144 |
+| `pack export` | `pack_id [-o out.yaml]` | YAML to stdout or file | 2147-2174 |
+| `pack show` | `pack_id` | YAML to stdout | 2177-2185 |
+| `pack generate` | `--product X --audience Y --count N` | confirmation string | 2188-2286 |
+
+Parser: `parser.py:507-606`. No equivalent `instruments import/export/generate` — only `instruments install` is a write operation.
+
+## 7. Schema & Versioning
+
+**Persona pack schema** — implicit, code-enforced (no JSON Schema file):
+```yaml
+name: string          # pack-level, required
+description: string   # optional
+personas:
+  - name: string      # REQUIRED per persona
+    age: int          # optional
+    occupation: string
+    background: string
+    personality_traits: string | list[string]  # normalized to lowercase list
+```
+
+**Instrument pack schema:**
+```yaml
+name: string      # required
+version: int      # required (schema version 1/2/3)
+description, author: optional
+instrument:
+  version: 1|2|3
+  rounds: [...]   # v2+ only
+  questions: [...] # v1 flat
+```
+
+Validation via `parse_instrument()` (not shown in this audit); called before save at `commands.py:2360`.
+
+**Version tracking:**
+- Persona packs: **no `version:` field supported.** No per-pack version. Overwriting same ID replaces content silently.
+- Instrument packs: **required `version:` at top level.** Indicates instrument *schema* version (not pack version). All bundled instruments are `version: 1`. No interaction with synthpanel's own version.
+- **No migration tooling.** Breaking schema changes would require manual user YAML updates.
+
+**`_MANIFEST_FIELDS` shared pattern** (`data.py:61-69`):
+```python
+_MANIFEST_FIELDS = ("name", "version", "description", "author")
+# Returns: {"id": pack_id, "name": ..., "version": ..., "description": ..., "author": ...}
+```
+Used by `list_instrument_packs()` for metadata display. Personas don't use `version`; defaults to empty string.
+
+## Seams Observed
+
+1. **Personas lack version field.** Unlike instruments. Overwriting pack ID = silent replace, no history/rollback.
+2. **No schema registry.** Schemas inferred from Python validation functions, not published JSON Schema or OpenAPI.
+3. **`SYNTH_PANEL_DATA_DIR` is the only configuration point.** No `~/.synthpanel/config.yaml`, no XDG alternative.
+4. **Bundled pack immutability.** No in-place replacement mechanism; pip upgrade required.
+5. **File-based collision resolution.** ID-based filename matching; no registry or metadata check for conflicts.
+6. **LLM generation schema hardcoded.** `pack generate` schema defined inline in handler, not referenceable as a pack-level constraint.
+7. **No published pack index.** No registry server, no PyPI-like discovery of third-party packs.
+8. **Instruments and personas have separate mechanics.** Instruments have manifest `version` + pre-install validation; personas don't. Install paths diverge.
+
+## Citations
+
+mcp/data.py:1-533; cli/commands.py:2096-2372; cli/parser.py:507-606; tests/test_mcp_data.py:12-225; tests/test_cli.py:2087-2303; src/synth_panel/packs/*.yaml (9 bundled); packs/instruments/*.yaml (8 bundled); pyproject.toml.

--- a/specs/sp-pack-registry/research/python-ecosystem-patterns.md
+++ b/specs/sp-pack-registry/research/python-ecosystem-patterns.md
@@ -1,0 +1,170 @@
+# Python Ecosystem Content Distribution — Landscape Audit
+
+Objective scan of 11 tools' patterns for distributing user-authored content.
+
+## 1. pre-commit (Git-based with manifest)
+
+**Model:** Decentralized; hook providers create Git repos with `.pre-commit-hooks.yaml` manifest. Users reference via Git URLs pinned to tags. No central registry.
+
+**Workflow:** Author creates Git repo + manifest + language-specific install → tags release → users reference by URL + rev.
+
+**Review:** None. Repositories are author-maintained. Official `pre-commit-hooks` repo is reference/trusted implementation only.
+
+**Upgrades:** Version pinning via tags (`rev: v6.0.0`). Breaking changes = author's responsibility via release notes.
+
+**Failures:** Abandoned repos discoverable but no central deprecation flag. No namespace collision (Git URLs are namespaces). No moderation.
+
+## 2. cookiecutter (GitHub-topic discovery)
+
+**Model:** GitHub search for `cookiecutter` topic. Install via `cookiecutter gh:user/repo` or local paths.
+
+**Workflow:** Author creates repo + `cookiecutter.json` + publishes + tags repo with topic.
+
+**Review:** None. Visibility relies on GitHub search ranking + community sharing.
+
+**Upgrades:** Git tags. Templates typically used once per project; fork/customize is common.
+
+**Failures:** Abandoned templates clutter search indefinitely. No namespace isolation (`cookiecutter-django` could be anyone). Community reputation only differentiator.
+
+## 3. dbt Packages (Hub registry)
+
+**Model:** Centralized `hub.getdbt.com` recommended; fallback to Git URL or tarball. Specified in `packages.yml` with semver.
+
+**Workflow:** Author creates package with `dbt_project.yml` + publishes to Git → submits to Hub (submission process *undocumented*) → users add to `packages.yml` + `dbt deps`.
+
+**Review:** Undocumented. dbt Labs hosts Hub "as courtesy" with caveat: "does not certify integrity, operability, effectiveness, or security." No published criteria.
+
+**Upgrades:** Semver pinning. `dbt deps` resolves. Breaking changes are author's responsibility.
+
+**Failures:** Opaque submission creates friction. No documented security review. Git fallback fragments ecosystem visibility. Packages exist in two places (Hub + Git).
+
+## 4. Jupyter Extensions (fragmented)
+
+**Model:** `jupyter-contrib-extensions` consolidated repo + PyPI packages following `jupyter_*` naming. Install via pip or `jupyter nbextensions` commands.
+
+**Workflow:** Contribute to consolidated repo OR publish to PyPI. Extensions register via Python entry points.
+
+**Review:** Consolidated repo: GitHub PR + community review. Standalone PyPI: no review.
+
+**Upgrades:** PyPI versioning + pip pinning. Entry points auto-discover; upgrades transparent.
+
+**Failures:** Fragmented discovery (no central like dbt). Authors choose consolidated-visibility vs independent-autonomy. PyPI namespace collision possible. Abandoned extensions in consolidated repo create debt; removal disruptive.
+
+## 5. Home Assistant + HACS (dual)
+
+**Model:** (1) Official integrations bundled in `home-assistant/core`. (2) Community via HACS (Home Assistant Community Store), aggregating repos from curated `hacs/default` list.
+
+**Workflow:** Official = contribute to core with rigorous review. Community = repo with `manifest.json` + PR to `hacs/default` to register URL.
+
+**Review:** Official = intensive core-team review. Community = PR to register. Manifest enforces consistent format. HACS sandboxes + version-pins.
+
+**Upgrades:** HACS tracks GitHub releases + semver. Users pin or auto-update within major. Compatibility flags prevent broken installs.
+
+**Failures:** `hacs/default` list is centrally maintained, bottlenecks registration. Abandoned integrations persist unless removed. Rejected core contributions fork and maintain independently → fragmentation. Security review burden on HACS maintainers.
+
+## 6. OpenSearch plugins (undocumented)
+
+**Model:** Undocumented. Plugins as binary artifacts (JAR/JS bundles). Install via `opensearch-plugin install` with URL or local path. No central registry documented.
+
+**Workflow:** Inferred — build → host on URL → users install via plugin CLI.
+
+**Review:** None documented.
+
+**Upgrades:** Plugin versioning = author's responsibility. No centralized version mgmt documented.
+
+**Failures:** No registry → discoverability problem. No vetting documented. Users must know plugin URL or find via informal channels. Security is user responsibility.
+
+## 7. Sphinx themes/extensions (PyPI namespace)
+
+**Model:** PyPI packages following `sphinx-*` naming. `pip install sphinx-theme-foo`. Entry points auto-register at import time.
+
+**Workflow:** Python package with Sphinx entry points → publish to PyPI → pip install → auto-register.
+
+**Review:** PyPI's publish-and-pray. No Sphinx-specific review.
+
+**Upgrades:** PyPI semver + pip pinning. Namespace packages (PEP 420) available but not widely adopted.
+
+**Failures:** PyPI flat namespace enables typosquatting. No central curated registry. Abandoned projects persist. Entry-point conflicts resolve first-in-wins non-deterministically.
+
+## 8. pytest plugins (entry-point auto-discovery)
+
+**Model:** PyPI packages with `pytest11` entry point. pytest auto-discovers installed plugins at startup.
+
+**Workflow:** Python package + `pytest11` entry point → PyPI → pip install → auto-load.
+
+**Review:** PyPI only. No pytest-specific review. Docs maintain informational list of 1300+ known plugins.
+
+**Upgrades:** PyPI semver + pip pinning. Auto-discovery loads new versions on upgrade unless pinned.
+
+**Failures:** PyPI namespace collision → typosquatting (`pytest-super-plugin-xyz` vs `pytest-super-pluginxyz`). Entry-point name collisions non-deterministic (first wins). Auto-discovery masks breaking changes. High supply-chain attack surface.
+
+## 9. conda-forge (community channel)
+
+**Model:** Centralized GitHub-based feedstock repos. Authors contribute to `conda-forge/staged-recipes` (new) or dedicated feedstock (updates). CI builds + publishes to conda-forge channel.
+
+**Workflow:** Recipe PR → community maintainer review → automated CI builds → publish. Feedstocks owned by maintainers.
+
+**Review:** GitHub PR review by community + automated CI. Requires proper metadata, license compliance, dependency resolution, multi-platform builds. Transparent; no formal security review.
+
+**Upgrades:** Semver with recipe pinning. Conda-forge bots automate version bumps. CI detects breaking changes. `conda lock` for reproducibility.
+
+**Failures:** PR review can bottleneck when maintainers overloaded. Unresponsive feedstock maintainers orphan packages. `staged-recipes` acts as new-package gatekeeper reducing squatting. No formal appeals governance.
+
+## 10. Jenkins plugins (centralized registry)
+
+**Model:** Central `plugins.jenkins.io` registry + GitHub hosting. JAR distributions queried via Jenkins Update Center UI.
+
+**Workflow:** Develop plugin → submit to registry (process undocumented publicly) → indexed in Update Center → users install via admin UI.
+
+**Review:** Undocumented. 2000+ plugins suggest a pathway exists but is not publicly documented. Registry categories imply some curation.
+
+**Upgrades:** Semver + compatibility metadata. Users pin or auto-update.
+
+**Failures:** Opaque submission + governance. Abandoned plugins persist indefinitely. No enforced security standards or code-review transparency. Unclear vulnerability disclosure.
+
+## 11. PyPI (namespace baseline)
+
+**Model:** Flat namespace, first-come-first-claimed. Case-insensitive; `-` and `_` normalize the same (collision edge cases). World-discoverable unless yanked/archived.
+
+**Workflow:** `setup.py`/`pyproject.toml` → twine upload → users `pip install`.
+
+**Review:** None. Publish-and-pray. 2FA required for uploads. Email verification for registration. Compromised accounts can upload malicious versions; token revocation + recovery exist.
+
+**Upgrades:** Semver convention (not enforced). Users pin. "Yanked" mechanism marks versions broken without removing. No automated security updates.
+
+**Failures:** Typosquatting documented (`texst` vs `test`). Character-normalization collisions (`my_package` == `my-package`). Abandoned projects persist forever. Supply-chain attacks undetected without external tooling. Flat namespace has no scoping like npm's `@user/package`.
+
+## Pattern Clusters & Failure-Mode Lessons
+
+### Centralization spectrum
+
+- **Decentralized** (pre-commit, cookiecutter): zero infrastructure, maximum discovery friction, author owns everything
+- **Centralized** (dbt Hub, HACS, conda-forge): curated registry, submission bottleneck, governance-critical; transparency varies (conda-forge good, dbt Hub poor)
+- **Hybrid** (pytest, Sphinx, Jupyter): PyPI infrastructure + entry-point auto-discovery for frictionless installation, inherits PyPI's flat-namespace vulnerabilities
+
+### Governance failure patterns
+
+- **Undocumented processes** (OpenSearch, Jenkins, dbt Hub): opacity creates friction and maintainer burnout
+- **Abandoned package persistence**: all models allow persistence without mechanism for cleanup (1300+ pytest plugins, many unmaintained)
+- **Moderation scaling**: community-driven (conda-forge) scales better than single-maintainer (dbt Hub) with clear governance + conflict resolution
+
+### Namespace & supply chain
+
+- **Flat namespaces** (PyPI, Sphinx): typosquatting + character-normalization collisions
+- **Scoped namespaces** (npm model, not standard in Python): per-user safety; PEP 420 partial solution not widely adopted
+- **Entry-point auto-discovery**: reduces user config, masks plugin load-order non-determinism, makes security audits harder
+
+### Security & trust gaps
+
+- **No universal code review**: only Home Assistant (official) + conda-forge (transparent PR) document security-focused review. dbt/pytest/Sphinx/Jupyter/OpenSearch delegate to authors or omit.
+- **Dependency confidence**: PyPI doesn't verify package contents at publish. Transitively trusted; compromised upstreams propagate silently.
+- **Breaking-change communication**: most systems lack structured compatibility metadata. Conda-forge's bot partially mitigates.
+
+### Lessons for plugin-registry design
+
+1. **Publish-to-pair (pre-commit, cookiecutter)** — minimal infra, fragments discovery; suitable for small specialized ecosystems.
+2. **Centralized manifest registry + distributed hosting (HACS)** — balances autonomy and curation. Requires clear manifest schema and registration process.
+3. **Entry-point auto-discovery (pytest, Sphinx)** — reduces friction, masks safety issues. Pair with explicit allow-listing or plugin-load logging.
+4. **Transparent community governance (conda-forge)** — scales better than opaque processes. Requires documented review criteria, appeals, moderation tooling.
+5. **Avoid PyPI flat namespace for plugin namespacing.** Use explicit scoping (prefix convention) or PEP 420 namespace packages with documented authoring guidelines.
+6. **Document submission, review, maintenance explicitly.** Undocumented processes invite governance failures. Transparency builds community trust even with strict processes.

--- a/specs/sp-viz-layer/questions.md
+++ b/specs/sp-viz-layer/questions.md
@@ -1,0 +1,62 @@
+# Q-phase: Panel-result consumption paths
+
+*Ticket hidden per QRSPI discipline. These questions drive objective code-mapping only; do not invent design direction from them.*
+
+## Problem (shared with R polecats)
+
+Panel results land as JSON files today. Non-terminal humans — PMs, stakeholders, execs — aren't the primary consumers of those files. Map what paths panel results currently travel from creation to consumption, and what the surrounding ecosystem already provides for transforming structured output into human-facing artifacts.
+
+## Research dimensions
+
+### 1. Panel-result JSON shape and schema
+
+- Where is the panel-result JSON schema defined? Is it documented, versioned, or inferred from callers?
+- What are the distinct top-level and nested sections a consumer can read? What shape does each take (scalar, list, dict, tree)?
+- Which fields are canonical (always present) vs optional vs strategy-dependent (e.g. single vs map-reduce)?
+- Is the schema stable? Are there deprecations, renames, or versioned variants in flight?
+
+### 2. Existing downstream consumers of panel results
+
+- What code reads `panel-result.json` today — inside `synthpanel`, inside SynthBench, inside any mayor/agent workflow?
+- What subsets do those consumers use? (e.g. just `total_cost`, just `per_model_results`, just `synthesis`)
+- Are there any existing transform/extract utilities (e.g. `analyze`, `inspect`, `synthesize`) that already produce human-readable summaries, and what format do they emit?
+- What command-line flags, API functions, or MCP tools already accept a saved panel result as input?
+
+### 3. Existing rendering / templating infrastructure in-repo
+
+- Does the repo already pull in Jinja, any HTML templating, Markdown renderers, or static-site generators? Where, for what?
+- How are site/* artifacts generated today (`render_site.py` post sp-ssrw)? Is that pipeline reusable for non-site outputs?
+- What styling / layout conventions exist (tailwind, CSS files, theme colors)? Are they in the package or only in the marketing site?
+- What's the rough size budget of the package on PyPI today, and which optional extras already fence off heavy dependencies?
+
+### 4. Adjacent OSS tooling in the same ICP
+
+- How do comparable OSS tools (Great Expectations, Prefect, Dagster, W&B local, MLflow, evidently, lm-eval-harness, HELM, Jupyter, nbconvert, quarto, papermill) present run results to non-engineers?
+- Which of those tools ship a CLI-only path, a report-generator subcommand, a rendered HTML artifact, a notebook integration, or a live server?
+- What packaging patterns do they use for the report-generation bits — core dep, optional extra, separate package?
+- What explicit "no web UI" or "no dashboard" positioning exists elsewhere, and how is the substitute surfaced?
+
+### 5. Stakeholder-output primitives already in the codebase
+
+- Does any existing subcommand emit formatted text (tables, markdown, boxed-text CLI output, progress bars, summaries)? List them with their output shape.
+- Is there a CLI print-helper abstraction? A structured "emit" layer? A reporter class? A formatter registry?
+- Are there any existing `--format` / `--output-format` flags across subcommands? What do they accept (text / json / ndjson / other)? Are they consistent?
+- What fields in panel output are intentionally human-readable vs machine-readable (e.g. pre-formatted dollar strings vs raw numbers)?
+
+### 6. Non-CLI invocation surfaces
+
+- The MCP server exposes 12 tools — do any of them return a rendered representation, or only structured data?
+- Does the Python SDK provide a `render()` / `report()` / `summarize()` method anywhere? What shapes are returned?
+- Are there existing consumers in mayor/ or related repos that build their own rendering on top of panel JSON? Describe the patterns they use (pandas DataFrame, jinja, plain string-formatting, other).
+- What are stakeholder handoff patterns founders / PMs / researchers use in practice today (per README, docs, blog posts, community channels)?
+
+### 7. Boundary conditions for any future rendering path
+
+- What's the largest panel-result JSON size observed in the self-audit artifacts (`mayor/results/synthpanel-self-audit/`)? At what n does it cross 1 MB, 10 MB?
+- Which sections of the output are safe to render verbatim vs need summarization (e.g. raw panelist text vs per-model cost)?
+- Are there any privacy / redaction concerns with rendering panel results — PII in personas, BYOK credentials anywhere in the output?
+- What's the current provenance / audit trail per panel (config_hash, timestamps, model versions) and how would a rendered report preserve it?
+
+## Deliverable
+
+`specs/sp-viz-layer/research/<dim>.md` per dimension, written objectively — what exists, not what *should* exist. Research phase synthesized into `research-map.md` for the human D-phase gate.

--- a/specs/sp-viz-layer/research-map.md
+++ b/specs/sp-viz-layer/research-map.md
@@ -1,0 +1,71 @@
+# Research Map — sp-viz-layer
+
+Synthesis of three research dimensions for the D-phase gate. Ticket now revealed: **sp-nj58 — viz/reporting layer for non-CLI stakeholders.**
+
+## What the codebase currently provides
+
+**Panel-result JSON is richly structured but semi-versioned.** Output schema is inferred from dataclasses + docs prose at `sdk.py:224-286` + `synthesis.py:64-97` + `mcp/data.py:482-530`. No explicit `schema_version`; optional-fields-default pattern preserves back-compat. Strategy-dependent fields (`synthesis.strategy`, `synthesis.per_question_synthesis`, `rounds[i].usage`) are only present on map-reduce runs. Largest observed artifact: 6.7 MB (n=100, 5 questions, full synthesis). Linear growth ~40 KB/persona; 1 MB at n≈25, extrapolates to 10 MB at n≈250.
+
+**Zero heavyweight templating infrastructure in-repo.** Core deps `httpx` + `pyyaml` (~150 KB wheel). Jinja is not imported anywhere. Two minimal internal substitution engines exist: `scripts/render_site.py` (regex `{{ key }}` for site generation, not reusable) and `src/synth_panel/templates.py::_SafeFormatter` (question-text `{placeholder}` substitution with security-guard dotted-access block).
+
+**Unified emit layer at `cli/output.py:20-60`** — `emit()` routes through `OutputFormat` enum (`text`/`json`/`ndjson`). All subcommands use it. Per-subcommand `--format` and `--output` overrides exist (`instruments graph`: `text`/`mermaid`; `analyze`: `text`/`json`/`csv`) but are legacy, predating the global flag.
+
+**Pre-formatting at transformation seams:**
+- `cost` is always a pre-formatted `$0.0000` USD string (via `format_usd()`) rather than a raw float
+- Error banners are pure-function strings that go to stderr regardless of `--output-format`
+- Synthesis result → flat template context `{theme_0, agreement_0, ...}` for question templating (synthesis structure not exposed)
+
+**No progress bars, no live status, no dashboards.** Convergence telemetry (sp-yaru) writes JSON lines to stderr or `--convergence-log` file only.
+
+## How comparable OSS tools solve this
+
+Three observable clusters:
+
+1. **Raw structured data + consumer choice** (lm-eval-harness, papermill): emit clean JSON/notebook, defer viz to ecosystem (W&B, Zeno, HF Hub). Explicit "no built-in dashboard" positioning. CLI-first.
+2. **Opinionated default reports** (Great Expectations, HELM, Quarto, evidently): ship structured results plus one or more rendered default formats (HTML, text summary, Jupyter notebook). No live UI hosting; static artifacts.
+3. **Interactive dashboard-first** (Prefect, Dagster, MLflow, W&B): live web UI is primary path; real-time observability + collaborative features; structured data accessible via API but secondary. Often cloud-backed.
+
+Tools emphasizing structured-data-first (lm-eval-harness, papermill) tend to **explicitly avoid hosting**. Tools without that positioning tend to ship dashboards. Visualization is a strategic choice, not an afterthought.
+
+## Observable seams (natural extension points)
+
+Seven places in the current codebase where a rendering layer could plug in without architectural changes:
+
+1. **`OutputFormat` routing** — add enum variant + `emit()` branch. Zero refactor of panel runners.
+2. **Cost display** — `format_summary()` is a pure function; swap to produce HTML tables, Markdown, or structured objects without touching the panel runner.
+3. **Error banners** — `_build_*_banner()` pure functions; swap for HTML/Markdown templates.
+4. **Analysis output** — `format_text()`/`format_csv()` in `analyze.py:505-544` are pure transformations; adding `format_html()` or `format_markdown()` is additive.
+5. **`analysis/inspect.py::InspectReport`** — walks the full schema today, used only by `panel inspect`. Ready for a non-CLI consumer.
+6. **Synthesis strategy metadata** — map-reduce `per_question_synthesis` is serialized but no consumer renders it; ready for step-wise disclosure.
+7. **Site rendering pipeline** (`scripts/render_site.py`) — the regex substitution engine is minimal but the pattern (template + placeholder dict + render function) generalizes.
+
+## Design-space tensions (for D-phase discussion)
+
+**Output-medium spectrum:** static markdown ↔ HTML report ↔ Jupyter notebook ↔ Voilà-style mini-dashboard ↔ full web UI. Each has different implications for package size, positioning ("CLI-first" vs adding-a-dashboard), and privacy (BYOK credentials shouldn't leak into shareable artifacts).
+
+**Input-source tension:** rendered output can derive from (a) live panel run via CLI subcommand (`synthpanel panel run --report HTML`), (b) post-hoc from saved JSON (`synthpanel report RESULT.json`), (c) MCP server returning rendered representation, (d) Python SDK emitting via a new `render()` method. These aren't mutually exclusive but have different consumer audiences.
+
+**Package-size tension:** current core wheel is ~150 KB. A report-generation extra that pulls in Jinja + HTML sanitizer + possibly a charting library would grow the install footprint. `synthpanel[report]` extra is the obvious fencing pattern; precedent already exists with `[mcp]`, `[composio]`, `[convergence]`.
+
+**Audience-authoring tension:** the rendered output needs an audience definition (exec brief? PM handoff? stakeholder PDF?) before the output shape can settle. Different audiences want different information density, different visual conventions, different length.
+
+**Provenance preservation:** a rendered report must carry `config_hash`, timestamps, model versions, pricing-snapshot-date for reproducibility — otherwise the report is a trust-laundering surface. The metadata fields exist in panel JSON (sp-ui40); the rendering layer needs to surface them.
+
+**Privacy constraints:** panel responses may include PII in personas; BYOK credentials live in the venv's environment, not in output JSON, but worth audit before rendering is shareable.
+
+## What the research does not answer
+
+- What's the primary user journey — someone running a panel and wanting a handoff artifact, or someone receiving a shared panel and wanting to consume it?
+- How much does the founder want "we don't ship a UI" to remain load-bearing vs evolvable?
+- Whether synthpanel's ICP actually expects charts / tables, or whether the existing structured JSON + external tooling (Jupyter, Quarto) would satisfy the signal we heard from panel audits.
+- Whether an MCP-surface rendered representation (returned from an MCP tool) is the clearest fit given the "zero-config inside Claude Desktop" positioning.
+
+## Files
+
+- `research/panel-json-schema.md`
+- `research/cli-rendering-primitives.md`
+- `research/adjacent-oss-landscape.md`
+
+## Ready for D-phase gate
+
+No design direction proposed. Research complete per the seven dimensions of `questions.md`. Human "brain-surgery" on architectural direction is the next gate.

--- a/specs/sp-viz-layer/research/adjacent-oss-landscape.md
+++ b/specs/sp-viz-layer/research/adjacent-oss-landscape.md
@@ -1,0 +1,113 @@
+# Adjacent OSS Landscape — Panel-Result Presentation Patterns
+
+Systematic documentation audit of 12 comparable OSS tools. How each presents run results to non-engineers.
+
+## 1. Great Expectations
+
+- **Report:** Generated HTML validation documentation + interactive reports
+- **Packaging:** Core; rendering utilities built-in
+- **Positioning:** "Structured results for CI/CD, alerting, dashboards." No "no-dashboard" stance.
+- **Input:** In-memory validation → JSON → auto-generated HTML
+- **Spectrum:** (b) opinionated default reports
+
+## 2. Prefect
+
+- **Report:** Web dashboard (localhost:4200 self-hosted, or Prefect Cloud)
+- **Packaging:** Core; dashboard in server package
+- **Positioning:** Real-time flow monitoring through an intuitive interface. Dashboard primary.
+- **Input:** Live state + logs via API; no emphasized static file export
+- **Spectrum:** (c) host interactive UI
+
+## 3. Dagster
+
+- **Report:** Web UI (Dagster Webserver) for asset lineage, run logs, materializations
+- **Packaging:** Core; web UI included
+- **Positioning:** "Integrated lineage, observability, unified control plane." UI primary; Slack mentioned alongside.
+- **Input:** Live asset state + logs; rendered in webserver
+- **Spectrum:** (c) interactive UI
+
+## 4. Weights & Biases
+
+- **Report:** Interactive dashboards + exportable static reports (PDF, LaTeX zip)
+- **Packaging:** Core; export via standard UI
+- **Positioning:** Document and share AI insights collaboratively. UI-centric.
+- **Input:** `run.log()` API → persistent backend → live UI → web-interface exports
+- **Spectrum:** (c) interactive UI, optional static export
+
+## 5. MLflow
+
+- **Report:** Web experiment tracking UI (localhost:5000); traces + metrics dashboards
+- **Packaging:** Core; MLflow server in base package
+- **Positioning:** Track models/parameters/metrics across experiments. UI-centric; no CLI-only emphasis.
+- **Input:** `mlflow.log_*` API → local or remote backend → live UI
+- **Spectrum:** (c) interactive UI
+
+## 6. Evidently
+
+- **Report:** Interactive reports (Python/Jupyter) + JSON export + HTML + monitoring dashboard
+- **Packaging:** Core; Report class and monitoring UI in base
+- **Positioning:** Flexible — Python/Jupyter native + dashboard alternative
+- **Input:** In-memory dataframes → computed report objects → optional Evidently Cloud backend
+- **Spectrum:** (a) → (b) bridge; emits raw JSON/dict by default; interactive HTML reports available
+
+## 7. lm-eval-harness
+
+- **Report:** JSON results files (`results.json`, `<task>_eval_samples.json`) + optional W&B / Zeno / HF Hub integrations
+- **Packaging:** Core evaluation in base; viz integrations opt-in (require external auth)
+- **Positioning:** Structured output + reproducibility. No built-in dashboard; viz delegated.
+- **Input:** Eval run → flat JSON local or cloud; pushed externally on request
+- **Spectrum:** (a) emit raw structured data — pure structured-first, viz delegated
+
+## 8. HELM
+
+- **Report:** Web leaderboard + local web UI (`helm-server` localhost:8000) + text summaries (`helm-summarize`)
+- **Packaging:** Core; web UI + summarize commands in base install
+- **Positioning:** "Holistic, reproducible, transparent evaluation." Multiple paths: leaderboard + local UI + text summary
+- **Input:** Eval run → structured data → web + text
+- **Spectrum:** (b) opinionated default reports (multi-format)
+
+## 9. Jupyter
+
+- **Report:** Interactive notebook (`.ipynb` JSON) + rich output (HTML, images, LaTeX, MIME) + static exports via nbconvert
+- **Packaging:** Notebook viewer core; export via nbconvert separate
+- **Positioning:** Open document format based on JSON; rich inline output; ecosystem (Voilà, JupyterLab) bridges to dashboards
+- **Input:** Executed cells with inline outputs; `.ipynb` JSON persisted
+- **Spectrum:** (a) → (b) bridge
+
+## 10. nbconvert
+
+- **Report:** Static exports (HTML, PDF, LaTeX, Markdown, Python, reST, asciidoc, slides)
+- **Packaging:** Separate package (bundled in some distributions)
+- **Positioning:** CLI tool for format conversion; pure conversion, no visualization engine
+- **Input:** `.ipynb` file → static format
+- **Spectrum:** (a) + infrastructure
+
+## 11. Quarto
+
+- **Report:** Multi-format publishing (HTML, PDF, Word, ePub, websites, dashboards, books) from single md/notebook source
+- **Packaging:** Standalone tool; integrates via Jupyter; core rendering engine included
+- **Positioning:** Reproducible, production-quality articles, dashboards, books from one source
+- **Input:** Markdown or notebooks → rendered at build time
+- **Spectrum:** (b) opinionated report generation (multi-format)
+
+## 12. papermill
+
+- **Report:** Executed `.ipynb` with injected-parameters cell
+- **Packaging:** Core; execution + parameter injection in base
+- **Positioning:** Execute notebooks with injected parameters; store to S3/Azure/GCS/local. Reproducibility + parameter management.
+- **Input:** `.ipynb` + parameter dict → parameterized executed notebook
+- **Spectrum:** (a) emit structured data
+
+## Pattern Clusters
+
+**Cluster A — Raw structured data + consumer choice** (lm-eval-harness, papermill): explicitly emit clean JSON/notebook/files; defer viz to consumers (W&B, Zeno, HF Hub, nbconvert, Quarto). CLI-first; minimal or no built-in UI. Tight ecosystem integration.
+
+**Cluster B — Opinionated default reports** (Great Expectations, HELM, Quarto, evidently): ship structured results + one or more default rendered formats. Rendering in core or minimal extras. No live UI hosting; static artifacts or Jupyter-native. Flexible downstream use.
+
+**Cluster C — Interactive dashboard-first** (Prefect, Dagster, MLflow, W&B): live web UI is primary consumption path. Real-time observability, collaborative features, integrated alerting. API access secondary. Often cloud-backed.
+
+**Cluster D — Infrastructure & format-agnostic** (Jupyter, nbconvert, papermill, Quarto): treat notebooks/markdown as canonical structured form. Rendering/export handled by ecosystem tools or format-independent.
+
+## Spectrum observation
+
+Tools without explicit "no-dashboard" positioning tend to offer dashboards. Tools that *do* emphasize structured-data-first (lm-eval-harness, papermill) explicitly avoid hosting and position as CLI-first or notebook-native. Visualization is a strategic choice, not an afterthought, across all tools audited.

--- a/specs/sp-viz-layer/research/cli-rendering-primitives.md
+++ b/specs/sp-viz-layer/research/cli-rendering-primitives.md
@@ -1,0 +1,127 @@
+# CLI Rendering Primitives — Objective Codebase Map
+
+## 1. Rendering & Templating Dependencies
+
+**No heavyweight templating engines.** Core deps are `httpx>=0.27` + `pyyaml>=6.0` (`pyproject.toml:25-28`). Jinja is NOT imported anywhere.
+
+**Two internal substitution engines:**
+- `scripts/render_site.py:45-52` — regex-based `{{ key }}` placeholder substitution for site HTML. No dotted access, filters, or inheritance.
+- `src/synth_panel/templates.py:38-84` — `_SafeFormatter` subclass of `string.Formatter` for question-text `{placeholder}` substitution. Blocks dotted/bracket access; returns literal placeholder on missing keys.
+
+**No Markdown renderer, no HTML template lib, no static-site generator** in deps or code.
+
+## 2. Site HTML Pipeline
+
+- Entry: `scripts/render_site.py` (CLI script; also `render()` importable function).
+- Placeholders: `{{ version }}` ← `src/synth_panel/__version__.py` (regex at 25-32); `{{ release_date }}` ← `CHANGELOG.md` `## [X.Y.Z] - YYYY-MM-DD` (35-42).
+- Template: `site/index.html.j2` (515 lines); Output: `site/index.html`. Writes via `OUTPUT_PATH.write_text()` (55-62).
+- **Not reusable for panel-result rendering** — substitution engine supports only simple key lookups, no schema/loops/conditionals; tailored to static site metadata only.
+
+## 3. Styling & Theme
+
+- Tailwind CSS via CDN (`<script src="https://cdn.tailwindcss.com">` line 73 of index.html.j2). Marketing-site only, not shipped with package.
+- Colors: emerald 300/400/500 primary; slate 200/400/900 background; amber 300 accents; dark mode default (line 95).
+- No CLI theme/color conventions. No table/banner/progress-bar color scheme.
+
+## 4. Existing Subcommands Emitting Formatted Text
+
+| Subcommand | Formats | Shape | Ref |
+|---|---|---|---|
+| `prompt` | TEXT | raw response + cost line | cli/commands.py:419-439 |
+| `panel run` | TEXT | cost banners + synthesis | 1468-1583 |
+| `panel run` (errors) | TEXT | `!` × 70 boxed banner | 1917-2026 |
+| `panel inspect` | TEXT | key=value + tables | analysis/inspect.py:452+ |
+| `analyze` | TEXT, CSV | stats tables, CSV rows | analyze.py:396-544 |
+| `instruments graph` | TEXT, MERMAID | plain DAG or Mermaid flowchart | commands.py:2422-2475 |
+| `pack list` | TEXT | name+description list | implicit |
+
+### Cost summary format (`cost.py:561-591` `format_summary()`)
+
+Two lines: `Total: total_tokens=... input=... output=... estimated_cost=$0.0000 model=... pricing=estimated-default` + `  cost breakdown: input=$... output=$... cache_write=$... cache_read=$...`.
+
+### Error banners
+
+- Total failure (commands.py:1917-1950) — `!` × 70 border, "PANEL RUN INVALID", failing models + sample errors
+- Failure threshold exceeded (1953-2026) — error rate vs threshold + affected personas (first 4)
+- Missing input (1996-2000) — refusal rate + affected personas
+
+### Progress / status
+
+**No progress bars or live updates.** Convergence telemetry (sp-yaru) writes JSON lines to stderr or `--convergence-log` file but not human-formatted.
+
+## 5. Emit Layer
+
+**Central `emit()` at `cli/output.py:20-60`** — single unified formatter.
+
+```python
+def emit(fmt: OutputFormat, *, message: str, usage: dict|None, extra: dict|None, file=None) -> None
+```
+
+| Format | Output |
+|---|---|
+| TEXT | message + optional `  tokens: input=N output=M` line |
+| JSON | single-line `{"message":..., "usage":..., ...extra}` |
+| NDJSON | `{"type":"message","text":..., "usage":..., ...extra}` |
+
+`OutputFormat` enum at `cli/output.py:14-17`: `TEXT="text"`, `JSON="json"`, `NDJSON="ndjson"`.
+
+**No reporter class or formatter registry.** Each subcommand directly calls `emit()` with hardcoded messages. Banner/summary/DAG functions return strings then get printed via `emit()` or `print()`.
+
+**Cost formatting:** `CostEstimate.format_usd()` always returns `f"${total:.4f}"` (cost.py:458-459). Per-panelist cost uses same method in `format_panelist_result()` (_runners.py:516-535). Pre-formatted in panel output; machine consumers see the string, not the float — preserves billing precision across local-table drift.
+
+## 6. `--format` / `--output-format` Flags
+
+**Global `--output-format`:** parser.py:56-60. Choices: `text`, `json`, `ndjson`. Default: `text`. Parsed to `args.output_format` → `OutputFormat` enum → passed to all handlers.
+
+**Per-subcommand overrides (legacy, less consistent):**
+| Subcommand | Flag | Choices | Ref |
+|---|---|---|---|
+| `instruments graph` | `--format` | text, mermaid | parser.py:656-660 |
+| `analyze` | `--output` | text, json, csv | parser.py:673-677 |
+
+**MCP tools return only JSON** (always `json.dumps(..., indent=2)`). No `--format` equivalent.
+
+## 7. Human-Readable vs Machine-Readable Fields
+
+| Field | Readability | Source → Seam |
+|---|---|---|
+| `responses` | Machine | Raw text from LLM, `_runners.py:526-535` |
+| `cost` | **Human** | Pre-formatted `$0.0000` via `format_usd()` |
+| `usage` | Machine | Raw token counts |
+| `synthesis.summary` | Hybrid | Free-text + structured lists |
+| `verdict`, `confidence` | Human (verdict), Machine (confidence) | From structured-output schema; enum string vs 0-1 float |
+
+**Transformation seams:**
+1. Panelist response → structured extraction (`structured/output.py:52-148`) — LLM text → JSON via tool-use; extraction layer opaque to CLI
+2. Panelist usage → cost string (`_runners.py:516-535`) — raw tokens exist in `usage`; formatted `cost` added as separate field; caller uses either
+3. Synthesis result → flat template context (`templates.py:17-35`) — nested → `{theme_0, theme_1, agreement_0, ...}` dict; question templating sees flat keys only
+4. Error details → banner text (commands.py:1917-2026) — structured dict → multiline boxed string; first sample truncated to 240 chars
+
+**Intentionally pre-formatted:** cost (`$0.0000`), verdicts (enum strings), timestamps (ISO 8601 when present).
+
+## 8. Package Size & Optional Dependencies
+
+**Core:** ~150 KB wheel. `httpx` + `pyyaml` only.
+
+**Optional extras (pyproject.toml:38-57):**
+| Extra | Deps | Purpose |
+|---|---|---|
+| `[mcp]` | `mcp>=1.0` | MCP server, stdio transport (heavy) |
+| `[composio]` | `composio>=0.5`, `pydantic>=2.0` | Vendor tool integrations (heavy) |
+| `[convergence]` | `synthbench>=0.1` | Convergence + human-baseline lookup |
+| `[dev]` | pytest, ruff, mypy, pip-audit | test/lint |
+
+Heavy optional extras correctly fenced. Users get ~150 KB core unless they opt into MCP/Composio/convergence.
+
+## Seams Observed
+
+Seven extension points at transform boundaries:
+1. **`OutputFormat` routing** — add enum variant + `emit()` branch to support a new format
+2. **Cost display** — `format_summary()` is pure function; swap without touching panel runner
+3. **Error banners** — `_build_*_banner()` pure functions; swap for HTML/Markdown templates
+4. **Structured schema** — fully user-controlled via `--schema`/`--extract-schema`
+5. **Question templating** — extend `_SafeFormatter` to support conditionals/filters/loops
+6. **Analysis output** — `format_text()`/`format_csv()` pure transformations; add `format_html()`/`format_markdown()` without touching analysis engine
+7. **Site rendering** — swap regex substitution for real templating engine
+
+**No architectural blocker for HTML reports / Markdown docs / interactive dashboards** — seams exist; only implementation is missing.

--- a/specs/sp-viz-layer/research/panel-json-schema.md
+++ b/specs/sp-viz-layer/research/panel-json-schema.md
@@ -1,0 +1,150 @@
+# Panel-Result JSON Schema — Research Summary
+
+**Scope:** `src/synth_panel/` + tests + docs, cross-validated against real artifacts in `/Users/openclaw/gastown-dev/mayor/results/synthpanel-self-audit/`.
+
+## 1. Schema Definition: Locus and Versioning
+
+**Where defined:** Inferred from code, not a formal schema artifact. Three loci:
+- `src/synth_panel/sdk.py:224–286` — `PanelResult`, `PollResult`, `PromptResult` dataclasses. `to_dict()` at 163–165 serializes to plain dict.
+- `src/synth_panel/synthesis.py:64–97` — `_SYNTHESIS_SCHEMA` JSON Schema for the synthesis object.
+- `src/synth_panel/mcp/data.py:482–530` — `save_panel_result()` documents which top-level fields are saved; optional fields are conditionally included (521–530).
+
+**Versioning:** No explicit `schema_version` field. CHANGELOG references output-shape changes via ticket IDs (sp-avmm, sp-g270, sp-kkzz) but does not bump any schema version.
+
+**Back-compat strategy:** Optional fields default in dataclasses (e.g., `cost_is_estimated: bool = False` at sdk.py:279). Old results lacking them deserialize cleanly. Example: `synthesis_error` added in sp-avmm (sdk.py:285); `terminal_round` present only on multi-round runs.
+
+**Canonical contract (prose):** `docs/mcp.md:99–134` — JSON example showing `rounds`, `path`, `terminal_round`, `synthesis`, `total_cost`, `total_usage`, `results`.
+
+## 2. Distinct Sections and Shapes
+
+### Top-level scalars & metadata
+
+| Field | Type | Always | Notes |
+|---|---|---|---|
+| `result_id` | string | ✓ | `result-YYYYMMDD-HHMMSS-<hex>` |
+| `message` | string | ✓ | CLI-emitted human status |
+| `model` | string | ✓ | Panelist model alias |
+| `persona_count`, `question_count` | int | ✓ | |
+| `total_cost` | string | ✓ | USD formatted (`"$0.1234"`) |
+| `panelist_cost` | string | ◐ | Ensemble runs (sp-atvc) |
+| `total_usage` | dict | ✓ | Token bucket (see below) |
+| `panelist_usage` | dict | ◐ | Multi-question CLI runs (sp-027) |
+| `run_invalid` | bool | ◐ | Default False (sp-bjt4) |
+| `cost_is_estimated` | bool | ◐ | Default False (sp-nn8k) |
+
+### Rounds (per-round results)
+
+```python
+rounds: list[{
+    "name": str,
+    "results": list[PanelistResult],
+    "synthesis": dict | None,
+    "usage": dict | None,  # map-reduce only
+}]
+```
+
+### Panelist result (per-persona)
+
+```python
+rounds[i]["results"][j] = {
+    "persona": str,
+    "responses": list[{"question": str, "response": str, "extraction": dict | None}],
+    "usage": dict,
+    "cost": str,  # pre-formatted USD
+    "error": str | None,
+    "model": str | None,  # ensemble only
+}
+```
+
+### Synthesis
+
+Serialized from `SynthesisResult` (synthesis.py:104–147). Keys: `summary`, `themes`, `agreements`, `disagreements`, `surprises`, `recommendation`, `usage`, `cost`, `model`, `prompt_version`, plus strategy-dependent `strategy`, `per_question_synthesis` (dict[str,str] keyed by question index — strings for JSON round-trip), `map_cost_breakdown`.
+
+### Path (multi-round routing)
+
+```python
+path: list[{"round": str, "branch": str, "next": str | None}]
+```
+
+Empty list for v1/v2 single-round. `orchestrator.py:815` renders branch descriptions.
+
+### Metadata (provenance & audit)
+
+```python
+metadata: dict | None = {
+    "version": {"synthpanel": str, "python": str},
+    "models": {"panelist": str, "synthesis": str | None},
+    "generation_params": {"temperature": float|None, "top_p": float|None, "max_tokens": int},
+    "config_hash": str,  # sp-ui40
+    "cost": {"total_tokens": int, "total_cost_usd": float, "per_model": dict},
+    "timing": {"total_seconds": float, "per_panelist_avg": float},
+    "template_vars_fingerprint": dict[str, str],
+}
+```
+
+Pre-metadata results have `metadata: None`. `per_model` bucketing is ensemble-specific (sp-atvc).
+
+### Ensemble-specific
+
+```python
+cost_breakdown: {"by_model": dict[str, str], "total": str}  # sp-gl9
+model_assignment: dict[str, str]  # persona → model
+per_model_results: [...]  # ensemble runs
+```
+
+### Warnings & failure stats
+
+`warnings` (list[str]), `failure_stats` (errored_pairs/failure_rate/failed_panelists), `synthesis_error` (dict added in sp-avmm), `missing_input_stats`.
+
+## 3. Canonical vs Optional vs Strategy-Dependent
+
+**Always canonical (all versions):** `result_id`, `model`, `persona_count`, `question_count`, `total_cost`, `total_usage`, `rounds` (≥1), `path` (may be empty), `synthesis` (may be None).
+
+**Optional (context-dependent):** `metadata`, `terminal_round`, `results` (back-compat flat shape), `panelist_cost`, `panelist_usage`, `per_model_results`, `cost_breakdown`, `model_assignment`, `warnings`, `failure_stats`, `run_invalid`, `synthesis_error`, `missing_input_stats`, `convergence` (sp-yaru, opt-in).
+
+**Strategy-dependent (synthesis.py:141–147):**
+- `synthesis.strategy` — omitted for single, `"map-reduce"` otherwise
+- `synthesis.per_question_synthesis` — None for single, dict for map-reduce (string keys)
+- `synthesis.map_cost_breakdown` — None/list[dict]
+- `rounds[i].usage` — map-reduce only
+
+## 4. Schema Stability
+
+**Unstable with back-compat guardrails.** Recent changes:
+| Ticket | v | Change |
+|---|---|---|
+| sp-avmm | 0.9.8 | Added `synthesis_error`, `run_invalid` |
+| sp-kkzz | 0.9.8 | Added `strategy`, `per_question_synthesis`, `map_cost_breakdown` |
+| sp-atvc | 0.9.8 | Ensemble `per_model` bucket; added `cost_breakdown`, `model_assignment` |
+| sp-gl9 | 0.9.8 | `per_model_results` / `cost_breakdown` on non-ensemble runs |
+| sp-g270 | 0.9.8 | `personas_merge_warnings` array |
+| sp-027 | 0.9.7 | `panelist_usage` on multi-question CLI |
+| sp-ui40 | 0.9.7 | `template_vars_fingerprint`; config_hash includes resolved vars |
+
+No deprecations documented. No removals announced. Consumers use presence checks.
+
+## 5. Observed Panel-Result JSON Sizes
+
+| Source | n | Size |
+|---|---|---|
+| round3/synthpanel__landing-page-comprehension | 6 | 51 KB |
+| ensemble_30/synthpanel__product-feedback | 30 | 1.2 MB |
+| ensemble_50/synthpanel__product-feedback | 50 | 2.0 MB |
+| ensemble_100/synthpanel__product-feedback | 100 | 3.9 MB |
+| ensemble_100_v099_ctx2/synthpanel__product-feedback | 100 | 6.7 MB |
+
+Linear: ~40 KB/persona baseline. Crosses 1 MB at n≈25. 10 MB extrapolates to n≈250. Largest observed: 6.7 MB.
+
+## Seams observed
+
+1. **`analysis/inspect.py`** — `InspectReport` dataclass (line 75) walks schema for per-persona/per-model/synthesis-status summaries. No CLI subcommand exposes it beyond `panel inspect`.
+2. **Per-response `extraction` field** (`mcp/data.py:507`) — optional structured-output dict persisted but no downstream consumer documented.
+3. **`metadata.cost.per_model`** — multi-model cost breakdown structured, not surfaced in CLI summary.
+4. **Session persistence** (`persistence.py`, `mcp/data.py:385–403`) — `{result_id}.sessions/{persona_name}.json` enables replay/extend but no browsing API.
+5. **Synthesis strategy metadata** (`synthesis.py:141–147`) — map-reduce intermediate summaries serialized but not rendered.
+6. **`metadata.template_vars_fingerprint`** — available for cross-run diffing; no diff utility exposed.
+7. **Failure stats granularity** (`failure_stats.errored_personas`) — per-persona error lists captured but not surfaced.
+
+## Citations
+
+sdk.py:163–286; synthesis.py:64–147; mcp/data.py:482–530; analysis/inspect.py:75–97; docs/mcp.md:99–134; CHANGELOG.md lines 12–73.


### PR DESCRIPTION
## Summary

QRSPI R-phase output for three in-flight initiatives. Parallel Explore subagent research across 8 dimensions, synthesized into 3 per-topic research-maps for the D-phase gate.

- `specs/sp-viz-layer/` — 3 dimension files + research-map
- `specs/sp-pack-registry/` — 3 dimension files + research-map
- `specs/sp-inline-calibration/` — 2 dimension files + research-map

Research is ticket-blind per QRSPI discipline; each research-map surfaces observable seams, observable tensions, and open questions without advocating a design direction.

Related beads: sp-nj58 (viz), sp-5roa (registry), sp-0ku0 (calibration).

## Test plan

Docs-only PR. No code changes. Format/lint N/A.