### PR TITLE
docs(site): add "Who this isn't for" block surfacing non-enterprise positioning (sp-o1y0)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -248,6 +248,46 @@
             </p>
           </div>
         </div>
+
+        <!-- Who this isn't for -->
+        <div
+          class="mt-8 rounded-lg border border-slate-800 bg-slate-900/40 p-5 text-sm text-slate-300"
+          id="not-for"
+        >
+          <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Who this <span class="text-slate-200">isn't</span> for
+          </p>
+          <p class="mt-3 text-slate-300">
+            synthpanel is <strong class="text-slate-100">CLI-first,
+            local-first, BYOK-first</strong> by design. It does
+            <strong class="text-slate-100">not</strong> ship:
+          </p>
+          <ul class="mt-3 space-y-1.5 text-slate-400">
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>a hosted web UI or dashboard</span>
+            </li>
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>a managed SaaS tier</span>
+            </li>
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>SSO, RBAC, or audit-log infrastructure</span>
+            </li>
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>SOC 2 (or equivalent) compliance attestation</span>
+            </li>
+          </ul>
+          <p class="mt-3 text-slate-400">
+            These are
+            <strong class="text-slate-200">deliberate non-features</strong>,
+            not a roadmap gap. If you need a hosted GUI or enterprise
+            compliance artifacts for a vendor review, synthpanel isn't your
+            product — and that's intentional.
+          </p>
+        </div>
       </section>
 
       <!-- See it in action -->

--- a/site/index.html.j2
+++ b/site/index.html.j2
@@ -248,6 +248,46 @@
             </p>
           </div>
         </div>
+
+        <!-- Who this isn't for -->
+        <div
+          class="mt-8 rounded-lg border border-slate-800 bg-slate-900/40 p-5 text-sm text-slate-300"
+          id="not-for"
+        >
+          <p class="text-xs font-semibold uppercase tracking-wider text-slate-400">
+            Who this <span class="text-slate-200">isn't</span> for
+          </p>
+          <p class="mt-3 text-slate-300">
+            synthpanel is <strong class="text-slate-100">CLI-first,
+            local-first, BYOK-first</strong> by design. It does
+            <strong class="text-slate-100">not</strong> ship:
+          </p>
+          <ul class="mt-3 space-y-1.5 text-slate-400">
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>a hosted web UI or dashboard</span>
+            </li>
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>a managed SaaS tier</span>
+            </li>
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>SSO, RBAC, or audit-log infrastructure</span>
+            </li>
+            <li class="flex gap-2">
+              <span aria-hidden="true" class="text-slate-600">×</span>
+              <span>SOC 2 (or equivalent) compliance attestation</span>
+            </li>
+          </ul>
+          <p class="mt-3 text-slate-400">
+            These are
+            <strong class="text-slate-200">deliberate non-features</strong>,
+            not a roadmap gap. If you need a hosted GUI or enterprise
+            compliance artifacts for a vendor review, synthpanel isn't your
+            product — and that's intentional.
+          </p>
+        </div>
       </section>
 
       <!-- See it in action -->


### PR DESCRIPTION
## Summary
- Add a "Who this isn't for" block on the landing page that clearly surfaces the non-enterprise positioning so prospects self-select out early, reducing bad-fit discovery calls

## Source
- Polecat: nux
- Issue: sp-o1y0
- MR: sp-wisp-a7e
- Branch: polecat/nux-moaphkgr

## Test plan
- [ ] CI passes (site version guard test still green)
- [ ] Both site/index.html and site/index.html.j2 updated consistently (template substitution from #228 still rebuilds clean)

## Conflict note
Touches site/index.html and site/index.html.j2 — depends on PR #228 (sp-ssrw) landing first or being rebased simultaneously, since #228 introduces the template file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)