### PR TITLE
test(synthesis): regression for sub-chunking with long question prefix (sp-34f7)

### DIFF
--- a/tests/test_synthesis_subchunk.py
+++ b/tests/test_synthesis_subchunk.py
@@ -441,10 +441,7 @@ class TestLongQuestionPrefix:
         # brief whose content dwarfs the actual ask. Sized so 101
         # repetitions push the map body past haiku's 192k effective
         # limit with trivially short answers.
-        header = (
-            "On a scale of 0 to 10, how likely are you to recommend "
-            "SynthPanel to a peer? Context follows.\n\n"
-        )
+        header = "On a scale of 0 to 10, how likely are you to recommend SynthPanel to a peer? Context follows.\n\n"
         brief = (
             "SynthPanel is an open-source Python package and MCP server that "
             "orchestrates synthetic focus groups — panels of LLM-powered "
@@ -473,9 +470,7 @@ class TestLongQuestionPrefix:
         full_est = estimate_single_pass_tokens(panelists, [q], prompt=_MAP_PROMPT_TEMPLATE)
         assert full_est > 192_000, f"scenario must overflow haiku; got {full_est}"
 
-        batches = _partition_panelists_for_context(
-            panelists, q, _MAP_PROMPT_TEMPLATE, context_limit=192_000
-        )
+        batches = _partition_panelists_for_context(panelists, q, _MAP_PROMPT_TEMPLATE, context_limit=192_000)
         assert batches is not None, "sub-chunking must be able to split"
         assert len(batches) >= 2, f"expected multiple batches, got {len(batches)}"
         assert sum(len(b) for b in batches) == 100
@@ -483,9 +478,7 @@ class TestLongQuestionPrefix:
         # Every batch fits the limit once the prefix cost is counted.
         for b in batches:
             est_b = estimate_single_pass_tokens(b, [q], prompt=_MAP_PROMPT_TEMPLATE)
-            assert est_b <= 192_000, (
-                f"batch of {len(b)} still overflows: {est_b} > 192000"
-            )
+            assert est_b <= 192_000, f"batch of {len(b)} still overflows: {est_b} > 192000"
 
     def test_map_reduce_sub_chunks_long_prefix_on_haiku(self):
         """End-to-end: n=100 + long-brief Q on haiku succeeds via sub-chunking.

--- a/tests/test_synthesis_subchunk.py
+++ b/tests/test_synthesis_subchunk.py
@@ -414,3 +414,107 @@ class TestLargeN:
         # panelists must have sub-chunked.
         for entry in result.map_cost_breakdown:
             assert entry.get("sub_chunked") is True
+
+
+# --- sp-34f7: long-question-prefix regression ---
+
+
+class TestLongQuestionPrefix:
+    """Regression for sp-34f7: question-text prefix must factor into the
+    sub-chunk token budget.
+
+    ``_format_panelist_data`` echoes the question text once per panelist's
+    response block (``  Q: <text>\\n  A: <answer>``), so a ~2.5k-token
+    product-brief question duplicated across 100 panelists contributes
+    ~250k tokens on its own — enough to overflow haiku's 192k window even
+    with trivially short answers. The audit run
+    ``ensemble_100_v099_ctx2/synthpanel__product-feedback.json`` failed
+    this way before sub-chunking was in place; these tests pin that the
+    estimator and partitioner both see the prefix cost and split
+    accordingly.
+    """
+
+    def _long_brief_question_text(self) -> str:
+        # ~13k chars ≈ 3.3k tokens under the 4-chars-per-token heuristic.
+        # Mirrors the product-feedback Q1 shape that tripped the audit
+        # (ensemble_100_v099_ctx2): a short stem + a multi-paragraph
+        # brief whose content dwarfs the actual ask. Sized so 101
+        # repetitions push the map body past haiku's 192k effective
+        # limit with trivially short answers.
+        header = (
+            "On a scale of 0 to 10, how likely are you to recommend "
+            "SynthPanel to a peer? Context follows.\n\n"
+        )
+        brief = (
+            "SynthPanel is an open-source Python package and MCP server that "
+            "orchestrates synthetic focus groups — panels of LLM-powered "
+            "personas that answer research questions in parallel. "
+        ) * 50
+        return header + brief
+
+    def test_partition_accounts_for_repeated_question_prefix(self):
+        """Short answers + very long Q text still forces partitioning.
+
+        If partition ignored the per-panelist Q echo, it would return a
+        single batch and the downstream map call would overflow at
+        runtime. Asserting ``len(batches) >= 2`` pins that the estimator
+        charges each panelist slot for the duplicated prefix.
+        """
+        q_text = self._long_brief_question_text()
+        # Trivially short answers: prefix must be the overflow driver.
+        panelists = _fat_panelists(100, q_text, chars_per_response=50)
+        q = {"text": q_text}
+
+        # Sanity: the full-panel single-pass estimate must exceed haiku's
+        # effective limit — otherwise the scenario isn't actually
+        # exercising the overflow path.
+        from synth_panel.synthesis import estimate_single_pass_tokens
+
+        full_est = estimate_single_pass_tokens(panelists, [q], prompt=_MAP_PROMPT_TEMPLATE)
+        assert full_est > 192_000, f"scenario must overflow haiku; got {full_est}"
+
+        batches = _partition_panelists_for_context(
+            panelists, q, _MAP_PROMPT_TEMPLATE, context_limit=192_000
+        )
+        assert batches is not None, "sub-chunking must be able to split"
+        assert len(batches) >= 2, f"expected multiple batches, got {len(batches)}"
+        assert sum(len(b) for b in batches) == 100
+
+        # Every batch fits the limit once the prefix cost is counted.
+        for b in batches:
+            est_b = estimate_single_pass_tokens(b, [q], prompt=_MAP_PROMPT_TEMPLATE)
+            assert est_b <= 192_000, (
+                f"batch of {len(b)} still overflows: {est_b} > 192000"
+            )
+
+    def test_map_reduce_sub_chunks_long_prefix_on_haiku(self):
+        """End-to-end: n=100 + long-brief Q on haiku succeeds via sub-chunking.
+
+        Reproduces the shape of the audit failure
+        (``ensemble_100_v099_ctx2/synthpanel__product-feedback.json``):
+        n=100 panelists answering a long-brief question on haiku. The
+        current sub-chunk fallback must carry the run to completion
+        rather than raising ``MapChunkOverflowError``.
+        """
+        q_text = self._long_brief_question_text()
+        panelists = _fat_panelists(100, q_text, chars_per_response=50)
+        questions = [{"text": q_text}]
+
+        # Upper-bound responses: a handful of batches + 1 inner reduce + 1 outer reduce.
+        responses = [_tool_response(f"call-{i}") for i in range(20)]
+        client = _SequenceClient(responses)
+
+        result = synthesize_panel_mapreduce(
+            client,
+            panelists,
+            questions,
+            model="haiku",
+            max_workers=1,
+        )
+        assert result.strategy == STRATEGY_MAP_REDUCE
+        assert result.per_question_synthesis is not None
+        assert 0 in result.per_question_synthesis
+        assert result.map_cost_breakdown is not None
+        entry = result.map_cost_breakdown[0]
+        assert entry.get("sub_chunked") is True
+        assert entry.get("batch_count", 0) >= 2


### PR DESCRIPTION
## Summary
- Add regression test covering the edge case where a long question prefix consumes most of the context window, forcing sub-chunking from PR #233 to engage

## Source
- Polecat: furiosa
- Issue: sp-34f7
- MR: sp-wisp-a52
- Branch: polecat/furiosa-moaph4nw

## Test plan
- [ ] CI passes
- [ ] Test fails intentionally if sub-chunking regresses on the long-prefix case

## Conflict note
Touches tests/test_synthesis_subchunk.py — depends on PR #233 (sp-4g6a) landing first (that PR introduces the test file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)