### PR TITLE
feat(mcp): optional version field on persona packs + opt-in shadow warning (sp-lk3w)

### DIFF
--- a/src/synth_panel/mcp/data.py
+++ b/src/synth_panel/mcp/data.py
@@ -129,11 +129,16 @@ def _bundled_instrument_packs() -> dict[str, dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def list_persona_packs() -> list[dict[str, Any]]:
+def list_persona_packs(*, warn_on_shadow: bool = False) -> list[dict[str, Any]]:
     """Return metadata for all persona packs (bundled + user-saved).
 
     Bundled packs are listed first. If a user-saved pack has the same ID as
     a bundled pack, the user-saved version takes precedence.
+
+    ``warn_on_shadow``: when True, emit a ``UserWarning`` for every bundled
+    pack hidden by a user-saved pack of the same id. This is the
+    registry-import path; local callers leave it False to preserve the
+    historical silent-shadow behavior.
     """
     seen: set[str] = set()
     packs: list[dict[str, Any]] = []
@@ -161,6 +166,14 @@ def list_persona_packs() -> list[dict[str, Any]]:
     bundled = []
     for pack_id, data in sorted(_bundled_packs().items()):
         if pack_id in seen:
+            if warn_on_shadow:
+                import warnings
+
+                warnings.warn(
+                    f"Bundled persona pack {pack_id!r} is shadowed by a user-saved pack",
+                    UserWarning,
+                    stacklevel=2,
+                )
             continue
         personas = data.get("personas", [])
         bundled.append(
@@ -176,7 +189,12 @@ def list_persona_packs() -> list[dict[str, Any]]:
 
 
 def get_persona_pack(pack_id: str) -> dict[str, Any]:
-    """Load a persona pack by ID. User-saved packs override bundled ones."""
+    """Load a persona pack by ID. User-saved packs override bundled ones.
+
+    Pack-level manifest fields are normalized via
+    :func:`validate_pack_manifest` — in particular ``version`` defaults to
+    ``"1"`` when absent.
+    """
     _validate_pack_id(pack_id)
     # Check user-saved packs first
     p = _packs_dir() / f"{pack_id}.yaml"
@@ -184,13 +202,14 @@ def get_persona_pack(pack_id: str) -> dict[str, Any]:
         data = yaml.safe_load(p.read_text(encoding="utf-8"))
         if not isinstance(data, dict):
             raise ValueError(f"Invalid persona pack format in {pack_id}")
+        data = validate_pack_manifest(data)
         data["id"] = pack_id
         return data
 
     # Fall back to bundled packs
     bundled = _bundled_packs()
     if pack_id in bundled:
-        data = bundled[pack_id]
+        data = validate_pack_manifest(bundled[pack_id])
         data["id"] = pack_id
         return data
 
@@ -199,6 +218,27 @@ def get_persona_pack(pack_id: str) -> dict[str, Any]:
 
 class PackValidationError(ValueError):
     """Raised when a persona pack fails schema validation."""
+
+
+def validate_pack_manifest(data: dict[str, Any]) -> dict[str, Any]:
+    """Validate pack-level manifest fields and apply defaults.
+
+    Currently enforces one rule: the optional ``version`` field must be a
+    string. When absent, it defaults to ``"1"``. Other manifest fields
+    (``name``, ``description``, ``author``) are passed through unchanged.
+
+    Returns a shallow copy of *data* with defaults applied. Raises
+    :class:`PackValidationError` for type violations.
+    """
+    if not isinstance(data, dict):
+        raise PackValidationError("pack manifest must be a mapping")
+    out = dict(data)
+    version = out.get("version")
+    if version is None:
+        out["version"] = "1"
+    elif not isinstance(version, str):
+        raise PackValidationError(f"pack version must be a string, got {type(version).__name__}")
+    return out
 
 
 def validate_persona_pack(personas: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -245,19 +285,36 @@ def save_persona_pack(
     name: str,
     personas: list[dict[str, Any]],
     pack_id: str | None = None,
+    version: str | None = None,
 ) -> dict[str, Any]:
     """Save a persona pack and return its metadata.
 
     Validates personas before saving. Raises :class:`PackValidationError`
     on invalid data.
+
+    When ``version`` is provided it must be a string and is written to the
+    on-disk manifest. When omitted, no ``version:`` field is written — the
+    pack loads as ``"1"`` via :func:`get_persona_pack`'s default.
     """
     personas = validate_persona_pack(personas)
     pid = pack_id or f"pack-{uuid.uuid4().hex[:8]}"
     _validate_pack_id(pid)
     p = _packs_dir() / f"{pid}.yaml"
-    data = {"name": name, "personas": personas}
+    data: dict[str, Any] = {"name": name}
+    if version is not None:
+        validated = validate_pack_manifest({"version": version})
+        data["version"] = validated["version"]
+    data["personas"] = personas
     p.write_text(yaml.dump(data, default_flow_style=False), encoding="utf-8")
-    return {"id": pid, "name": name, "persona_count": len(personas), "path": str(p)}
+    meta: dict[str, Any] = {
+        "id": pid,
+        "name": name,
+        "persona_count": len(personas),
+        "path": str(p),
+    }
+    if version is not None:
+        meta["version"] = data["version"]
+    return meta
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_persona_version_field.py
+++ b/tests/test_persona_version_field.py
@@ -1,0 +1,142 @@
+"""Tests for the optional pack-level ``version`` field on persona packs
+and the opt-in shadow warning in ``list_persona_packs`` (sp-lk3w).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+import yaml
+
+
+@pytest.fixture(autouse=True)
+def _data_dir(tmp_path, monkeypatch):
+    """Point SYNTH_PANEL_DATA_DIR at a temp directory for every test."""
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+
+
+# Import after env is set so ``_data_dir()`` picks up the temp path.
+from synth_panel.mcp.data import (
+    PackValidationError,
+    get_persona_pack,
+    list_persona_packs,
+    save_persona_pack,
+    validate_pack_manifest,
+)
+
+
+class TestValidatePackManifest:
+    def test_missing_version_defaults_to_one(self):
+        result = validate_pack_manifest({"name": "P"})
+        assert result["version"] == "1"
+
+    def test_explicit_version_passes_through(self):
+        result = validate_pack_manifest({"name": "P", "version": "2"})
+        assert result["version"] == "2"
+
+    def test_non_string_version_rejected_int(self):
+        with pytest.raises(PackValidationError, match="version must be a string"):
+            validate_pack_manifest({"version": 2})
+
+    def test_non_string_version_rejected_float(self):
+        with pytest.raises(PackValidationError, match="version must be a string"):
+            validate_pack_manifest({"version": 1.0})
+
+    def test_non_string_version_rejected_list(self):
+        with pytest.raises(PackValidationError, match="version must be a string"):
+            validate_pack_manifest({"version": ["1"]})
+
+    def test_non_dict_rejected(self):
+        with pytest.raises(PackValidationError, match="must be a mapping"):
+            validate_pack_manifest("not a dict")  # type: ignore[arg-type]
+
+    def test_no_mutation_of_input(self):
+        original = {"name": "P"}
+        validate_pack_manifest(original)
+        assert "version" not in original
+
+
+class TestVersionRoundTrip:
+    def test_save_with_version_get_returns_it(self):
+        save_persona_pack("With Version", [{"name": "Alice"}], pack_id="v2-pack", version="2")
+        pack = get_persona_pack("v2-pack")
+        assert pack["version"] == "2"
+        assert pack["name"] == "With Version"
+        assert pack["id"] == "v2-pack"
+
+    def test_save_returns_version_in_meta(self):
+        meta = save_persona_pack("X", [{"name": "A"}], pack_id="meta-v", version="3")
+        assert meta["version"] == "3"
+
+    def test_save_without_version_get_defaults_to_one(self):
+        save_persona_pack("No Version", [{"name": "Alice"}], pack_id="no-v")
+        pack = get_persona_pack("no-v")
+        assert pack["version"] == "1"
+
+    def test_save_without_version_omits_field_in_yaml(self):
+        """Backwards compat: omitting version does not write a version: key."""
+        from synth_panel.mcp.data import _packs_dir
+
+        save_persona_pack("Legacy", [{"name": "A"}], pack_id="legacy")
+        raw = (_packs_dir() / "legacy.yaml").read_text(encoding="utf-8")
+        parsed = yaml.safe_load(raw)
+        assert "version" not in parsed
+
+    def test_save_with_non_string_version_rejected(self):
+        with pytest.raises(PackValidationError, match="version must be a string"):
+            save_persona_pack("Bad", [{"name": "A"}], pack_id="badv", version=2)  # type: ignore[arg-type]
+
+
+class TestBundledPacksRegression:
+    """All 9 bundled packs must load unchanged (with defaulted version="1")."""
+
+    BUNDLED = (
+        "developer",
+        "enterprise-buyer",
+        "general-consumer",
+        "healthcare-patient",
+        "startup-founder",
+        "job-seekers",
+        "recruiters-talent",
+        "product-research",
+        "ai-eval-buyers",
+    )
+
+    @pytest.mark.parametrize("pack_id", BUNDLED)
+    def test_bundled_pack_loads_with_default_version(self, pack_id):
+        pack = get_persona_pack(pack_id)
+        assert pack["id"] == pack_id
+        assert pack["version"] == "1"
+        # Still has personas (existing behavior unchanged).
+        assert isinstance(pack.get("personas"), list)
+        assert pack["personas"]
+
+
+class TestShadowWarning:
+    def test_local_import_silent_when_shadowing(self):
+        """Default call path does NOT warn when user shadows bundled."""
+        save_persona_pack("My Devs", [{"name": "Dev"}], pack_id="developer")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            list_persona_packs()
+        assert not any("shadowed" in str(w.message) for w in caught)
+
+    def test_registry_import_warns_on_shadow(self):
+        """Opt-in flag fires a UserWarning per shadowed bundled pack."""
+        save_persona_pack("My Devs", [{"name": "Dev"}], pack_id="developer")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            list_persona_packs(warn_on_shadow=True)
+        shadow_warnings = [w for w in caught if "shadowed" in str(w.message)]
+        assert len(shadow_warnings) == 1
+        assert shadow_warnings[0].category is UserWarning
+        assert "developer" in str(shadow_warnings[0].message)
+
+    def test_registry_import_silent_when_no_shadow(self):
+        """Opt-in flag does not warn when no user pack shadows anything."""
+        save_persona_pack("Custom", [{"name": "A"}], pack_id="my-own-pack")
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            list_persona_packs(warn_on_shadow=True)
+        assert not any("shadowed" in str(w.message) for w in caught)


### PR DESCRIPTION
## Summary
- Allow persona packs to carry an optional `version` field so MCP clients can pin against a known pack revision
- Opt-in warning when a saved pack shadows a bundled pack of the same name, so users notice drift without breaking existing flows

## Source
- Polecat: dementus
- Issue: sp-lk3w
- MR: sp-wisp-9oc
- Branch: polecat/dementus-moaxizhv

## Test plan
- [ ] CI passes (new coverage in test_persona_version_field.py)
- [ ] Saved pack with same name as a bundled pack emits the shadow warning only when opt-in is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)