### PR TITLE
feat(registry): gh: URL resolver (sp-udsv)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ docs/internal/
 .env
 .env.local
 *.key
+
+# Gas Town (added by gt)
+CLAUDE.md

--- a/src/synth_panel/registry/__init__.py
+++ b/src/synth_panel/registry/__init__.py
@@ -1,0 +1,22 @@
+"""Pack registry support.
+
+Resolves remote pack sources (`gh:`, `github.com/blob/`,
+`raw.githubusercontent.com`) to raw-content URLs. Fetch + cache
+layers live in sibling modules (added in later tickets).
+"""
+
+from synth_panel.registry.github import (
+    DEFAULT_PATH,
+    DEFAULT_REF,
+    GitHubSource,
+    parse_gh_source,
+    resolve_source,
+)
+
+__all__ = [
+    "DEFAULT_PATH",
+    "DEFAULT_REF",
+    "GitHubSource",
+    "parse_gh_source",
+    "resolve_source",
+]

--- a/src/synth_panel/registry/github.py
+++ b/src/synth_panel/registry/github.py
@@ -1,0 +1,233 @@
+"""GitHub URL resolver for remote pack sources.
+
+Accepted source forms:
+
+- ``gh:user/repo`` — defaults to ``ref=main``, ``path=synthpanel-pack.yaml``
+- ``gh:user/repo@ref``
+- ``gh:user/repo:path``
+- ``gh:user/repo@ref:path``
+- ``https://raw.githubusercontent.com/...`` — passthrough
+- ``https://github.com/user/repo/blob/ref/path`` — rewritten to raw
+
+When the default path is used (no ``:path`` given) and the default file
+is not present (HTTP 404), the resolver falls back to listing the repo
+root via the GitHub Contents API and selects the single ``*.yaml`` or
+``*.yml`` at the root. Zero or multiple candidates raise ``ValueError``.
+
+Per S-gate OQ1, the default publishable path is ``synthpanel-pack.yaml``
+— namespaced to avoid collisions with unrelated ``pack.yaml`` files.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+import httpx
+
+RAW_BASE = "https://raw.githubusercontent.com"
+GITHUB_API_BASE = "https://api.github.com"
+DEFAULT_REF = "main"
+DEFAULT_PATH = "synthpanel-pack.yaml"
+
+_HTTP_TIMEOUT = 10.0
+
+
+@dataclass(frozen=True)
+class GitHubSource:
+    """Parsed components of a ``gh:user/repo[@ref][:path]`` source spec.
+
+    ``path_is_explicit`` indicates whether the user supplied ``:path``
+    explicitly; the resolver only attempts the single-yaml fallback when
+    this is ``False``.
+    """
+
+    user: str
+    repo: str
+    ref: str
+    path: str
+    path_is_explicit: bool
+
+
+def parse_gh_source(source: str) -> GitHubSource:
+    """Parse a ``gh:`` source spec into a :class:`GitHubSource`.
+
+    Raises ``ValueError`` with a precise message for malformed input
+    (missing ``user/repo``, empty segments, etc.).
+    """
+    if not isinstance(source, str):
+        raise ValueError(f"gh source must be a string, got {type(source).__name__}")
+    if not source.startswith("gh:"):
+        raise ValueError(f"not a gh: source: {source!r}")
+
+    body = source[len("gh:") :]
+    if not body:
+        raise ValueError("empty gh: source (expected gh:user/repo[@ref][:path])")
+
+    at_idx = body.find("@")
+    colon_idx = body.find(":")
+
+    if at_idx >= 0 and (colon_idx < 0 or at_idx < colon_idx):
+        user_repo = body[:at_idx]
+        rest = body[at_idx + 1 :]
+        rest_colon = rest.find(":")
+        if rest_colon >= 0:
+            ref = rest[:rest_colon]
+            path: str | None = rest[rest_colon + 1 :]
+        else:
+            ref = rest
+            path = None
+    else:
+        if colon_idx >= 0:
+            user_repo = body[:colon_idx]
+            path = body[colon_idx + 1 :]
+        else:
+            user_repo = body
+            path = None
+        ref = DEFAULT_REF
+
+    parts = user_repo.split("/")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError(
+            f"invalid user/repo in gh: source {source!r} "
+            "(expected gh:user/repo[@ref][:path])"
+        )
+    user, repo = parts
+
+    if not ref:
+        raise ValueError(f"empty ref in gh: source {source!r}")
+    if path is not None and not path:
+        raise ValueError(f"empty path in gh: source {source!r}")
+
+    path_is_explicit = path is not None
+    return GitHubSource(
+        user=user,
+        repo=repo,
+        ref=ref,
+        path=path if path_is_explicit else DEFAULT_PATH,
+        path_is_explicit=path_is_explicit,
+    )
+
+
+def resolve_source(
+    source: str,
+    *,
+    client: httpx.Client | None = None,
+) -> str:
+    """Resolve any supported source spec to a raw-content URL.
+
+    If ``source`` is a ``gh:`` URI with no explicit ``:path`` and the
+    default path 404s, the repo root is inspected via the GitHub
+    Contents API to locate a single ``*.yaml``/``*.yml`` file.
+
+    ``client`` is an optional pre-configured :class:`httpx.Client`
+    (used by tests with ``MockTransport``); when omitted, a fresh
+    client with a 10-second timeout is created for the call.
+    """
+    if source.startswith("gh:"):
+        parsed = parse_gh_source(source)
+        return _resolve_github(parsed, client=client)
+    if source.startswith("https://raw.githubusercontent.com/"):
+        return source
+    if source.startswith("https://github.com/"):
+        return _rewrite_blob_url(source)
+    raise ValueError(
+        f"unsupported pack source {source!r} "
+        "(expected gh:user/repo..., https://github.com/... or https://raw.githubusercontent.com/...)"
+    )
+
+
+def _resolve_github(
+    parsed: GitHubSource,
+    *,
+    client: httpx.Client | None,
+) -> str:
+    default_url = _raw_url(parsed.user, parsed.repo, parsed.ref, parsed.path)
+    if parsed.path_is_explicit:
+        return default_url
+
+    owns_client = client is None
+    client = client or httpx.Client(timeout=_HTTP_TIMEOUT, follow_redirects=True)
+    try:
+        resp = client.head(default_url)
+        if resp.status_code == 200:
+            return default_url
+        if resp.status_code == 404:
+            return _fallback_root_yaml(parsed, client)
+        raise ValueError(
+            f"unexpected HTTP {resp.status_code} probing {default_url} "
+            "(expected 200 or 404)"
+        )
+    finally:
+        if owns_client:
+            client.close()
+
+
+def _fallback_root_yaml(parsed: GitHubSource, client: httpx.Client) -> str:
+    api_url = (
+        f"{GITHUB_API_BASE}/repos/{parsed.user}/{parsed.repo}/contents/"
+        f"?ref={parsed.ref}"
+    )
+    resp = client.get(api_url)
+    if resp.status_code == 404:
+        raise ValueError(
+            f"repo or ref not found: {parsed.user}/{parsed.repo}@{parsed.ref}"
+        )
+    if resp.status_code != 200:
+        raise ValueError(
+            f"cannot list repo contents (HTTP {resp.status_code}): {api_url}"
+        )
+
+    try:
+        items = resp.json()
+    except ValueError as exc:
+        raise ValueError(f"malformed JSON from {api_url}: {exc}") from exc
+    if not isinstance(items, list):
+        raise ValueError(
+            f"expected a list of repo contents from {api_url}, got {type(items).__name__}"
+        )
+
+    yamls = [
+        item["name"]
+        for item in items
+        if isinstance(item, dict)
+        and item.get("type") == "file"
+        and isinstance(item.get("name"), str)
+        and (item["name"].endswith(".yaml") or item["name"].endswith(".yml"))
+    ]
+    if not yamls:
+        raise ValueError(
+            f"no *.yaml at root of {parsed.user}/{parsed.repo}@{parsed.ref}; "
+            f"expected {DEFAULT_PATH} or a single root-level yaml"
+        )
+    if len(yamls) > 1:
+        raise ValueError(
+            f"multiple yaml files at root of {parsed.user}/{parsed.repo}@{parsed.ref}: "
+            f"{sorted(yamls)}; specify one explicitly with gh:{parsed.user}/{parsed.repo}"
+            f"{'@' + parsed.ref if parsed.ref != DEFAULT_REF else ''}:<path>"
+        )
+    return _raw_url(parsed.user, parsed.repo, parsed.ref, yamls[0])
+
+
+_BLOB_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/blob/(.+)$")
+
+
+def _rewrite_blob_url(url: str) -> str:
+    match = _BLOB_RE.match(url)
+    if not match:
+        raise ValueError(
+            f"unsupported github.com URL {url!r} "
+            "(expected https://github.com/user/repo/blob/ref/path)"
+        )
+    user, repo, tail = match.group(1), match.group(2), match.group(3)
+    ref, _, path = tail.partition("/")
+    if not ref or not path:
+        raise ValueError(
+            f"malformed github.com/blob/ URL {url!r} "
+            "(expected .../blob/<ref>/<path>)"
+        )
+    return _raw_url(user, repo, ref, path)
+
+
+def _raw_url(user: str, repo: str, ref: str, path: str) -> str:
+    return f"{RAW_BASE}/{user}/{repo}/{ref}/{path}"

--- a/src/synth_panel/registry/github.py
+++ b/src/synth_panel/registry/github.py
@@ -88,10 +88,7 @@ def parse_gh_source(source: str) -> GitHubSource:
 
     parts = user_repo.split("/")
     if len(parts) != 2 or not all(parts):
-        raise ValueError(
-            f"invalid user/repo in gh: source {source!r} "
-            "(expected gh:user/repo[@ref][:path])"
-        )
+        raise ValueError(f"invalid user/repo in gh: source {source!r} (expected gh:user/repo[@ref][:path])")
     user, repo = parts
 
     if not ref:
@@ -154,38 +151,26 @@ def _resolve_github(
             return default_url
         if resp.status_code == 404:
             return _fallback_root_yaml(parsed, client)
-        raise ValueError(
-            f"unexpected HTTP {resp.status_code} probing {default_url} "
-            "(expected 200 or 404)"
-        )
+        raise ValueError(f"unexpected HTTP {resp.status_code} probing {default_url} (expected 200 or 404)")
     finally:
         if owns_client:
             client.close()
 
 
 def _fallback_root_yaml(parsed: GitHubSource, client: httpx.Client) -> str:
-    api_url = (
-        f"{GITHUB_API_BASE}/repos/{parsed.user}/{parsed.repo}/contents/"
-        f"?ref={parsed.ref}"
-    )
+    api_url = f"{GITHUB_API_BASE}/repos/{parsed.user}/{parsed.repo}/contents/?ref={parsed.ref}"
     resp = client.get(api_url)
     if resp.status_code == 404:
-        raise ValueError(
-            f"repo or ref not found: {parsed.user}/{parsed.repo}@{parsed.ref}"
-        )
+        raise ValueError(f"repo or ref not found: {parsed.user}/{parsed.repo}@{parsed.ref}")
     if resp.status_code != 200:
-        raise ValueError(
-            f"cannot list repo contents (HTTP {resp.status_code}): {api_url}"
-        )
+        raise ValueError(f"cannot list repo contents (HTTP {resp.status_code}): {api_url}")
 
     try:
         items = resp.json()
     except ValueError as exc:
         raise ValueError(f"malformed JSON from {api_url}: {exc}") from exc
     if not isinstance(items, list):
-        raise ValueError(
-            f"expected a list of repo contents from {api_url}, got {type(items).__name__}"
-        )
+        raise ValueError(f"expected a list of repo contents from {api_url}, got {type(items).__name__}")
 
     yamls = [
         item["name"]
@@ -215,17 +200,11 @@ _BLOB_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/blob/(.+)$")
 def _rewrite_blob_url(url: str) -> str:
     match = _BLOB_RE.match(url)
     if not match:
-        raise ValueError(
-            f"unsupported github.com URL {url!r} "
-            "(expected https://github.com/user/repo/blob/ref/path)"
-        )
+        raise ValueError(f"unsupported github.com URL {url!r} (expected https://github.com/user/repo/blob/ref/path)")
     user, repo, tail = match.group(1), match.group(2), match.group(3)
     ref, _, path = tail.partition("/")
     if not ref or not path:
-        raise ValueError(
-            f"malformed github.com/blob/ URL {url!r} "
-            "(expected .../blob/<ref>/<path>)"
-        )
+        raise ValueError(f"malformed github.com/blob/ URL {url!r} (expected .../blob/<ref>/<path>)")
     return _raw_url(user, repo, ref, path)
 
 

--- a/tests/test_registry_github_resolver.py
+++ b/tests/test_registry_github_resolver.py
@@ -1,0 +1,276 @@
+"""Tests for the GitHub URL resolver (``synth_panel.registry.github``)."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from synth_panel.registry.github import (
+    DEFAULT_PATH,
+    DEFAULT_REF,
+    GitHubSource,
+    parse_gh_source,
+    resolve_source,
+)
+
+# ---------- parse_gh_source ----------
+
+
+def test_parse_gh_default_ref_and_path() -> None:
+    parsed = parse_gh_source("gh:owner/repo")
+    assert parsed == GitHubSource(
+        user="owner",
+        repo="repo",
+        ref=DEFAULT_REF,
+        path=DEFAULT_PATH,
+        path_is_explicit=False,
+    )
+
+
+def test_parse_gh_with_ref() -> None:
+    parsed = parse_gh_source("gh:owner/repo@v1.2")
+    assert parsed.ref == "v1.2"
+    assert parsed.path == DEFAULT_PATH
+    assert parsed.path_is_explicit is False
+
+
+def test_parse_gh_with_explicit_path() -> None:
+    parsed = parse_gh_source("gh:owner/repo:packs/custom.yaml")
+    assert parsed.ref == DEFAULT_REF
+    assert parsed.path == "packs/custom.yaml"
+    assert parsed.path_is_explicit is True
+
+
+def test_parse_gh_with_ref_and_path() -> None:
+    parsed = parse_gh_source("gh:owner/repo@abc123:nested/dir/pack.yaml")
+    assert parsed.ref == "abc123"
+    assert parsed.path == "nested/dir/pack.yaml"
+    assert parsed.path_is_explicit is True
+
+
+def test_parse_gh_repo_name_with_dots() -> None:
+    parsed = parse_gh_source("gh:my-org/repo.name")
+    assert parsed.user == "my-org"
+    assert parsed.repo == "repo.name"
+
+
+def test_parse_gh_path_with_at_sign_after_colon() -> None:
+    # When ':' precedes '@', '@' must be treated as part of the path,
+    # not a ref delimiter.
+    parsed = parse_gh_source("gh:u/r:weird@name.yaml")
+    assert parsed.ref == DEFAULT_REF
+    assert parsed.path == "weird@name.yaml"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "gh:",
+        "gh:user",
+        "gh:/repo",
+        "gh:user/",
+        "gh:@ref",
+        "gh:user/repo@",
+        "gh:user/repo:",
+        "gh:user/repo@ref:",
+        "gh:user/repo/extra",
+    ],
+)
+def test_parse_gh_malformed_raises(source: str) -> None:
+    with pytest.raises(ValueError):
+        parse_gh_source(source)
+
+
+def test_parse_gh_non_gh_source_raises() -> None:
+    with pytest.raises(ValueError):
+        parse_gh_source("https://example.com/pack.yaml")
+
+
+# ---------- resolve_source (gh: variants, explicit paths) ----------
+
+
+def _explode(request: httpx.Request) -> httpx.Response:
+    raise AssertionError(f"unexpected network call: {request.method} {request.url}")
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def test_resolve_explicit_path_never_calls_network() -> None:
+    with _client(_explode) as client:
+        url = resolve_source("gh:owner/repo@v1:pkgs/my.yaml", client=client)
+    assert url == "https://raw.githubusercontent.com/owner/repo/v1/pkgs/my.yaml"
+
+
+def test_resolve_default_path_hit() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "HEAD"
+        assert request.url.host == "raw.githubusercontent.com"
+        assert request.url.path == f"/owner/repo/{DEFAULT_REF}/{DEFAULT_PATH}"
+        return httpx.Response(200)
+
+    with _client(handler) as client:
+        url = resolve_source("gh:owner/repo", client=client)
+    assert url == f"https://raw.githubusercontent.com/owner/repo/{DEFAULT_REF}/{DEFAULT_PATH}"
+
+
+def test_resolve_default_path_404_fallback_single_yaml() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            assert request.method == "HEAD"
+            return httpx.Response(404)
+        assert request.url.host == "api.github.com"
+        assert request.url.path == "/repos/owner/repo/contents/"
+        assert request.url.params.get("ref") == DEFAULT_REF
+        return httpx.Response(
+            200,
+            json=[
+                {"name": "README.md", "type": "file"},
+                {"name": "docs", "type": "dir"},
+                {"name": "only-pack.yaml", "type": "file"},
+            ],
+        )
+
+    with _client(handler) as client:
+        url = resolve_source("gh:owner/repo", client=client)
+    assert url == "https://raw.githubusercontent.com/owner/repo/main/only-pack.yaml"
+
+
+def test_resolve_default_path_404_fallback_single_yml_extension() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            return httpx.Response(404)
+        return httpx.Response(
+            200,
+            json=[{"name": "spec.yml", "type": "file"}],
+        )
+
+    with _client(handler) as client:
+        url = resolve_source("gh:owner/repo", client=client)
+    assert url.endswith("/spec.yml")
+
+
+def test_resolve_default_path_404_fallback_zero_yamls_rejects() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            return httpx.Response(404)
+        return httpx.Response(
+            200,
+            json=[
+                {"name": "README.md", "type": "file"},
+                {"name": "LICENSE", "type": "file"},
+            ],
+        )
+
+    with _client(handler) as client, pytest.raises(ValueError, match="no .*yaml"):
+        resolve_source("gh:owner/repo", client=client)
+
+
+def test_resolve_default_path_404_fallback_multiple_yamls_rejects() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            return httpx.Response(404)
+        return httpx.Response(
+            200,
+            json=[
+                {"name": "one.yaml", "type": "file"},
+                {"name": "two.yaml", "type": "file"},
+            ],
+        )
+
+    with _client(handler) as client, pytest.raises(ValueError, match="multiple yaml"):
+        resolve_source("gh:owner/repo", client=client)
+
+
+def test_resolve_default_path_404_api_404_reports_missing_repo() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            return httpx.Response(404)
+        return httpx.Response(404, json={"message": "Not Found"})
+
+    with _client(handler) as client, pytest.raises(ValueError, match="repo or ref not found"):
+        resolve_source("gh:owner/repo", client=client)
+
+
+def test_resolve_default_path_unexpected_status_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    with _client(handler) as client, pytest.raises(ValueError, match="HTTP 500"):
+        resolve_source("gh:owner/repo", client=client)
+
+
+def test_resolve_default_path_fallback_ignores_directories() -> None:
+    # A directory whose name ends in .yaml should not be treated as a file.
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            return httpx.Response(404)
+        return httpx.Response(
+            200,
+            json=[
+                {"name": "fake.yaml", "type": "dir"},
+                {"name": "real-pack.yaml", "type": "file"},
+            ],
+        )
+
+    with _client(handler) as client:
+        url = resolve_source("gh:owner/repo", client=client)
+    assert url.endswith("/real-pack.yaml")
+
+
+def test_resolve_fallback_honors_ref() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.host == "raw.githubusercontent.com":
+            assert request.url.path == "/owner/repo/v2.0/synthpanel-pack.yaml"
+            return httpx.Response(404)
+        assert request.url.params.get("ref") == "v2.0"
+        return httpx.Response(200, json=[{"name": "alt.yaml", "type": "file"}])
+
+    with _client(handler) as client:
+        url = resolve_source("gh:owner/repo@v2.0", client=client)
+    assert url == "https://raw.githubusercontent.com/owner/repo/v2.0/alt.yaml"
+
+
+# ---------- resolve_source (https passthrough / blob rewrite) ----------
+
+
+def test_resolve_raw_url_passthrough_no_network() -> None:
+    url = "https://raw.githubusercontent.com/u/r/main/pack.yaml"
+    with _client(_explode) as client:
+        assert resolve_source(url, client=client) == url
+
+
+def test_resolve_blob_url_rewritten_no_network() -> None:
+    with _client(_explode) as client:
+        url = resolve_source(
+            "https://github.com/owner/repo/blob/v1.0/packs/pack.yaml",
+            client=client,
+        )
+    assert url == "https://raw.githubusercontent.com/owner/repo/v1.0/packs/pack.yaml"
+
+
+def test_resolve_blob_url_with_nested_path() -> None:
+    url = resolve_source(
+        "https://github.com/owner/repo/blob/main/a/b/c/pack.yaml",
+    )
+    assert url == "https://raw.githubusercontent.com/owner/repo/main/a/b/c/pack.yaml"
+
+
+def test_resolve_github_non_blob_url_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported github.com URL"):
+        resolve_source("https://github.com/owner/repo/tree/main")
+
+
+def test_resolve_github_blob_missing_path_rejected() -> None:
+    with pytest.raises(ValueError):
+        resolve_source("https://github.com/owner/repo/blob/main")
+
+
+def test_resolve_unsupported_scheme_rejected() -> None:
+    with pytest.raises(ValueError, match="unsupported pack source"):
+        resolve_source("ftp://example.com/pack.yaml")
+    with pytest.raises(ValueError, match="unsupported pack source"):
+        resolve_source("/local/path.yaml")


### PR DESCRIPTION
## Summary
- Add a `gh:` URL resolver so persona/instrument packs can be installed directly from a GitHub repo path (`gh:owner/repo/path`) without users having to download manually first
- Includes a safety-net auto-save commit for uncommitted implementation work (gt-pvx)

## Source
- Polecat: toast
- Issue: sp-udsv
- MR: sp-wisp-2j0
- Branch: polecat/toast-moaxiinr

## Test plan
- [ ] CI passes (new coverage in test_registry_github_resolver.py)
- [ ] `synthpanel panel run --personas gh:owner/repo/packs/foo.yaml` resolves against a known public repo

## Note
Two commits on the branch — the auto-save safety-net commit is intentionally part of this PR per gt-pvx protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)