### PR TITLE
feat(reporting): implement load_panel_json + ReportLoadError (sp-kwhl)

### DIFF
--- a/src/synth_panel/reporting/loader.py
+++ b/src/synth_panel/reporting/loader.py
@@ -1,11 +1,21 @@
-"""Loader stubs for post-hoc panel reporting.
+"""Loader for post-hoc panel reporting (sp-viz-layer T2).
 
-Scaffold for sp-viz-layer T1 — bodies raise :class:`NotImplementedError`.
-T2 fills in the path-or-ID resolution and the failure taxonomy.
+Resolves a RESULT_ID-or-path to a parsed panel-result ``dict`` and raises a
+single exception type, :class:`ReportLoadError`, with a discriminator
+``.code`` attribute for the three failure modes used by the CLI.
+
+The resolution policy mirrors :func:`handle_panel_inspect` and
+:func:`handle_analyze` for behavioural parity: a ``result_ref`` that ends
+in ``.json`` *and* refers to an existing path is read from disk; anything
+else is delegated to :func:`synth_panel.mcp.data.get_panel_result`. This
+means an ID that happens to end in ``.json`` or a path that looks like an
+ID but does not exist on disk both fall through to the MCP-data store.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
 from typing import Any
 
 
@@ -26,14 +36,34 @@ class ReportLoadError(Exception):
 def load_panel_json(result_ref: str) -> dict[str, Any]:
     """Resolve a panel result ID or file path to a parsed JSON dict.
 
-    Mirrors the path-or-ID resolution used by ``handle_panel_inspect`` and
-    ``handle_analyze``: paths ending in ``.json`` that exist on disk are read
-    directly; anything else is delegated to
+    If ``result_ref`` ends in ``.json`` *and* the corresponding path exists,
+    it is read from disk and ``data["id"]`` is defaulted to the path stem.
+    Otherwise the call is delegated to
     :func:`synth_panel.mcp.data.get_panel_result`.
 
     Raises:
-        ReportLoadError: with ``.code`` set to ``"not_found"``,
-            ``"invalid_json"``, or ``"invalid_shape"`` per the failure mode.
+        ReportLoadError: with ``.code`` set to ``"not_found"`` for missing
+            paths/IDs, ``"invalid_json"`` for malformed JSON, or
+            ``"invalid_shape"`` if the parsed root is not a ``dict``.
     """
 
-    raise NotImplementedError("sp-viz-layer T2: implement load_panel_json")
+    path = Path(result_ref)
+    if result_ref.endswith(".json") and path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ReportLoadError("invalid_json", f"not valid JSON: {result_ref}: {exc}") from exc
+        if isinstance(data, dict):
+            data.setdefault("id", path.stem)
+    else:
+        from synth_panel.mcp.data import get_panel_result
+
+        try:
+            data = get_panel_result(result_ref)
+        except FileNotFoundError as exc:
+            raise ReportLoadError("not_found", f"panel result not found: {result_ref}") from exc
+
+    if not isinstance(data, dict):
+        raise ReportLoadError("invalid_shape", "panel result is not a JSON object")
+
+    return data

--- a/tests/test_reporting_loader.py
+++ b/tests/test_reporting_loader.py
@@ -1,5 +1,87 @@
-"""Tests for synth_panel.reporting.loader.
+"""Tests for :mod:`synth_panel.reporting.loader` (sp-viz-layer T2).
 
-Scaffold for sp-viz-layer T1 — tests are filled in by T2 per
-structure.md §6.
+Covers the five core cases from structure.md §6 plus the path-vs-ID
+disambiguation edge cases flagged in plan.md Risk #3.
 """
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synth_panel.reporting.loader import ReportLoadError, load_panel_json
+
+FIXTURES = Path(__file__).parent / "fixtures" / "reporting"
+
+
+def test_load_from_path_happy():
+    """A real fixture JSON path returns a dict with the stem as ``id``."""
+    path = FIXTURES / "rounds_shape.json"
+    data = load_panel_json(str(path))
+    assert isinstance(data, dict)
+    assert data["id"] == "rounds_shape"
+    assert "rounds" in data
+
+
+def test_load_from_id_delegates_to_mcp_data(monkeypatch):
+    """A bare ID that does not refer to a file delegates to MCP data."""
+    sentinel = {"id": "result-xyz", "model": "claude-sonnet-4-6"}
+    captured: dict[str, str] = {}
+
+    def fake_get(result_id: str) -> dict:
+        captured["id"] = result_id
+        return sentinel
+
+    monkeypatch.setattr("synth_panel.mcp.data.get_panel_result", fake_get)
+
+    data = load_panel_json("result-xyz")
+    assert data is sentinel
+    assert captured["id"] == "result-xyz"
+
+
+def test_load_missing_file_raises_not_found(tmp_path, monkeypatch):
+    """A bare ID with no matching pack file surfaces as ``not_found``.
+
+    Also covers plan.md Risk #3's 'path that does not exist but looks
+    like an ID' ambiguity — the input falls through to MCP data because
+    it has no ``.json`` suffix, and the empty data dir forces a miss.
+    """
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    with pytest.raises(ReportLoadError) as exc_info:
+        load_panel_json("missing-result-id")
+    assert exc_info.value.code == "not_found"
+
+
+def test_load_invalid_json_raises_invalid_json(tmp_path):
+    """A path whose contents are not valid JSON raises ``invalid_json``."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ this is not json", encoding="utf-8")
+    with pytest.raises(ReportLoadError) as exc_info:
+        load_panel_json(str(bad))
+    assert exc_info.value.code == "invalid_json"
+
+
+def test_load_non_object_root_raises_invalid_shape(tmp_path):
+    """A JSON root that is not an object raises ``invalid_shape``."""
+    arr = tmp_path / "arr.json"
+    arr.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ReportLoadError) as exc_info:
+        load_panel_json(str(arr))
+    assert exc_info.value.code == "invalid_shape"
+
+
+def test_id_ending_in_json_falls_through_to_mcp_data(monkeypatch):
+    """Plan.md Risk #3: an ID that happens to end in ``.json`` but has no
+    matching file on disk must delegate to MCP data, not crash."""
+    captured: dict[str, str] = {}
+
+    def fake_get(result_id: str) -> dict:
+        captured["id"] = result_id
+        return {"id": result_id, "rounds": []}
+
+    monkeypatch.setattr("synth_panel.mcp.data.get_panel_result", fake_get)
+
+    data = load_panel_json("looks-like-a-file.json")
+    assert captured["id"] == "looks-like-a-file.json"
+    assert data["id"] == "looks-like-a-file.json"


### PR DESCRIPTION
## Summary
- Implement `load_panel_json` in the reporting loader (scaffolded by PR #239)
- Add dedicated `ReportLoadError` so callers distinguish report-loading failures from generic IO/JSON errors

## Source
- Polecat: dementus
- Issue: sp-kwhl
- MR: sp-wisp-sae
- Branch: polecat/dementus-mobmytfg

## Test plan
- [ ] CI passes (updated coverage in test_reporting_loader.py)
- [ ] Malformed result JSON raises `ReportLoadError`, not a bare JSONDecodeError

## Conflict note
Touches src/synth_panel/reporting/loader.py and tests/test_reporting_loader.py — overlaps with PR #243 (sp-u88v, reporting/markdown.py) only at test-file sibling level. Low conflict risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)