### PR TITLE
feat(cli): wire synthpanel report subcommand (sp-awfz)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -2932,6 +2932,65 @@ def handle_analyze(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return 0
 
 
+def handle_report(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Render a saved panel result as a Markdown report (sp-viz-layer T4).
+
+    Resolves the RESULT (ID or ``.json`` path), walks it through
+    :func:`build_inspect_report`, and emits Markdown via
+    :func:`render_markdown`. Destination is stdout by default; ``--output
+    PATH`` writes to disk (``-`` explicitly means stdout).
+
+    Error parity with :func:`handle_panel_inspect`: a :exc:`ReportLoadError`
+    prints to stderr in TEXT mode and is ``emit``-ted as a JSON/NDJSON
+    error payload otherwise, returning exit code 1.
+
+    S-gate OQ3: in JSON/NDJSON modes with ``--output FILE``, the handler is
+    silent — the file IS the output, no status line on stdout. TEXT mode
+    emits a stderr status line when writing to a file so humans see
+    confirmation without polluting stdout.
+    """
+    from synth_panel.analysis.inspect import build_inspect_report
+    from synth_panel.reporting import ReportLoadError, load_panel_json, render_markdown
+
+    result_ref = args.result
+
+    try:
+        data = load_panel_json(result_ref)
+    except ReportLoadError as err:
+        msg = f"Error: {err}"
+        if fmt is OutputFormat.TEXT:
+            print(msg, file=sys.stderr)
+        else:
+            emit(fmt, message=msg, extra={"error": err.code})
+        return 1
+
+    resolved_path: Path | None = None
+    candidate = Path(result_ref)
+    if result_ref.endswith(".json") and candidate.exists():
+        resolved_path = candidate
+
+    report = build_inspect_report(data)
+    md = render_markdown(
+        report,
+        data,
+        source_path=str(resolved_path) if resolved_path is not None else None,
+    )
+
+    output_arg = getattr(args, "output", None)
+    if output_arg is None or output_arg == "-":
+        sys.stdout.write(md)
+        return 0
+
+    out_path = Path(output_arg)
+    out_path.write_text(md, encoding="utf-8")
+
+    if fmt is OutputFormat.TEXT:
+        print(f"Report written: {out_path} ({len(md)} bytes)", file=sys.stderr)
+    # JSON/NDJSON: silent per S-gate OQ3 — the file is the output.
+
+    return 0
+
+
 def _format_path(path: list[dict[str, Any]]) -> str:
     """Render an executed branching path as a single human line.
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -693,6 +693,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Output format (default: text).",
     )
 
+    # report (sp-viz-layer T4): render a saved panel result as Markdown.
+    report_parser = subparsers.add_parser(
+        "report",
+        help="Render a saved panel result as a shareable Markdown report.",
+    )
+    report_parser.add_argument(
+        "result",
+        metavar="RESULT",
+        help="Panel result ID or path to a result JSON file.",
+    )
+    report_parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        metavar="PATH",
+        help="Write to PATH instead of stdout ('-' = stdout, default).",
+    )
+    report_parser.add_argument(
+        "--format",
+        default="markdown",
+        choices=["markdown"],
+        help="Report format (default: markdown). HTML reserved for v2.",
+    )
+
     # mcp-serve
     subparsers.add_parser(
         "mcp-serve",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -26,6 +26,7 @@ from synth_panel.cli.commands import (
     handle_panel_run,
     handle_panel_synthesize,
     handle_prompt,
+    handle_report,
     handle_whoami,
 )
 from synth_panel.cli.output import OutputFormat
@@ -91,6 +92,8 @@ def main(argv: list[str] | None = None) -> int:
             return 1
     elif args.command == "analyze":
         return handle_analyze(args, output_format)
+    elif args.command == "report":
+        return handle_report(args, output_format)
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
     elif args.command == "login":

--- a/tests/test_cli_report.py
+++ b/tests/test_cli_report.py
@@ -1,5 +1,94 @@
-"""Tests for the ``synthpanel report`` CLI subcommand.
+"""CLI integration tests for ``synthpanel report`` (sp-viz-layer T4).
 
-Scaffold for sp-viz-layer T1 — tests are filled in by T4 per
-structure.md §6.
+Covers the five cases listed in ``specs/sp-viz-layer/structure.md`` §6:
+stdout-happy-path, file-output, not-found in TEXT and JSON modes, and
+malformed JSON on disk. Each test drives the full :func:`main` entry
+point so parser-wiring regressions surface here.
 """
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from synth_panel.main import main
+from synth_panel.reporting.markdown import BANNER, FOOTER
+
+FIXTURES = Path(__file__).parent / "fixtures" / "reporting"
+
+
+def test_report_to_stdout(capsys):
+    """``synthpanel report <fixture.json>`` writes Markdown to stdout."""
+    fixture = FIXTURES / "flat_shape.json"
+
+    code = main(["report", str(fixture)])
+
+    assert code == 0
+    captured = capsys.readouterr()
+    assert "# Panel Report:" in captured.out
+    assert BANNER in captured.out
+    assert FOOTER in captured.out
+    # Nothing on stderr when writing to stdout.
+    assert captured.err == ""
+
+
+def test_report_to_file(tmp_path, capsys):
+    """``synthpanel report <fixture.json> -o FILE`` writes Markdown to FILE."""
+    fixture = FIXTURES / "flat_shape.json"
+    out_file = tmp_path / "report.md"
+
+    code = main(["report", str(fixture), "-o", str(out_file)])
+
+    assert code == 0
+    assert out_file.exists()
+    contents = out_file.read_text(encoding="utf-8")
+    assert "# Panel Report:" in contents
+    assert BANNER in contents
+    assert FOOTER in contents
+
+    captured = capsys.readouterr()
+    # TEXT mode emits a status line to stderr so humans get confirmation.
+    assert "Report written" in captured.err
+    assert str(out_file) in captured.err
+    # stdout stays clean — the file is the output.
+    assert captured.out == ""
+
+
+def test_report_not_found_returns_1_stderr(tmp_path, monkeypatch, capsys):
+    """Missing result in TEXT mode: exit 1 with error message on stderr."""
+    # Point the MCP data dir at an empty tmp_path so the lookup misses.
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+
+    code = main(["report", "no-such-result-id"])
+
+    assert code == 1
+    captured = capsys.readouterr()
+    assert "Error" in captured.err
+    assert "no-such-result-id" in captured.err
+    assert captured.out == ""
+
+
+def test_report_not_found_returns_1_json_error(tmp_path, monkeypatch, capsys):
+    """Missing result in JSON mode: exit 1 with a JSON error payload on stdout."""
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+
+    code = main(["--output-format", "json", "report", "no-such-result-id"])
+
+    assert code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["error"] == "not_found"
+    assert "no-such-result-id" in payload["message"]
+
+
+def test_report_invalid_json_returns_1(tmp_path, capsys):
+    """A ``.json`` file with malformed contents: exit 1 with invalid_json."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ this is not json", encoding="utf-8")
+
+    code = main(["--output-format", "json", "report", str(bad)])
+
+    assert code == 1
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["error"] == "invalid_json"


### PR DESCRIPTION
## Summary
- Wire the `synthpanel report` subcommand into the CLI parser + dispatch (reporting module + loader + renderer landed in #239 / #243 / #244)
- Users can now run `synthpanel report <result.json>` end-to-end

## Source
- Polecat: nux
- Issue: sp-awfz
- MR: sp-wisp-6v5
- Branch: polecat/nux-mobnovlw

## Test plan
- [ ] CI passes (new coverage in test_cli_report.py)
- [ ] `synthpanel report --help` lists the subcommand; a fixture result renders to stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)