### PR TITLE
docs(convergence): document per_question[key].calibration wire format (sp-7npy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Documentation
+- (sp-7npy) Convergence: document the shipped inline-calibration wire format as `per_question[key].calibration` (a sub-object with `jsd`, `baseline_spec`, `extractor`, `auto_derived`, and — on disjoint supports — `alignment_error`). A flat `per_question[key].human_jsd` scalar was considered during D-gate of sp-inline-calibration and rejected in favor of the sub-object shape; this field was never shipped, so no code removal is needed. Any downstream consumer that wrote speculative code against `.human_jsd` should migrate to `.calibration.jsd`. `sp-pack-registry` fingerprints depend on the sub-object shape.
+
 ## [0.9.9] - 2026-04-22
 
 ### Fixed

--- a/src/synth_panel/convergence.py
+++ b/src/synth_panel/convergence.py
@@ -463,6 +463,16 @@ class ConvergenceTracker:
                     "curve": [{"n": n, "jsd": round(jsd, 6)} for n, jsd in curve],
                     "support_size": len(state.cumulative),
                 }
+                # Wire format (sp-7npy): inline calibration is attached as
+                # ``per_question[key].calibration`` — a sub-object with
+                # ``jsd``, ``baseline_spec``, ``extractor``, ``auto_derived``,
+                # and (on disjoint supports) ``alignment_error``. A flat
+                # ``per_question[key].human_jsd`` scalar was considered during
+                # D-gate and rejected in favor of this sub-object; it was
+                # never shipped. Downstream consumers that wrote speculative
+                # code against ``.human_jsd`` should migrate to
+                # ``.calibration.jsd``. sp-pack-registry fingerprints depend
+                # on the sub-object shape.
                 if human_dist is not None:
                     model_dist = {k: float(v) for k, v in state.cumulative.items()}
                     jsd = compute_calibration_jsd(model_dist, human_dist)


### PR DESCRIPTION
## Summary
- Document the shipped inline-calibration wire format (`per_question[key].calibration` sub-object) in CHANGELOG under Unreleased
- Add an inline comment above the `build_report()` calibration attachment block noting that a flat `.human_jsd` scalar was considered during D-gate of sp-inline-calibration and rejected — never shipped
- Flag `sp-pack-registry` as the downstream fingerprint consumer that depends on the sub-object shape

Pure docs, no behavior change. Heads off speculative downstream consumers that may have been written against the rejected flat-scalar sketch in `design.md` L18-20.

Closes sp-7npy (T5 of sp-inline-calibration).

## Test plan
- [x] `pytest tests/test_convergence_metric.py tests/test_calibration.py` — 42 passed
- [x] `python -c "from synth_panel.convergence import ConvergenceTracker"` imports clean
- [x] CHANGELOG entry placed under `[Unreleased]` → `Documentation`
- [x] Inline comment sits directly above the `if human_dist is not None:` branch in `build_report()`