### PR TITLE
docs: audit and refresh for v0.9.9 feature set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to synthpanel are documented here.
 
-For auto-generated release notes, see [GitHub Releases](https://github.com/DataViking-Tech/synth-panel/releases).
+For auto-generated release notes, see [GitHub Releases](https://github.com/DataViking-Tech/SynthPanel/releases).
 
 ## [Unreleased]
+
+### Added
+- (sp-5r88 / sp-a6jc / sp-ttwy / sp-bldz) Inline SynthBench calibration via `panel run --calibrate-against DATASET:QUESTION`. Force-enables convergence tracking against a published human baseline (v1 allowlist: `gss`, `ntia`), auto-derives a `pick_one` extractor schema from the baseline when option count ≤ 5 (override with `--extract-schema`), and attaches a `calibration` sub-object to every tracked question in the output. The sub-object carries `jsd`, `baseline_spec`, `extractor`, `auto_derived`, and — on disjoint supports — `alignment_error`. Requires `pip install 'synthpanel[convergence]'`. Cadence is NOT implicit — pair with `--convergence-check-every` to control sampling.
+- (sp-lk3w) Optional `version:` field on persona packs. MCP surfaces a non-fatal shadow warning when a user-installed pack shadows a bundled pack with an older version string, so silently-stale packs can't sit on top of a newer bundled definition.
+- (sp-udsv) `gh:` URL resolver — parses `gh:owner/repo[@ref][/path]` into raw-content URLs with tight allowlist validation. Foundation piece for `sp-pack-registry` (pack import from GitHub).
 
 ### Documentation
 - (sp-7npy) Convergence: document the shipped inline-calibration wire format as `per_question[key].calibration` (a sub-object with `jsd`, `baseline_spec`, `extractor`, `auto_derived`, and — on disjoint supports — `alignment_error`). A flat `per_question[key].human_jsd` scalar was considered during D-gate of sp-inline-calibration and rejected in favor of the sub-object shape; this field was never shipped, so no code removal is needed. Any downstream consumer that wrote speculative code against `.human_jsd` should migrate to `.calibration.jsd`. `sp-pack-registry` fingerprints depend on the sub-object shape.
@@ -233,12 +238,20 @@ Patch release in the 0.7.x series. See the [README Versions table](README.md#ver
 - Rounds-shaped panel output with `path`, `terminal_round`, and `warnings` fields
 - `extend_panel` MCP tool for ad-hoc follow-up rounds
 
-[Unreleased]: https://github.com/DataViking-Tech/synth-panel/compare/v0.8.0...HEAD
-[0.8.0]: https://github.com/DataViking-Tech/synth-panel/compare/v0.7.4...v0.8.0
-[0.7.4]: https://github.com/DataViking-Tech/synth-panel/compare/v0.7.0...v0.7.4
-[0.7.0]: https://github.com/DataViking-Tech/synth-panel/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/DataViking-Tech/synth-panel/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/DataViking-Tech/synth-panel/compare/v0.4.0...v0.5.0
-[0.4.1]: https://github.com/DataViking-Tech/synth-panel/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/DataViking-Tech/synth-panel/releases/tag/v0.4.0
-[0.3.0]: https://github.com/DataViking-Tech/synth-panel/releases/tag/v0.3.0
+[Unreleased]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.9...HEAD
+[0.9.9]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.8...v0.9.9
+[0.9.8]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.7...v0.9.8
+[0.9.7]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.6...v0.9.7
+[0.9.6]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.5...v0.9.6
+[0.9.5]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.4...v0.9.5
+[0.9.4]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.2...v0.9.4
+[0.9.2]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.9.0...v0.9.2
+[0.9.0]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.7.4...v0.8.0
+[0.7.4]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.7.0...v0.7.4
+[0.7.0]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.4.0...v0.5.0
+[0.4.1]: https://github.com/DataViking-Tech/SynthPanel/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/DataViking-Tech/SynthPanel/releases/tag/v0.4.0
+[0.3.0]: https://github.com/DataViking-Tech/SynthPanel/releases/tag/v0.3.0

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ arguments to override. Provider keys are read from environment variables
 (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`/`GEMINI_API_KEY`,
 `XAI_API_KEY`) — pass whichever your model requires.
 
-Pin to a specific version (`:0.9.4`) in production rather than `:latest`.
+Pin to a specific version (`:0.9.9`) in production rather than `:latest`.
 
 ## Use as a Python Library
 
@@ -763,6 +763,13 @@ baseline from [SynthBench](https://github.com/DataViking-Tech/synthbench) (insta
 
 | Version | Highlights |
 |---------|-----------|
+| 0.9.9 | `--synthesis-strategy=auto` now routes to map-reduce on context overflow instead of hard-failing; OpenRouter alias resolution tightened for sub-1¢ local-table sanity checks; `--personas-merge` warns (or errors via `--personas-merge-on-collision`) on name collisions with bundled packs; version single-sourced from `src/synth_panel/__version__.py` with templated site render |
+| 0.9.8 | Fail-loud synthesis (context-overflow pre-flight + structured `synthesis_error`), per-question map-reduce synthesis (`--synthesis-strategy=single\|map-reduce\|auto`), response-schema validation with deterministic distributions for bounded question types, rate-limit-aware client (`--max-concurrent`, `--rate-limit-rps`), live convergence telemetry + `--auto-stop`, 4 new bundled persona packs (`job-seekers`, `recruiters-talent`, `product-research`, `ai-eval-buyers`) raising shipped personas 24 → 84, `/synthpanel-poll` slash command |
+| 0.9.7 | Provider-reported cost is authoritative — when a provider returns `usage.cost` (e.g. OpenRouter), that value is recorded verbatim instead of being recomputed from a local pricing table; `pricing_fallback` warning surfaced when a model falls through to `DEFAULT_PRICING`; ensemble rounding no longer silently drops low-weight models |
+| 0.9.5 | Fail-fast on unsubstituted `{placeholder}` variables in instruments/personas, `--personas-merge PATH` for layered persona packs, `--dry-run` pre-run preview, `run_invalid` flag on degenerate runs, MCP BYOK detection routes through the credentials store |
+| 0.9.4 | `synthpanel login` / `logout` / `whoami` credential-store CLI; MCP recognises `OPENROUTER_API_KEY` as BYOK and picks a sensible default; Docker images on GHCR + Docker Hub multi-arch; MCP sampling fallback for `run_prompt` and `run_quick_poll` |
+| 0.9.0 | First release post-public-flip. Repo renamed to `SynthPanel` (PyPI name `synthpanel` unchanged) |
+| 0.8.0 | `lookup_pricing_by_provider` public helper for synthbench-format provider strings; multi-question CLI cost shape symmetry (`total_cost` / `panelist_cost` / `total_usage` / `panelist_usage`) |
 | 0.7.0 | Multi-model ensemble blending (`--blend`), OpenRouter provider support, temperature/top_p controls, prompt template customization |
 | 0.6.0 | `--models` weighted model spec, `--temperature`/`--top_p` flags, persona prompt templates, pack generation, domain templates, MCP improvements |
 | 0.5.0 | v3 branching instruments, router predicates, 5 bundled instrument packs, `instruments` subcommand (list/show/install/graph), MCP `*_instrument_pack` tools, rounds-shaped panel output, `extend_panel` ad-hoc round tool |


### PR DESCRIPTION
## Summary

Mayor-run stale-doc sweep for the 0.9.x feature run. Scope is intentionally narrow — skipping what's actively being documented elsewhere.

**In-flight PRs left untouched** to avoid conflicts:
- #249 (sp-0g9r) — `--calibrate-against` docs on `docs/convergence.md`
- #250 (sp-z3uy) — `synthpanel report` on README / site / CHANGELOG

Those files/topics are left to their owners; this PR covers everything else that was stale in README and CHANGELOG as of main @ 343b76b.

## Files updated

### `README.md`
- [x] Line 136 — Docker pin example bumped `:0.9.4` → `:0.9.9`.
- [x] Versions table — backfilled 0.8.0 and the 0.9.x series (0.9.0, 0.9.4, 0.9.5, 0.9.7, 0.9.8, 0.9.9). Prior table cut off at 0.7.0 and hid ~14 releases' worth of shipped features.

### `CHANGELOG.md`
- [x] `[Unreleased]` — added missing `### Added` block for:
  - sp-5r88 / sp-a6jc / sp-ttwy / sp-bldz — inline calibration via `--calibrate-against` + `per_question[key].calibration` sub-object
  - sp-lk3w — optional `version:` field on persona packs + MCP shadow warning
  - sp-udsv — `gh:` URL resolver
  - (sp-7npy Documentation entry was already present — retained.)
- [x] Header link — fixed `synth-panel/releases` → `SynthPanel/releases`.
- [x] Compare/tag anchor block at bottom — refreshed all entries to the canonical `SynthPanel` slug and backfilled anchors for 0.9.0, 0.9.2, 0.9.4, 0.9.5, 0.9.6, 0.9.7, 0.9.8, 0.9.9. Old anchors resolved to dead compare URLs after the 2026-04-15 repo rename.

## Not touched (verified still current)

- `site/index.html` + `site/index.html.j2` — version badge + `softwareVersion` already render `0.9.9`; "Who this isn't for" block from sp-o1y0 is in place.
- `pyproject.toml` — description, keywords, classifiers still accurate; `dynamic = ["version"]` sp-ssrw wiring correct. **Version intentionally NOT bumped.**
- `docs/mcp.md` — tool count (12) still correct; BYOK + sampling mode sections accurate.
- Other `docs/*.md` — not in audit scope for this PR.

## Test plan

- [ ] CI passes (docs-only; no Python touched, so no ruff run needed)
- [ ] CHANGELOG anchor links resolve on github.com after merge
- [ ] No conflict with #249 / #250 when they merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)