### PR TITLE
feat(cli): pack import gh:... with --unverified + collision UX (sp-w9a5)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -2248,11 +2248,26 @@ def handle_pack_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
 
 def handle_pack_import(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """Import a persona pack from a YAML file."""
+    """Import a persona pack from a local file or remote source.
+
+    Routes on ``args.source``:
+
+    - ``gh:user/repo[@ref][:path]`` / ``https://…`` → remote fetch path with
+      registry consultation, collision checks, and ``--unverified`` gating.
+    - Anything else → local file path (existing behavior, unchanged).
+    """
+    source = args.source
+    if source.startswith("gh:") or source.startswith("http://") or source.startswith("https://"):
+        return _handle_pack_import_remote(args, fmt, source)
+    return _handle_pack_import_local(args, fmt, source)
+
+
+def _handle_pack_import_local(args: argparse.Namespace, fmt: OutputFormat, source: str) -> int:
+    """Local-path branch of ``pack import`` (unchanged behavior)."""
     from synth_panel.mcp.data import PackValidationError, save_persona_pack
 
     try:
-        personas = _load_personas(args.file)
+        personas = _load_personas(source)
     except (FileNotFoundError, ValueError) as exc:
         print(f"Error loading file: {exc}", file=sys.stderr)
         return 1
@@ -2260,17 +2275,226 @@ def handle_pack_import(args: argparse.Namespace, fmt: OutputFormat) -> int:
     # Determine pack name: explicit flag > YAML 'name' key > filename stem
     pack_name = args.name
     if not pack_name:
-        data = _load_yaml(args.file)
+        data = _load_yaml(source)
         if isinstance(data, dict):
             pack_name = data.get("name")
     if not pack_name:
-        pack_name = Path(args.file).stem
+        pack_name = Path(source).stem
 
     try:
         result = save_persona_pack(pack_name, personas, pack_id=args.pack_id)
     except PackValidationError as exc:
         print(f"Validation error: {exc}", file=sys.stderr)
         return 1
+
+    if fmt is OutputFormat.TEXT:
+        print(f"Imported pack '{result['name']}' ({result['persona_count']} personas) as {result['id']}")
+    else:
+        emit(fmt, message="Pack imported", extra=result)
+
+    return 0
+
+
+def _slugify_pack_id(value: str) -> str:
+    """Best-effort slug: lowercase, non-alphanumeric → ``-``, trim ``-``s."""
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return slug or "pack"
+
+
+def _default_pack_id_from_source(source: str) -> str:
+    """Derive a fallback pack id from a ``gh:``/``https://…`` source."""
+    from synth_panel.registry import parse_gh_source
+
+    if source.startswith("gh:"):
+        try:
+            parsed = parse_gh_source(source)
+        except ValueError:
+            return _slugify_pack_id(source[3:] or "pack")
+        return _slugify_pack_id(parsed.repo)
+
+    # https URL: use the path stem, falling back to the host.
+    from urllib.parse import urlparse
+
+    parts = urlparse(source)
+    tail = Path(parts.path).stem or parts.netloc or "pack"
+    return _slugify_pack_id(tail)
+
+
+def _source_in_registry(source: str) -> bool:
+    """Return True when *source* is listed in the cached registry.
+
+    Only ``gh:`` sources can be matched against the registry — http(s)
+    URLs have no repo/ref to key on, so they are always treated as
+    unregistered (forcing the ``--unverified`` path).
+    """
+    from synth_panel.registry import fetch_registry, parse_gh_source
+
+    if not source.startswith("gh:"):
+        return False
+    try:
+        parsed = parse_gh_source(source)
+    except ValueError:
+        return False
+
+    repo_slug = f"{parsed.user}/{parsed.repo}"
+    try:
+        registry = fetch_registry()
+    except Exception:
+        return False
+
+    for entry in registry.get("packs", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("repo") != repo_slug:
+            continue
+        entry_ref = entry.get("ref") or "main"
+        if entry_ref == parsed.ref:
+            return True
+    return False
+
+
+def _handle_pack_import_remote(
+    args: argparse.Namespace,
+    fmt: OutputFormat,
+    source: str,
+) -> int:
+    """Remote-source branch of ``pack import`` (``gh:`` / ``https://…``)."""
+    import hashlib
+
+    import httpx
+
+    from synth_panel.mcp.data import (
+        PackValidationError,
+        _bundled_packs,
+        _packs_dir,
+        save_persona_pack,
+        validate_persona_pack,
+    )
+    from synth_panel.registry import resolve_source
+
+    # 1. Resolve to a raw URL.
+    try:
+        url = resolve_source(source)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # 2. Fetch the YAML body.
+    try:
+        with httpx.Client(timeout=10.0, follow_redirects=True) as client:
+            resp = client.get(url)
+    except httpx.HTTPError as exc:
+        print(f"Error fetching {url}: {exc}", file=sys.stderr)
+        return 1
+
+    if resp.status_code == 404:
+        print(
+            f"Error: pack not found at {url} (HTTP 404).\n  Repo may be private; GITHUB_TOKEN support planned.",
+            file=sys.stderr,
+        )
+        return 1
+    if resp.status_code != 200:
+        print(f"Error: HTTP {resp.status_code} fetching {url}", file=sys.stderr)
+        return 1
+
+    content = resp.text
+
+    # 3. Parse YAML.
+    try:
+        data = yaml.safe_load(content)
+    except yaml.YAMLError as exc:
+        print(f"Error: invalid YAML at {url}: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(data, dict):
+        print(
+            f"Error: pack YAML at {url} must be a mapping, got {type(data).__name__}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 4. Validate personas (same bar as local import).
+    personas = data.get("personas")
+    if personas is None and isinstance(data, list):
+        personas = data
+    try:
+        personas = validate_persona_pack(personas if personas is not None else [])
+    except PackValidationError as exc:
+        print(f"Validation error: {exc}", file=sys.stderr)
+        return 1
+
+    # 5. Determine target pack_id: explicit flag > YAML 'id' > derived.
+    if args.pack_id:
+        pack_id = args.pack_id
+    elif isinstance(data.get("id"), str) and data["id"].strip():
+        pack_id = data["id"]
+    else:
+        pack_id = _default_pack_id_from_source(source)
+
+    # 6. Collision checks.
+    if pack_id in _bundled_packs():
+        print(
+            f"Error: pack id '{pack_id}' collides with a bundled pack.\n"
+            f"  Re-run with --id <new-id> to import under a different name.",
+            file=sys.stderr,
+        )
+        return 1
+
+    saved_path = _packs_dir() / f"{pack_id}.yaml"
+    if saved_path.exists() and not args.force:
+        print(
+            f"Error: pack id '{pack_id}' already exists as a user-saved pack.\n"
+            f"  Re-run with --force to overwrite, or --id <new-id> for a new copy.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 7. Registry consultation.
+    is_registered = _source_in_registry(source)
+    if not is_registered and not args.unverified:
+        print(
+            f"Error: pack '{source}' is not in the synthpanel registry.\n  Rerun with --unverified to import anyway.",
+            file=sys.stderr,
+        )
+        return 1
+    if is_registered and args.unverified:
+        print(
+            f"Note: '{source}' is already in the synthpanel registry; --unverified flag unnecessary.",
+            file=sys.stderr,
+        )
+
+    # 8. Resolve pack name (explicit flag > YAML 'name' > pack_id).
+    pack_name = args.name
+    if not pack_name:
+        yaml_name = data.get("name")
+        if isinstance(yaml_name, str) and yaml_name.strip():
+            pack_name = yaml_name
+    if not pack_name:
+        pack_name = pack_id
+
+    # 9. Save.
+    version = data.get("version") if isinstance(data.get("version"), str) else None
+    try:
+        result = save_persona_pack(
+            pack_name,
+            personas,
+            pack_id=pack_id,
+            version=version,
+        )
+    except (PackValidationError, ValueError) as exc:
+        print(f"Validation error: {exc}", file=sys.stderr)
+        return 1
+
+    # 10. Section-4 warning block for unverified imports.
+    if not is_registered and args.unverified:
+        checksum = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        print(
+            f"! Pack '{source}' is not in the synthpanel registry.\n"
+            f"  Source:      {url}\n"
+            f"  Checksum:    sha256:{checksum}\n"
+            f"  Imported as: {pack_id}\n"
+            f"  Use 'pack search' to browse registered packs.",
+            file=sys.stderr,
+        )
 
     if fmt is OutputFormat.TEXT:
         print(f"Imported pack '{result['name']}' ({result['persona_count']} personas) as {result['id']}")

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -537,23 +537,40 @@ def build_parser() -> argparse.ArgumentParser:
     # pack import
     pack_import_parser = pack_subparsers.add_parser(
         "import",
-        help="Import a persona pack from a YAML file.",
+        help="Import a persona pack from a YAML file or GitHub source.",
     )
     pack_import_parser.add_argument(
-        "file",
-        metavar="FILE",
-        help="Path to a YAML persona pack file.",
+        "source",
+        metavar="SOURCE",
+        help=(
+            "Local YAML path, gh:user/repo[@ref][:path] URI, or https URL "
+            "(raw.githubusercontent.com or github.com/.../blob/...)."
+        ),
     )
     pack_import_parser.add_argument(
         "--name",
         default=None,
-        help="Name for the pack (default: derived from file or pack content).",
+        help="Name for the pack (default: derived from source or pack content).",
     )
     pack_import_parser.add_argument(
         "--id",
         default=None,
         dest="pack_id",
         help="Custom pack ID (default: auto-generated).",
+    )
+    pack_import_parser.add_argument(
+        "--unverified",
+        action="store_true",
+        help=(
+            "Allow importing a remote pack that is not listed in the "
+            "synthpanel registry. Prints a one-time warning block with "
+            "source URL, sha256 checksum, and imported id."
+        ),
+    )
+    pack_import_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing user-saved pack with the same id.",
     )
 
     # pack export

--- a/src/synth_panel/registry/__init__.py
+++ b/src/synth_panel/registry/__init__.py
@@ -1,10 +1,48 @@
 """Pack registry support.
 
-Resolves remote pack sources (`gh:`, `github.com/blob/`,
-`raw.githubusercontent.com`) to raw-content URLs. Fetch + cache
-layers live in sibling modules (added in later tickets).
+Three layers, each usable on its own:
+
+1. :mod:`.github` — parses ``gh:user/repo[@ref][:path]`` and
+   ``github.com/blob/`` URLs into raw-content URLs.
+2. :mod:`.fetch` — HTTP GET of the registry ``default.json``
+   (conditional on ETag), returning a parsed dict.
+3. :mod:`.cache` — 24h TTL cache at
+   ``$SYNTH_PANEL_DATA_DIR/registry-cache.json`` with offline and
+   stale-fallback behavior.
+
+Most callers want :func:`fetch_registry` (cache-aware) and
+:func:`resolve_pack` (id → :class:`RegistryEntry`).
 """
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from synth_panel.registry.cache import (
+    CACHE_FILENAME,
+    CACHE_TTL,
+    DATA_DIR_ENV,
+    EMPTY_REGISTRY,
+    OFFLINE_ENV,
+    REFRESH_ENV,
+    CachedRegistry,
+    cache_path,
+    load_registry,
+    read_cache,
+    write_cache,
+)
+from synth_panel.registry.fetch import (
+    DEFAULT_REGISTRY_URL,
+    FETCH_TIMEOUT,
+    REGISTRY_URL_ENV,
+    FetchResult,
+    RegistryFetchError,
+    fetch_registry_http,
+    registry_url,
+)
 from synth_panel.registry.github import (
     DEFAULT_PATH,
     DEFAULT_REF,
@@ -13,10 +51,128 @@ from synth_panel.registry.github import (
     resolve_source,
 )
 
+
+@dataclass(frozen=True)
+class RegistryEntry:
+    """One entry from ``default.json`` — identifies a registered pack.
+
+    Mirrors the schema documented in structure.md §2. ``ref`` defaults
+    to ``"main"`` when the JSON entry omits it; ``calibration`` is
+    reserved (always ``None`` in v1).
+    """
+
+    id: str
+    kind: str
+    name: str
+    description: str
+    repo: str
+    path: str
+    author: dict[str, Any]
+    ref: str = "main"
+    version: str | None = None
+    tags: tuple[str, ...] = ()
+    added_at: str | None = None
+    calibration: Any = None
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> RegistryEntry:
+        """Hydrate a :class:`RegistryEntry` from a ``default.json`` entry.
+
+        Raises ``KeyError`` if ``id``/``repo``/``path`` are missing
+        (the three fields we require for any useful resolution).
+        """
+        raw_tags = data.get("tags") or ()
+        if isinstance(raw_tags, (list, tuple)):
+            tags = tuple(t for t in raw_tags if isinstance(t, str))
+        else:
+            tags = ()
+
+        author = data.get("author") or {}
+        if not isinstance(author, dict):
+            author = {}
+
+        version = data.get("version")
+        if version is not None and not isinstance(version, str):
+            version = str(version)
+
+        added_at = data.get("added_at")
+        if added_at is not None and not isinstance(added_at, str):
+            added_at = str(added_at)
+
+        return cls(
+            id=str(data["id"]),
+            kind=str(data.get("kind", "persona")),
+            name=str(data.get("name", "")),
+            description=str(data.get("description", "")),
+            repo=str(data["repo"]),
+            path=str(data["path"]),
+            author=dict(author),
+            ref=str(data.get("ref") or "main"),
+            version=version,
+            tags=tags,
+            added_at=added_at,
+            calibration=data.get("calibration"),
+        )
+
+
+def fetch_registry(
+    *,
+    client: httpx.Client | None = None,
+    url: str | None = None,
+    refresh: bool | None = None,
+    offline: bool | None = None,
+) -> dict[str, Any]:
+    """Return the parsed registry dict, using the cache where possible.
+
+    See :func:`synth_panel.registry.cache.load_registry` for the full
+    fresh/stale/offline decision tree. This is the thin public wrapper.
+    """
+    return load_registry(client=client, url=url, refresh=refresh, offline=offline)
+
+
+def resolve_pack(
+    pack_id: str,
+    *,
+    client: httpx.Client | None = None,
+    url: str | None = None,
+    refresh: bool | None = None,
+    offline: bool | None = None,
+) -> RegistryEntry | None:
+    """Look up a pack by id; returns ``None`` if it isn't in the registry."""
+    registry = fetch_registry(client=client, url=url, refresh=refresh, offline=offline)
+    for entry in registry.get("packs", []) or []:
+        if isinstance(entry, dict) and entry.get("id") == pack_id:
+            try:
+                return RegistryEntry.from_dict(entry)
+            except (KeyError, TypeError, ValueError):
+                return None
+    return None
+
+
 __all__ = [
+    "CACHE_FILENAME",
+    "CACHE_TTL",
+    "DATA_DIR_ENV",
     "DEFAULT_PATH",
     "DEFAULT_REF",
+    "DEFAULT_REGISTRY_URL",
+    "EMPTY_REGISTRY",
+    "FETCH_TIMEOUT",
+    "OFFLINE_ENV",
+    "REFRESH_ENV",
+    "REGISTRY_URL_ENV",
+    "CachedRegistry",
+    "FetchResult",
     "GitHubSource",
+    "RegistryEntry",
+    "RegistryFetchError",
+    "cache_path",
+    "fetch_registry",
+    "fetch_registry_http",
     "parse_gh_source",
+    "read_cache",
+    "registry_url",
+    "resolve_pack",
     "resolve_source",
+    "write_cache",
 ]

--- a/src/synth_panel/registry/cache.py
+++ b/src/synth_panel/registry/cache.py
@@ -1,0 +1,223 @@
+"""Registry cache with 24h TTL, offline fallback, and conditional refresh.
+
+Cache file lives at ``$SYNTH_PANEL_DATA_DIR/registry-cache.json`` (default
+``~/.synthpanel/registry-cache.json``) and has the shape described in
+structure.md §5::
+
+    {
+      "fetched_at": "2026-04-22T14:03:00Z",
+      "source_url": "https://.../default.json",
+      "etag": "\"abc123\"" | null,
+      "registry": { "schema_version": 1, "packs": [...] }
+    }
+
+The top-level :func:`load_registry` is the entry point most callers want:
+it consults the cache, conditionally refreshes against the network, and
+gracefully degrades to a stale or empty registry when the network is
+unreachable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+from synth_panel.registry.fetch import (
+    RegistryFetchError,
+    fetch_registry_http,
+    registry_url,
+)
+
+CACHE_FILENAME = "registry-cache.json"
+CACHE_TTL = timedelta(hours=24)
+DATA_DIR_ENV = "SYNTH_PANEL_DATA_DIR"
+OFFLINE_ENV = "SYNTHPANEL_REGISTRY_OFFLINE"
+REFRESH_ENV = "SYNTHPANEL_REGISTRY_REFRESH"
+
+EMPTY_REGISTRY: dict[str, Any] = {"schema_version": 1, "packs": []}
+
+WarnFn = Callable[[str], None]
+
+
+def _data_dir() -> Path:
+    d = Path(os.environ.get(DATA_DIR_ENV, "~/.synthpanel")).expanduser()
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def cache_path() -> Path:
+    """Return the absolute path to the registry cache file."""
+    return _data_dir() / CACHE_FILENAME
+
+
+@dataclass(frozen=True)
+class CachedRegistry:
+    """In-memory view of a parsed cache file."""
+
+    fetched_at: datetime
+    source_url: str
+    etag: str | None
+    registry: dict[str, Any]
+
+
+def _parse_iso(value: str) -> datetime | None:
+    # datetime.fromisoformat on 3.10 does not accept a trailing "Z"; normalize.
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def read_cache(path: Path | None = None) -> CachedRegistry | None:
+    """Read and parse the cache file. Returns ``None`` if missing/corrupt."""
+    target = path or cache_path()
+    if not target.exists():
+        return None
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+
+    fetched = _parse_iso(str(raw.get("fetched_at", "")))
+    registry = raw.get("registry")
+    source = raw.get("source_url")
+    if fetched is None or not isinstance(registry, dict) or not isinstance(source, str):
+        return None
+
+    etag = raw.get("etag")
+    if not isinstance(etag, str) and etag is not None:
+        etag = None
+
+    return CachedRegistry(
+        fetched_at=fetched,
+        source_url=source,
+        etag=etag,
+        registry=registry,
+    )
+
+
+def write_cache(
+    registry: dict[str, Any],
+    *,
+    source_url: str,
+    etag: str | None = None,
+    fetched_at: datetime | None = None,
+    path: Path | None = None,
+) -> None:
+    """Atomically write the cache file.
+
+    Writes to ``<path>.tmp`` then ``os.replace``s into place so a crash
+    mid-write cannot leave the cache in a half-written state.
+    """
+    target = path or cache_path()
+    stamp = fetched_at or datetime.now(timezone.utc)
+    payload: dict[str, Any] = {
+        "fetched_at": stamp.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_url": source_url,
+        "etag": etag,
+        "registry": registry,
+    }
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, target)
+
+
+def _is_fresh(cached: CachedRegistry, now: datetime | None = None) -> bool:
+    moment = now or datetime.now(timezone.utc)
+    return (moment - cached.fetched_at) < CACHE_TTL
+
+
+def _env_flag(name: str) -> bool:
+    val = os.environ.get(name)
+    if val is None:
+        return False
+    return val.strip().lower() not in ("", "0", "false", "no", "off")
+
+
+def _default_warn(message: str) -> None:
+    print(message, file=sys.stderr)
+
+
+def load_registry(
+    *,
+    client: httpx.Client | None = None,
+    url: str | None = None,
+    refresh: bool | None = None,
+    offline: bool | None = None,
+    warn: WarnFn | None = None,
+) -> dict[str, Any]:
+    """Return the registry dict, going through the cache layer.
+
+    Semantics (structure.md §5):
+
+    - ``offline`` (flag or ``SYNTHPANEL_REGISTRY_OFFLINE=1``) — never
+      touch the network. Returns the cached registry if present, else
+      an empty ``{"schema_version": 1, "packs": []}``.
+    - ``refresh`` (flag or ``SYNTHPANEL_REGISTRY_REFRESH=1``) — bypass
+      the TTL and force a fetch (ignoring any cached ETag).
+    - Otherwise, if the cache is fresh (<24h) and matches the active
+      URL, return it with zero network calls.
+    - If the cache is stale, attempt a conditional GET with the cached
+      ETag. 304 → bump ``fetched_at`` and return cached; 200 → overwrite
+      cache and return new; network error → stderr warning + stale
+      cache (or empty registry if no cache existed).
+    """
+    target_url = url or registry_url()
+    emit = warn or _default_warn
+
+    offline_flag = offline if offline is not None else _env_flag(OFFLINE_ENV)
+    refresh_flag = refresh if refresh is not None else _env_flag(REFRESH_ENV)
+
+    cached = read_cache()
+
+    if offline_flag:
+        if cached is not None:
+            return cached.registry
+        return _empty()
+
+    url_matches = cached is not None and cached.source_url == target_url
+    if cached is not None and url_matches and not refresh_flag and _is_fresh(cached):
+        return cached.registry
+
+    conditional_etag: str | None = None
+    if cached is not None and url_matches and not refresh_flag:
+        conditional_etag = cached.etag
+
+    try:
+        result = fetch_registry_http(target_url, etag=conditional_etag, client=client)
+    except RegistryFetchError as exc:
+        if cached is not None:
+            emit(f"synthpanel: registry fetch failed ({exc}); using stale cache from {cached.fetched_at.isoformat()}")
+            return cached.registry
+        emit(f"synthpanel: registry unavailable ({exc}); returning empty registry")
+        return _empty()
+
+    if result.not_modified and cached is not None:
+        write_cache(cached.registry, source_url=target_url, etag=cached.etag)
+        return cached.registry
+
+    # result.data is guaranteed non-None for a 200 in fetch_registry_http.
+    assert result.data is not None
+    write_cache(result.data, source_url=target_url, etag=result.etag)
+    return result.data
+
+
+def _empty() -> dict[str, Any]:
+    # Return a fresh copy so callers cannot mutate the module constant.
+    return {"schema_version": 1, "packs": []}

--- a/src/synth_panel/registry/fetch.py
+++ b/src/synth_panel/registry/fetch.py
@@ -1,0 +1,104 @@
+"""HTTP fetch of the synthpanel pack registry ``default.json``.
+
+This module is the raw network layer. It performs a single GET (optionally
+conditional on a cached ETag) and returns the parsed JSON body plus any
+``ETag`` header the server sent back. Caching, TTL, and offline behavior
+live in :mod:`synth_panel.registry.cache`.
+
+The registry URL defaults to
+``https://raw.githubusercontent.com/DataViking-Tech/synthpanel-registry/main/default.json``
+and can be overridden at runtime via ``SYNTHPANEL_REGISTRY_URL`` — useful
+for tests, forks, and air-gapped environments.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+DEFAULT_REGISTRY_URL = "https://raw.githubusercontent.com/DataViking-Tech/synthpanel-registry/main/default.json"
+REGISTRY_URL_ENV = "SYNTHPANEL_REGISTRY_URL"
+FETCH_TIMEOUT = 10.0
+
+
+def registry_url() -> str:
+    """Return the active registry URL, honoring ``SYNTHPANEL_REGISTRY_URL``."""
+    return os.environ.get(REGISTRY_URL_ENV, DEFAULT_REGISTRY_URL)
+
+
+@dataclass(frozen=True)
+class FetchResult:
+    """Outcome of a single HTTP fetch against the registry.
+
+    On a 200 response, ``data`` holds the parsed JSON body and ``etag``
+    is whatever the server returned (possibly ``None``). On a 304
+    (conditional-GET hit against ``If-None-Match``), ``data`` is ``None``
+    and ``not_modified`` is ``True``; the caller is expected to keep
+    using its cached payload.
+    """
+
+    data: dict[str, Any] | None
+    etag: str | None
+    not_modified: bool
+
+
+class RegistryFetchError(Exception):
+    """Network, HTTP-status, or JSON-parse failure during registry fetch."""
+
+
+def fetch_registry_http(
+    url: str | None = None,
+    *,
+    etag: str | None = None,
+    client: httpx.Client | None = None,
+    timeout: float = FETCH_TIMEOUT,
+) -> FetchResult:
+    """GET the registry JSON, optionally conditional on ``etag``.
+
+    Returns a :class:`FetchResult`:
+
+    - 200 → ``data`` is the parsed JSON dict, ``etag`` is the new
+      server-sent value (or ``None``), ``not_modified`` is ``False``.
+    - 304 → ``data`` is ``None``, ``etag`` echoes the conditional value
+      the caller supplied, ``not_modified`` is ``True``.
+
+    Any other status, any ``httpx.HTTPError``, malformed JSON, or a
+    non-object top-level value raises :class:`RegistryFetchError`.
+
+    ``client`` is an optional pre-configured :class:`httpx.Client`
+    (tests pass a ``MockTransport``-backed client here). When omitted,
+    a fresh client with a 10-second timeout is used and closed on exit.
+    """
+    target = url or registry_url()
+    headers: dict[str, str] = {}
+    if etag:
+        headers["If-None-Match"] = etag
+
+    owns_client = client is None
+    active = client or httpx.Client(timeout=timeout, follow_redirects=True)
+    try:
+        try:
+            resp = active.get(target, headers=headers)
+        except httpx.HTTPError as exc:
+            raise RegistryFetchError(f"network error fetching {target}: {exc}") from exc
+
+        if resp.status_code == 304:
+            return FetchResult(data=None, etag=etag, not_modified=True)
+        if resp.status_code != 200:
+            raise RegistryFetchError(f"unexpected HTTP {resp.status_code} from {target}")
+
+        try:
+            body = resp.json()
+        except ValueError as exc:
+            raise RegistryFetchError(f"malformed JSON from {target}: {exc}") from exc
+        if not isinstance(body, dict):
+            raise RegistryFetchError(f"expected JSON object from {target}, got {type(body).__name__}")
+
+        new_etag = resp.headers.get("ETag") or resp.headers.get("etag")
+        return FetchResult(data=body, etag=new_etag, not_modified=False)
+    finally:
+        if owns_client:
+            active.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2409,7 +2409,15 @@ class TestPackCommands:
 
         args = parser.parse_args(["pack", "import", "file.yaml"])
         assert args.pack_command == "import"
-        assert args.file == "file.yaml"
+        assert args.source == "file.yaml"
+        assert args.unverified is False
+        assert args.force is False
+
+        args = parser.parse_args(["pack", "import", "gh:user/repo@v1:packs/p.yaml", "--unverified", "--force"])
+        assert args.pack_command == "import"
+        assert args.source == "gh:user/repo@v1:packs/p.yaml"
+        assert args.unverified is True
+        assert args.force is True
 
         args = parser.parse_args(["pack", "export", "my-pack"])
         assert args.pack_command == "export"

--- a/tests/test_pack_import_gh.py
+++ b/tests/test_pack_import_gh.py
@@ -1,0 +1,335 @@
+"""Tests for the remote (``gh:``/``https://…``) branch of ``pack import``.
+
+Covers the registry consultation → collision → save flow introduced
+for sp-w9a5:
+
+- ``gh:`` happy path with cached registry containing the source
+  (silent success, one confirmation line, no warning block).
+- ``--unverified`` required path when the source isn't in the registry;
+  failure message guides users to re-run with the flag.
+- ``--unverified`` warning block (URL, sha256 checksum, imported id).
+- ``--unverified`` flag-unnecessary notice when the source IS already
+  in the registry.
+- Collision: bundled-id refused with ``--id`` hint.
+- Collision: user-saved id refused without ``--force``; accepted with it.
+- 404 handling with the private-repo / GITHUB_TOKEN hint.
+- Local-path ``pack import`` regression (unchanged behavior).
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from synth_panel.main import main
+from synth_panel.registry import cache as registry_cache
+
+SAMPLE_PACK_YAML = """\
+name: Example Pack
+personas:
+  - name: Alice
+    age: 34
+    occupation: Engineer
+  - name: Bob
+    age: 41
+    occupation: PM
+"""
+
+REGISTRY_WITH_ENTRY = {
+    "schema_version": 1,
+    "generated_at": "2026-04-22T00:00:00Z",
+    "packs": [
+        {
+            "id": "icp-demo",
+            "kind": "persona",
+            "name": "Demo Pack",
+            "description": "Example registered pack.",
+            "repo": "example/demo",
+            "path": "synthpanel-pack.yaml",
+            "ref": "main",
+            "author": {"github": "example"},
+            "added_at": "2026-04-22",
+            "calibration": None,
+        }
+    ],
+}
+
+EMPTY_REGISTRY = {
+    "schema_version": 1,
+    "generated_at": "2026-04-22T00:00:00Z",
+    "packs": [],
+}
+
+
+def _install_httpx_mock(
+    monkeypatch: pytest.MonkeyPatch,
+    handler: Callable[[httpx.Request], httpx.Response],
+) -> None:
+    """Replace ``httpx.Client`` with a MockTransport-backed stand-in.
+
+    Every ``httpx.Client(...)`` call in the target code path routes to
+    *handler* instead of the real network.
+    """
+    transport = httpx.MockTransport(handler)
+    real_init = httpx.Client.__init__
+
+    def _patched_init(self: httpx.Client, *args: object, **kwargs: object) -> None:
+        kwargs["transport"] = transport
+        real_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(httpx.Client, "__init__", _patched_init)
+
+
+def _seed_registry_cache(tmp_path, registry: dict) -> None:
+    """Pre-populate the on-disk registry cache with *registry*.
+
+    Written to ``$SYNTH_PANEL_DATA_DIR/registry-cache.json`` so
+    ``fetch_registry()`` returns it without any network call.
+    """
+    from datetime import datetime, timezone
+
+    cache_dir = tmp_path
+    cache_file = cache_dir / registry_cache.CACHE_FILENAME
+    payload = {
+        "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "source_url": "https://example/registry.json",
+        "etag": None,
+        "registry": registry,
+    }
+    cache_file.write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# gh: happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestGhHappyPath:
+    def test_registered_source_succeeds_silently(self, tmp_data_dir, monkeypatch, capsys):
+        """Registered ``gh:`` import: exit 0, one confirmation line, no warnings."""
+        _seed_registry_cache(tmp_data_dir, REGISTRY_WITH_ENTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("synthpanel-pack.yaml"):
+                return httpx.Response(200, text=SAMPLE_PACK_YAML)
+            return httpx.Response(404)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "gh:example/demo"])
+        captured = capsys.readouterr()
+        assert code == 0, captured.err
+        assert "Imported pack" in captured.out
+        assert "not in the synthpanel registry" not in captured.err
+        assert "not in the synthpanel registry" not in captured.out
+
+    def test_unregistered_requires_unverified_flag(self, tmp_data_dir, monkeypatch, capsys):
+        """Unregistered ``gh:`` source without ``--unverified`` fails with guidance."""
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "gh:stranger/pack"])
+        err = capsys.readouterr().err
+        assert code == 1
+        assert "not in the synthpanel registry" in err
+        assert "--unverified" in err
+
+    def test_unverified_prints_warning_block(self, tmp_data_dir, monkeypatch, capsys):
+        """``--unverified`` on unregistered source: warning block with URL + sha256 + id."""
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "gh:stranger/pack", "--unverified"])
+        captured = capsys.readouterr()
+        assert code == 0, captured.err
+        assert "not in the synthpanel registry" in captured.err
+        assert "raw.githubusercontent.com/stranger/pack/main/synthpanel-pack.yaml" in captured.err
+        assert "sha256:" in captured.err
+        assert "Imported as: pack" in captured.err  # default id from repo slug
+        assert "Imported pack" in captured.out
+
+    def test_unverified_on_registered_source_warns_flag_unnecessary(self, tmp_data_dir, monkeypatch, capsys):
+        """``--unverified`` on a registered source: note that the flag is unnecessary."""
+        _seed_registry_cache(tmp_data_dir, REGISTRY_WITH_ENTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "gh:example/demo", "--unverified"])
+        captured = capsys.readouterr()
+        assert code == 0, captured.err
+        assert "flag unnecessary" in captured.err
+        # The section-4 warning block must NOT fire for a registered source.
+        assert "Checksum:" not in captured.err
+        assert "Imported pack" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# collisions
+# ---------------------------------------------------------------------------
+
+
+class TestCollisions:
+    def test_bundled_id_collision_refuses_with_id_hint(self, tmp_data_dir, monkeypatch, capsys):
+        """Remote import with bundled id refuses and hints at ``--id``."""
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(
+            [
+                "pack",
+                "import",
+                "gh:stranger/pack",
+                "--unverified",
+                "--id",
+                "developer",  # bundled pack id
+            ]
+        )
+        err = capsys.readouterr().err
+        assert code == 1
+        assert "bundled pack" in err
+        assert "--id" in err
+
+    def test_saved_id_collision_requires_force(self, tmp_data_dir, monkeypatch, capsys):
+        """Remote import colliding with a saved pack id refuses without ``--force``."""
+        from synth_panel.mcp.data import save_persona_pack
+
+        save_persona_pack("Existing", [{"name": "Pre-existing"}], pack_id="mine")
+
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(
+            [
+                "pack",
+                "import",
+                "gh:stranger/pack",
+                "--unverified",
+                "--id",
+                "mine",
+            ]
+        )
+        err = capsys.readouterr().err
+        assert code == 1
+        assert "already exists" in err
+        assert "--force" in err
+
+    def test_saved_id_collision_accepts_force(self, tmp_data_dir, monkeypatch, capsys):
+        """``--force`` overwrites an existing user-saved pack."""
+        from synth_panel.mcp.data import get_persona_pack, save_persona_pack
+
+        save_persona_pack("Existing", [{"name": "Pre-existing"}], pack_id="mine")
+
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(
+            [
+                "pack",
+                "import",
+                "gh:stranger/pack",
+                "--unverified",
+                "--id",
+                "mine",
+                "--force",
+            ]
+        )
+        captured = capsys.readouterr()
+        assert code == 0, captured.err
+        # Overwritten: new content should reflect the remote personas.
+        pack = get_persona_pack("mine")
+        names = {p.get("name") for p in pack.get("personas", [])}
+        assert names == {"Alice", "Bob"}
+
+
+# ---------------------------------------------------------------------------
+# fetch failures
+# ---------------------------------------------------------------------------
+
+
+class TestFetchFailures:
+    def test_404_hints_at_private_repo(self, tmp_data_dir, monkeypatch, capsys):
+        """Explicit-path gh: 404 mentions private-repo + GITHUB_TOKEN."""
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        # Explicit path bypasses the root-yaml fallback probe in the resolver.
+        code = main(["pack", "import", "gh:ghost/vanished:synthpanel-pack.yaml", "--unverified"])
+        err = capsys.readouterr().err
+        assert code == 1
+        assert "private" in err.lower()
+        assert "GITHUB_TOKEN" in err
+
+    def test_malformed_yaml_rejected(self, tmp_data_dir, monkeypatch, capsys):
+        """Invalid YAML at the resolved URL fails cleanly."""
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=": : : not valid yaml : :\n  :")
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "gh:stranger/pack:pack.yaml", "--unverified"])
+        err = capsys.readouterr().err
+        assert code == 1
+        assert "invalid YAML" in err or "Validation error" in err
+
+
+# ---------------------------------------------------------------------------
+# local-path regression
+# ---------------------------------------------------------------------------
+
+
+class TestLocalPathRegression:
+    def test_local_path_import_unchanged(self, tmp_data_dir, capsys):
+        """Local YAML import goes through the unchanged local branch."""
+        pfile = tmp_data_dir / "local-pack.yaml"
+        pfile.write_text("name: Local\npersonas:\n  - name: Cara\n    age: 29\n")
+
+        code = main(["pack", "import", str(pfile)])
+        captured = capsys.readouterr()
+        assert code == 0, captured.err
+        assert "Imported pack 'Local'" in captured.out
+        # Remote-only features must not appear in the local branch.
+        assert "Checksum:" not in captured.err
+        assert "synthpanel registry" not in captured.err

--- a/tests/test_registry_cache.py
+++ b/tests/test_registry_cache.py
@@ -1,0 +1,375 @@
+"""Tests for the registry cache layer (``synth_panel.registry.cache``).
+
+Covers TTL, ETag conditional refresh, offline mode, stale fallback with
+warning, and the empty-registry graceful-degrade path.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import httpx
+import pytest
+
+from synth_panel.registry import (
+    CACHE_FILENAME,
+    CACHE_TTL,
+    EMPTY_REGISTRY,
+    OFFLINE_ENV,
+    REFRESH_ENV,
+    cache_path,
+    fetch_registry,
+    read_cache,
+    resolve_pack,
+    write_cache,
+)
+from synth_panel.registry.cache import load_registry
+from synth_panel.registry.fetch import REGISTRY_URL_ENV
+
+SAMPLE = {
+    "schema_version": 1,
+    "packs": [
+        {
+            "id": "icp-traitprint-cloud",
+            "kind": "persona",
+            "name": "Traitprint",
+            "description": "d",
+            "repo": "example/traitprint",
+            "path": "synthpanel-pack.yaml",
+            "ref": "v0.1",
+            "author": {"github": "example"},
+            "tags": ["b2b"],
+            "added_at": "2026-04-22",
+        }
+    ],
+}
+
+URL = "https://example.test/default.json"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Pin SYNTH_PANEL_DATA_DIR at a temp dir per test; clear env flags."""
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv(REGISTRY_URL_ENV, URL)
+    monkeypatch.delenv(OFFLINE_ENV, raising=False)
+    monkeypatch.delenv(REFRESH_ENV, raising=False)
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _explode(request: httpx.Request) -> httpx.Response:
+    raise AssertionError(f"unexpected network call: {request.method} {request.url}")
+
+
+# ---------- cache path + round-trip ----------
+
+
+def test_cache_path_honors_data_dir_env(tmp_path: Path) -> None:
+    assert cache_path() == tmp_path / CACHE_FILENAME
+
+
+def test_cache_round_trip_preserves_registry_and_etag() -> None:
+    write_cache(SAMPLE, source_url=URL, etag='"abc"')
+    cached = read_cache()
+    assert cached is not None
+    assert cached.registry == SAMPLE
+    assert cached.source_url == URL
+    assert cached.etag == '"abc"'
+
+
+def test_read_cache_missing_returns_none() -> None:
+    assert read_cache() is None
+
+
+def test_read_cache_corrupt_returns_none(tmp_path: Path) -> None:
+    cache_path().write_text("{not json", encoding="utf-8")
+    assert read_cache() is None
+
+
+def test_read_cache_wrong_shape_returns_none() -> None:
+    cache_path().write_text(json.dumps({"nope": True}), encoding="utf-8")
+    assert read_cache() is None
+
+
+# ---------- fresh cache → zero network ----------
+
+
+def test_fresh_cache_hit_skips_network() -> None:
+    write_cache(SAMPLE, source_url=URL, etag='"abc"')
+    with _client(_explode) as client:
+        data = load_registry(client=client)
+    assert data == SAMPLE
+
+
+def test_fresh_cache_is_returned_by_fetch_registry_public_api() -> None:
+    write_cache(SAMPLE, source_url=URL, etag=None)
+    with _client(_explode) as client:
+        data = fetch_registry(client=client)
+    assert data["packs"][0]["id"] == "icp-traitprint-cloud"
+
+
+# ---------- stale cache → conditional refresh ----------
+
+
+def test_stale_cache_304_keeps_cached_registry_and_bumps_fetched_at() -> None:
+    stale = datetime.now(timezone.utc) - CACHE_TTL - timedelta(hours=1)
+    write_cache(SAMPLE, source_url=URL, etag='"abc"', fetched_at=stale)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("if-none-match") == '"abc"'
+        return httpx.Response(304)
+
+    with _client(handler) as client:
+        data = load_registry(client=client)
+
+    assert data == SAMPLE
+    cached = read_cache()
+    assert cached is not None
+    # fetched_at was bumped to ~now (within the last minute)
+    assert (datetime.now(timezone.utc) - cached.fetched_at) < timedelta(minutes=1)
+
+
+def test_stale_cache_200_overwrites_with_new_payload() -> None:
+    stale = datetime.now(timezone.utc) - timedelta(hours=48)
+    write_cache(SAMPLE, source_url=URL, etag='"old"', fetched_at=stale)
+
+    updated = {
+        "schema_version": 1,
+        "packs": [{"id": "new-pack", "repo": "x/new", "path": "p.yaml"}],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=updated, headers={"ETag": '"new"'})
+
+    with _client(handler) as client:
+        data = load_registry(client=client)
+
+    assert data == updated
+    cached = read_cache()
+    assert cached is not None
+    assert cached.etag == '"new"'
+    assert cached.registry == updated
+
+
+def test_stale_cache_network_fail_returns_stale_with_warning() -> None:
+    stale = datetime.now(timezone.utc) - timedelta(hours=48)
+    write_cache(SAMPLE, source_url=URL, etag='"abc"', fetched_at=stale)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route", request=request)
+
+    warnings: list[str] = []
+    with _client(handler) as client:
+        data = load_registry(client=client, warn=warnings.append)
+
+    assert data == SAMPLE
+    assert any("stale cache" in w for w in warnings)
+
+
+# ---------- cache miss + fetch fail → empty registry ----------
+
+
+def test_no_cache_and_fetch_fail_returns_empty_registry_gracefully() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    warnings: list[str] = []
+    with _client(handler) as client:
+        data = load_registry(client=client, warn=warnings.append)
+
+    assert data == EMPTY_REGISTRY
+    assert data["packs"] == []
+    assert any("registry unavailable" in w for w in warnings)
+    # Mutating returned dict must not mutate the module constant.
+    data["packs"].append({"id": "leak"})
+    assert EMPTY_REGISTRY["packs"] == []
+
+
+def test_no_cache_and_http_404_returns_empty_registry() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    warnings: list[str] = []
+    with _client(handler) as client:
+        data = load_registry(client=client, warn=warnings.append)
+
+    assert data == EMPTY_REGISTRY
+
+
+# ---------- SYNTHPANEL_REGISTRY_OFFLINE ----------
+
+
+def test_offline_env_var_prevents_any_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_cache(SAMPLE, source_url=URL, etag='"abc"', fetched_at=datetime.now(timezone.utc) - timedelta(hours=48))
+    monkeypatch.setenv(OFFLINE_ENV, "1")
+
+    with _client(_explode) as client:
+        data = load_registry(client=client)
+
+    assert data == SAMPLE
+
+
+def test_offline_flag_argument_prevents_network() -> None:
+    write_cache(SAMPLE, source_url=URL, etag=None, fetched_at=datetime.now(timezone.utc) - timedelta(hours=48))
+    with _client(_explode) as client:
+        data = load_registry(client=client, offline=True)
+    assert data == SAMPLE
+
+
+def test_offline_with_no_cache_returns_empty_registry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(OFFLINE_ENV, "1")
+    with _client(_explode) as client:
+        data = load_registry(client=client)
+    assert data == EMPTY_REGISTRY
+
+
+def test_offline_env_var_false_values_ignored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # "0"/"false" must NOT trigger offline mode.
+    monkeypatch.setenv(OFFLINE_ENV, "0")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=SAMPLE)
+
+    with _client(handler) as client:
+        data = load_registry(client=client)
+    assert data == SAMPLE
+
+
+# ---------- SYNTHPANEL_REGISTRY_REFRESH ----------
+
+
+def test_refresh_env_bypasses_fresh_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    write_cache(SAMPLE, source_url=URL, etag='"abc"')
+    monkeypatch.setenv(REFRESH_ENV, "1")
+
+    new_payload = {"schema_version": 1, "packs": []}
+    seen_headers: list[dict[str, str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.append(dict(request.headers))
+        return httpx.Response(200, json=new_payload)
+
+    with _client(handler) as client:
+        data = load_registry(client=client)
+
+    assert data == new_payload
+    # REFRESH must skip the conditional ETag so we don't accept a 304.
+    assert "if-none-match" not in seen_headers[0]
+
+
+def test_refresh_flag_argument_bypasses_fresh_cache() -> None:
+    write_cache(SAMPLE, source_url=URL, etag='"abc"')
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"schema_version": 1, "packs": []})
+
+    with _client(handler) as client:
+        data = load_registry(client=client, refresh=True)
+    assert data["packs"] == []
+
+
+# ---------- SYNTHPANEL_REGISTRY_URL override on cache ----------
+
+
+def test_url_change_invalidates_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    write_cache(SAMPLE, source_url="https://old.example/r.json", etag='"abc"')
+    other_url = "https://new.example/r.json"
+    monkeypatch.setenv(REGISTRY_URL_ENV, other_url)
+
+    replacement = {"schema_version": 1, "packs": []}
+    seen_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_urls.append(str(request.url))
+        assert "if-none-match" not in request.headers
+        return httpx.Response(200, json=replacement)
+
+    with _client(handler) as client:
+        data = load_registry(client=client)
+
+    assert seen_urls == [other_url]
+    assert data == replacement
+
+
+# ---------- resolve_pack ----------
+
+
+def test_resolve_pack_hit_returns_entry() -> None:
+    write_cache(SAMPLE, source_url=URL, etag=None)
+    with _client(_explode) as client:
+        entry = resolve_pack("icp-traitprint-cloud", client=client)
+
+    assert entry is not None
+    assert entry.id == "icp-traitprint-cloud"
+    assert entry.repo == "example/traitprint"
+    assert entry.ref == "v0.1"
+    assert entry.tags == ("b2b",)
+    assert entry.author == {"github": "example"}
+
+
+def test_resolve_pack_miss_returns_none() -> None:
+    write_cache(SAMPLE, source_url=URL, etag=None)
+    with _client(_explode) as client:
+        entry = resolve_pack("nonexistent", client=client)
+    assert entry is None
+
+
+def test_resolve_pack_empty_registry_returns_none(capsys: pytest.CaptureFixture[str]) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    with _client(handler) as client:
+        entry = resolve_pack("anything", client=client)
+    assert entry is None
+    # Warning goes to stderr via the default warn hook.
+    assert "registry unavailable" in capsys.readouterr().err
+
+
+def test_resolve_pack_missing_ref_defaults_to_main() -> None:
+    registry = {
+        "schema_version": 1,
+        "packs": [
+            {
+                "id": "no-ref",
+                "kind": "persona",
+                "name": "No Ref",
+                "description": "",
+                "repo": "example/no-ref",
+                "path": "synthpanel-pack.yaml",
+                "author": {"github": "example"},
+            }
+        ],
+    }
+    write_cache(registry, source_url=URL, etag=None)
+    with _client(_explode) as client:
+        entry = resolve_pack("no-ref", client=client)
+    assert entry is not None
+    assert entry.ref == "main"
+
+
+# ---------- cache write atomicity ----------
+
+
+def test_write_cache_does_not_leave_tmp_file_behind() -> None:
+    write_cache(SAMPLE, source_url=URL, etag=None)
+    tmp_files = list(cache_path().parent.glob(f"{CACHE_FILENAME}.tmp*"))
+    assert tmp_files == []
+
+
+def test_write_cache_creates_parent_directory(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    nested = tmp_path / "nested" / "data"
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(nested))
+    write_cache(SAMPLE, source_url=URL, etag=None)
+    assert (nested / CACHE_FILENAME).exists()

--- a/tests/test_registry_fetch.py
+++ b/tests/test_registry_fetch.py
@@ -1,0 +1,219 @@
+"""Tests for the raw-HTTP registry fetcher (``synth_panel.registry.fetch``)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+import httpx
+import pytest
+
+from synth_panel.registry.fetch import (
+    DEFAULT_REGISTRY_URL,
+    REGISTRY_URL_ENV,
+    RegistryFetchError,
+    fetch_registry_http,
+    registry_url,
+)
+
+SAMPLE_REGISTRY = {
+    "schema_version": 1,
+    "generated_at": "2026-04-22T00:00:00Z",
+    "packs": [
+        {
+            "id": "icp-traitprint-cloud",
+            "kind": "persona",
+            "name": "Traitprint Cloud ICPs",
+            "description": "Buyer archetypes for Traitprint Cloud.",
+            "repo": "example/traitprint",
+            "path": "synthpanel-pack.yaml",
+            "ref": "v0.2.0",
+            "author": {"github": "example"},
+            "tags": ["b2b", "saas"],
+            "added_at": "2026-04-22",
+            "calibration": None,
+        }
+    ],
+}
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+# ---------- registry_url / env override ----------
+
+
+def test_registry_url_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(REGISTRY_URL_ENV, raising=False)
+    assert registry_url() == DEFAULT_REGISTRY_URL
+
+
+def test_registry_url_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    override = "https://example.internal/registry.json"
+    monkeypatch.setenv(REGISTRY_URL_ENV, override)
+    assert registry_url() == override
+
+
+# ---------- happy path ----------
+
+
+def test_fetch_200_returns_parsed_dict_and_etag() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert "If-None-Match" not in request.headers
+        return httpx.Response(
+            200,
+            json=SAMPLE_REGISTRY,
+            headers={"ETag": '"abc123"'},
+        )
+
+    with _client(handler) as client:
+        result = fetch_registry_http("https://example.test/default.json", client=client)
+
+    assert result.not_modified is False
+    assert result.data == SAMPLE_REGISTRY
+    assert result.etag == '"abc123"'
+
+
+def test_fetch_uses_env_override_when_url_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(REGISTRY_URL_ENV, "https://env.example/registry.json")
+
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, json=SAMPLE_REGISTRY)
+
+    with _client(handler) as client:
+        fetch_registry_http(client=client)
+
+    assert seen == ["https://env.example/registry.json"]
+
+
+def test_fetch_200_without_etag_header_returns_none_etag() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=SAMPLE_REGISTRY)
+
+    with _client(handler) as client:
+        result = fetch_registry_http("https://example.test/default.json", client=client)
+
+    assert result.etag is None
+    assert result.data == SAMPLE_REGISTRY
+
+
+# ---------- conditional GET (ETag) ----------
+
+
+def test_fetch_sends_if_none_match_when_etag_supplied() -> None:
+    seen_headers: dict[str, str] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.update(dict(request.headers))
+        return httpx.Response(200, json=SAMPLE_REGISTRY)
+
+    with _client(handler) as client:
+        fetch_registry_http(
+            "https://example.test/default.json",
+            etag='"abc123"',
+            client=client,
+        )
+
+    assert seen_headers.get("if-none-match") == '"abc123"'
+
+
+def test_fetch_304_returns_not_modified_and_echoes_etag() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers.get("if-none-match") == '"abc123"'
+        return httpx.Response(304)
+
+    with _client(handler) as client:
+        result = fetch_registry_http(
+            "https://example.test/default.json",
+            etag='"abc123"',
+            client=client,
+        )
+
+    assert result.not_modified is True
+    assert result.data is None
+    assert result.etag == '"abc123"'
+
+
+# ---------- error surfaces ----------
+
+
+def test_fetch_404_raises_registry_fetch_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404)
+
+    with _client(handler) as client, pytest.raises(RegistryFetchError, match="HTTP 404"):
+        fetch_registry_http("https://example.test/default.json", client=client)
+
+
+def test_fetch_500_raises_registry_fetch_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500)
+
+    with _client(handler) as client, pytest.raises(RegistryFetchError, match="HTTP 500"):
+        fetch_registry_http("https://example.test/default.json", client=client)
+
+
+def test_fetch_malformed_json_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=b"{this is not json",
+            headers={"content-type": "application/json"},
+        )
+
+    with _client(handler) as client, pytest.raises(RegistryFetchError, match="malformed JSON"):
+        fetch_registry_http("https://example.test/default.json", client=client)
+
+
+def test_fetch_non_object_json_raises() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[1, 2, 3])
+
+    with _client(handler) as client, pytest.raises(RegistryFetchError, match="expected JSON object"):
+        fetch_registry_http("https://example.test/default.json", client=client)
+
+
+def test_fetch_timeout_raises_registry_fetch_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("connect timed out", request=request)
+
+    with _client(handler) as client, pytest.raises(RegistryFetchError, match="network error"):
+        fetch_registry_http("https://example.test/default.json", client=client)
+
+
+def test_fetch_connect_error_raises_registry_fetch_error() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host", request=request)
+
+    with _client(handler) as client, pytest.raises(RegistryFetchError, match="network error"):
+        fetch_registry_http("https://example.test/default.json", client=client)
+
+
+# ---------- response body integrity ----------
+
+
+def test_fetch_preserves_nested_pack_entries() -> None:
+    registry = {
+        "schema_version": 1,
+        "packs": [
+            {"id": "a", "repo": "x/a", "path": "p.yaml", "tags": ["t1", "t2"]},
+            {"id": "b", "repo": "x/b", "path": "p.yaml", "author": {"github": "me"}},
+        ],
+    }
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, content=json.dumps(registry).encode("utf-8"), headers={"content-type": "application/json"}
+        )
+
+    with _client(handler) as client:
+        result = fetch_registry_http("https://example.test/default.json", client=client)
+
+    assert result.data == registry


### PR DESCRIPTION
## Summary
- Add `synthpanel pack import gh:owner/repo/path` leveraging the `gh:` resolver from PR #241
- `--unverified` opt-out for signature/integrity checks; collision UX surfaces when an import would shadow an existing pack

## Source
- Polecat: furiosa
- Issue: sp-w9a5
- MR: sp-wisp-y54
- Branch: polecat/furiosa-mobqbo4x

## Test plan
- [ ] CI passes (new coverage in test_pack_import_gh.py)
- [ ] `synthpanel pack import gh:owner/repo/packs/foo.yaml` round-trips against a known public repo

## Note
Branch is stacked on sp-wisp-8vv's registry fetch/cache layer (#252) — it contains that commit. Recommend landing #252 first; then this branch rebases cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)