### PR TITLE
feat(cli): pack search + pack list --registry (sp-vzhl)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -2230,7 +2230,15 @@ def _build_rounds_shape(
 
 
 def handle_pack_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """List all saved persona packs."""
+    """List persona packs.
+
+    Default: local installed packs. With ``--registry``: packs from the
+    cached synthpanel registry (id, name, ref, version columns). On empty
+    cache + fetch fail, prints an advisory line and exits 0.
+    """
+    if getattr(args, "registry", False):
+        return _handle_pack_list_registry(fmt)
+
     from synth_panel.mcp.data import list_persona_packs
 
     packs = list_persona_packs()
@@ -2243,6 +2251,104 @@ def handle_pack_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 print(f"  {p['id']}  {p['name']}  ({p['persona_count']} personas)")
     else:
         emit(fmt, message="Persona packs", extra={"packs": packs})
+
+    return 0
+
+
+def _handle_pack_list_registry(fmt: OutputFormat) -> int:
+    """Registry branch of ``pack list``."""
+    from synth_panel.registry import cache_path, fetch_registry
+
+    had_cache = cache_path().exists()
+    registry = fetch_registry()
+    raw_packs = registry.get("packs") or []
+    entries = [e for e in raw_packs if isinstance(e, dict) and e.get("id")]
+
+    if not entries and not had_cache and not cache_path().exists():
+        # Empty cache + fetch fail (load_registry returned EMPTY_REGISTRY
+        # without persisting a cache). Advisory, exit 0.
+        if fmt is OutputFormat.TEXT:
+            print("registry unavailable, try again later")
+        else:
+            emit(fmt, message="registry unavailable, try again later", extra={"packs": []})
+        return 0
+
+    rows = sorted(
+        (
+            {
+                "id": str(e.get("id", "")),
+                "name": str(e.get("name", "")),
+                "ref": str(e.get("ref") or "main"),
+                "version": str(e.get("version") or ""),
+            }
+            for e in entries
+        ),
+        key=lambda r: r["id"],
+    )
+
+    if fmt is OutputFormat.TEXT:
+        if not rows:
+            print("No packs in registry.")
+        else:
+            for r in rows:
+                print(f"  {r['id']}  {r['name']}  ({r['ref']})  {r['version']}".rstrip())
+    else:
+        emit(fmt, message="Registry packs", extra={"packs": rows})
+
+    return 0
+
+
+def handle_pack_search(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Search registry packs by substring across id, name, description, tags."""
+    from synth_panel.registry import cache_path, fetch_registry
+
+    term = (args.term or "").lower()
+
+    had_cache = cache_path().exists()
+    registry = fetch_registry()
+    raw_packs = registry.get("packs") or []
+    entries = [e for e in raw_packs if isinstance(e, dict) and e.get("id")]
+
+    if not entries and not had_cache and not cache_path().exists():
+        if fmt is OutputFormat.TEXT:
+            print("registry unavailable, try again later")
+        else:
+            emit(fmt, message="registry unavailable, try again later", extra={"matches": []})
+        return 0
+
+    matches: list[dict[str, Any]] = []
+    for e in entries:
+        haystack_parts = [
+            str(e.get("id", "")),
+            str(e.get("name", "")),
+            str(e.get("description", "")),
+        ]
+        tags = e.get("tags") or ()
+        if isinstance(tags, (list, tuple)):
+            haystack_parts.extend(str(t) for t in tags)
+        haystack = " ".join(haystack_parts).lower()
+        if term in haystack:
+            matches.append(
+                {
+                    "id": str(e.get("id", "")),
+                    "name": str(e.get("name", "")),
+                    "ref": str(e.get("ref") or "main"),
+                    "version": str(e.get("version") or ""),
+                    "description": str(e.get("description", "")),
+                }
+            )
+
+    matches.sort(key=lambda r: r["id"])
+
+    if fmt is OutputFormat.TEXT:
+        if not matches:
+            print(f"No packs match '{args.term}'.")
+        else:
+            for r in matches:
+                desc = f"  {r['description']}" if r["description"] else ""
+                print(f"  {r['id']}  {r['name']}  ({r['ref']})  {r['version']}{desc}".rstrip())
+    else:
+        emit(fmt, message="Registry search", extra={"term": args.term, "matches": matches})
 
     return 0
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -529,9 +529,27 @@ def build_parser() -> argparse.ArgumentParser:
     pack_subparsers = pack_parser.add_subparsers(dest="pack_command")
 
     # pack list
-    pack_subparsers.add_parser(
+    pack_list_parser = pack_subparsers.add_parser(
         "list",
         help="List all saved persona packs.",
+    )
+    pack_list_parser.add_argument(
+        "--registry",
+        action="store_true",
+        help=(
+            "List packs from the synthpanel registry instead of local installs. Prints id, name, ref, version columns."
+        ),
+    )
+
+    # pack search
+    pack_search_parser = pack_subparsers.add_parser(
+        "search",
+        help="Search registry packs by substring (id, name, description, tags).",
+    )
+    pack_search_parser.add_argument(
+        "term",
+        metavar="TERM",
+        help="Substring to match (case-insensitive) against id/name/description/tags.",
     )
 
     # pack import

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -21,6 +21,7 @@ from synth_panel.cli.commands import (
     handle_pack_generate,
     handle_pack_import,
     handle_pack_list,
+    handle_pack_search,
     handle_pack_show,
     handle_panel_inspect,
     handle_panel_run,
@@ -74,6 +75,8 @@ def main(argv: list[str] | None = None) -> int:
             return handle_pack_show(args, output_format)
         elif sub == "generate":
             return handle_pack_generate(args, output_format)
+        elif sub == "search":
+            return handle_pack_search(args, output_format)
         else:
             parser.parse_args(["pack", "--help"])
             return 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2191,6 +2191,215 @@ class TestPackCommands:
         out = capsys.readouterr().out
         assert "my-team" in out
 
+    def _seed_registry_cache(self, entries: list[dict[str, object]]) -> None:
+        """Write a fresh registry cache so fetch_registry() reads it and
+        does not hit the network. The fixture sets SYNTH_PANEL_DATA_DIR
+        to tmp_path, so the cache lives under the per-test temp dir."""
+        from synth_panel.registry import registry_url, write_cache
+
+        write_cache(
+            {"schema_version": 1, "packs": entries},
+            source_url=registry_url(),
+            etag='"test-etag"',
+        )
+
+    def test_pack_list_registry_prints_columns(self, capsys):
+        self._seed_registry_cache(
+            [
+                {
+                    "id": "zeta-pack",
+                    "kind": "persona",
+                    "name": "Zeta",
+                    "description": "Last letter persona",
+                    "repo": "a/b",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": ["greek"],
+                    "author": {"github": "a"},
+                },
+                {
+                    "id": "alpha-pack",
+                    "kind": "persona",
+                    "name": "Alpha",
+                    "description": "First letter persona",
+                    "repo": "c/d",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "v2",
+                    "version": "3",
+                    "tags": ["greek"],
+                    "author": {"github": "c"},
+                },
+            ]
+        )
+        code = main(["pack", "list", "--registry"])
+        assert code == 0
+        out = capsys.readouterr().out
+        # Stable-sorted by id: alpha before zeta.
+        assert out.index("alpha-pack") < out.index("zeta-pack")
+        assert "Alpha" in out and "Zeta" in out
+        assert "v2" in out
+        assert "3" in out  # version column
+
+    def test_pack_list_registry_json(self, capsys):
+        self._seed_registry_cache(
+            [
+                {
+                    "id": "one",
+                    "kind": "persona",
+                    "name": "One",
+                    "description": "",
+                    "repo": "a/b",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": [],
+                    "author": {},
+                }
+            ]
+        )
+        code = main(["--output-format", "json", "pack", "list", "--registry"])
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["packs"][0] == {
+            "id": "one",
+            "name": "One",
+            "ref": "main",
+            "version": "1",
+        }
+
+    def test_pack_list_registry_empty_cache_fetch_fail_is_advisory(self, capsys, monkeypatch):
+        """Empty cache + fetch fail → advisory message, exit 0."""
+        # No cache file written; make fetch_registry return empty registry
+        # (matching the load_registry empty-on-fail contract).
+        monkeypatch.setattr(
+            "synth_panel.registry.fetch_registry",
+            lambda **kw: {"schema_version": 1, "packs": []},
+        )
+        code = main(["pack", "list", "--registry"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "registry unavailable" in out
+        assert "try again later" in out
+
+    def test_pack_search_matches_across_fields(self, capsys):
+        self._seed_registry_cache(
+            [
+                {
+                    "id": "pricing-probe",
+                    "kind": "persona",
+                    "name": "Pricing Probe",
+                    "description": "Nothing special",
+                    "repo": "a/b",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": [],
+                    "author": {},
+                },
+                {
+                    "id": "dev-pack",
+                    "kind": "persona",
+                    "name": "Developers",
+                    "description": "Engineers who love PRICING discussions",
+                    "repo": "c/d",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": ["software"],
+                    "author": {},
+                },
+                {
+                    "id": "unrelated",
+                    "kind": "persona",
+                    "name": "Unrelated",
+                    "description": "Nothing matching",
+                    "repo": "e/f",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": [],
+                    "author": {},
+                },
+                {
+                    "id": "by-tag",
+                    "kind": "persona",
+                    "name": "Tagged",
+                    "description": "No literal match in description",
+                    "repo": "g/h",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": ["pricing"],
+                    "author": {},
+                },
+            ]
+        )
+        # Case-insensitive substring — matches id, name, description, tags.
+        code = main(["pack", "search", "pricing"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "pricing-probe" in out  # id match
+        assert "dev-pack" in out  # description match (uppercase PRICING)
+        assert "by-tag" in out  # tag match
+        assert "unrelated" not in out
+
+    def test_pack_search_no_matches(self, capsys):
+        self._seed_registry_cache(
+            [
+                {
+                    "id": "only",
+                    "kind": "persona",
+                    "name": "Only",
+                    "description": "solo",
+                    "repo": "a/b",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": [],
+                    "author": {},
+                }
+            ]
+        )
+        code = main(["pack", "search", "nonexistent-xyz"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "No packs match" in out
+
+    def test_pack_search_empty_cache_fetch_fail_is_advisory(self, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "synth_panel.registry.fetch_registry",
+            lambda **kw: {"schema_version": 1, "packs": []},
+        )
+        code = main(["pack", "search", "anything"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "registry unavailable" in out
+
+    def test_pack_search_json(self, capsys):
+        self._seed_registry_cache(
+            [
+                {
+                    "id": "match-one",
+                    "kind": "persona",
+                    "name": "Match",
+                    "description": "",
+                    "repo": "a/b",
+                    "path": "synthpanel-pack.yaml",
+                    "ref": "main",
+                    "version": "1",
+                    "tags": [],
+                    "author": {},
+                }
+            ]
+        )
+        code = main(["--output-format", "json", "pack", "search", "match"])
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["term"] == "match"
+        assert len(data["matches"]) == 1
+        assert data["matches"][0]["id"] == "match-one"
+
     def test_pack_generate_success(self, capsys, monkeypatch):
         """pack generate calls LLM and saves a valid persona pack."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary
- New `pack search <term>` subcommand — case-insensitive substring match across registry entries' id/name/description/tags (no `--tag` filter in v1 per S-gate OQ3).
- New `pack list --registry` flag — prints id/name/ref/version columns sourced from the cached registry; without the flag, existing local-packs behavior is preserved.
- Empty-cache + fetch-fail path prints `registry unavailable, try again later` and exits 0 (advisory, not error).

## Context
- Source issue: sp-vzhl (re-do of sp-7rd7, unblocked by sp-7we4 / PR #252 shipping the registry fetch+cache layer).
- Spec: sp-pack-registry (sp-5roa), plan: `specs/sp-pack-registry/plan.md` Ticket #6.

## Test plan
- [x] `pytest tests/test_cli.py` — 209 new lines of happy-path + empty-cache coverage in this PR.
- [ ] CI: test 3.10/3.11/3.12/3.13, coverage, security, lint, typecheck.
- [ ] Manual: `synthpanel pack search pricing` + `synthpanel pack list --registry` against a live cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)