### PR TITLE
fix(llm): warn on alias YAML/JSON parse failures (sp-s1is)

### DIFF
--- a/src/synth_panel/llm/aliases.py
+++ b/src/synth_panel/llm/aliases.py
@@ -9,11 +9,14 @@ Resolution order (highest priority wins):
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 # Short alias → canonical model identifier (tier 3: hardcoded fallback).
 _HARDCODED_ALIASES: dict[str, str] = {
@@ -51,7 +54,12 @@ def _load_file_aliases() -> dict[str, str]:
         return {}
     try:
         raw: Any = yaml.safe_load(_ALIASES_FILE.read_text())
-    except (OSError, yaml.YAMLError):
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning(
+            "aliases file at %s failed to parse: %s — ignoring",
+            _ALIASES_FILE,
+            exc,
+        )
         return {}
     if not isinstance(raw, dict):
         return {}
@@ -68,7 +76,12 @@ def _load_env_aliases() -> dict[str, str]:
         return {}
     try:
         parsed: Any = json.loads(raw)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.warning(
+            "%s env var failed to parse as JSON: %s — ignoring",
+            _ENV_VAR,
+            exc,
+        )
         return {}
     if not isinstance(parsed, dict):
         return {}

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import textwrap
 
 import pytest
@@ -78,10 +79,12 @@ def test_env_var_adds_new_alias(monkeypatch):
     assert resolve_alias("opus").startswith("claude-opus")
 
 
-def test_env_var_invalid_json_ignored(monkeypatch):
+def test_env_var_invalid_json_ignored(monkeypatch, caplog):
     monkeypatch.setenv("SYNTHPANEL_MODEL_ALIASES", "not json{")
-    # falls back to hardcoded
-    assert resolve_alias("sonnet").startswith("claude-sonnet")
+    with caplog.at_level(logging.WARNING, logger="synth_panel.llm.aliases"):
+        # falls back to hardcoded
+        assert resolve_alias("sonnet").startswith("claude-sonnet")
+    assert any("SYNTHPANEL_MODEL_ALIASES" in rec.getMessage() and "JSON" in rec.getMessage() for rec in caplog.records)
 
 
 def test_env_var_non_dict_ignored(monkeypatch):
@@ -122,11 +125,15 @@ def test_file_missing_is_fine(monkeypatch, tmp_path):
     assert resolve_alias("sonnet").startswith("claude-sonnet")
 
 
-def test_file_invalid_yaml_ignored(monkeypatch, tmp_path):
+def test_file_invalid_yaml_ignored(monkeypatch, tmp_path, caplog):
     aliases_file = tmp_path / "aliases.yaml"
     aliases_file.write_text(": : : not valid yaml [")
     monkeypatch.setattr("synth_panel.llm.aliases._ALIASES_FILE", aliases_file)
-    assert resolve_alias("sonnet").startswith("claude-sonnet")
+    with caplog.at_level(logging.WARNING, logger="synth_panel.llm.aliases"):
+        assert resolve_alias("sonnet").startswith("claude-sonnet")
+    assert any(
+        str(aliases_file) in rec.getMessage() and "failed to parse" in rec.getMessage() for rec in caplog.records
+    )
 
 
 def test_file_flat_format(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- `_load_file_aliases` and `_load_env_aliases` previously swallowed parse errors silently, so a malformed `~/.synthpanel/aliases.yaml` or `SYNTHPANEL_MODEL_ALIASES` env var would cause alias resolution to silently fall back to the raw input — handing a nonsense model name to the provider with no diagnostic.
- Emits `logger.warning` with the path/var and the exception text on parse failure.
- Updates the two existing "invalid input ignored" tests to assert the warning is actually logged.

## Context
- Source issue: sp-s1is (parent audit: sp-qtgu META-AUDIT, 2026-04-21).
- Touches `src/synth_panel/llm/aliases.py:52-55, 69-72`.

## Test plan
- [x] `pytest tests/test_aliases.py` — existing invalid-input tests now assert warning emission.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)