### PR TITLE
fix(synthesis): fail loud on partial structured payload (sp-qvqx)

### DIFF
--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -278,6 +278,30 @@ def synthesize_panel(
         )
 
     data = result.data
+    required_keys = _SYNTHESIS_SCHEMA["required"]
+    missing = [k for k in required_keys if k not in data]
+    if missing:
+        error_msg = f"synthesizer returned partial schema: missing keys {missing}"
+        logger.warning(
+            "%s (model=%s, present_keys=%s)",
+            error_msg,
+            resolved_model,
+            sorted(data.keys()),
+        )
+        return SynthesisResult(
+            summary=data.get("summary", "") or "Synthesis failed — see error field.",
+            themes=data.get("themes", []) if isinstance(data.get("themes"), list) else [],
+            agreements=data.get("agreements", []) if isinstance(data.get("agreements"), list) else [],
+            disagreements=data.get("disagreements", []) if isinstance(data.get("disagreements"), list) else [],
+            surprises=data.get("surprises", []) if isinstance(data.get("surprises"), list) else [],
+            recommendation=data.get("recommendation", ""),
+            usage=usage,
+            cost=cost,
+            model=resolved_model,
+            is_fallback=True,
+            error=error_msg,
+        )
+
     return SynthesisResult(
         summary=data.get("summary", ""),
         themes=data.get("themes", []),

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -184,6 +184,57 @@ class TestSynthesizePanel:
         assert result.summary == "Synthesis failed — see error field."
         assert result.themes == []
 
+    def test_fallback_on_empty_structured_payload(self):
+        """sp-qvqx: tool call succeeds but returns {} — must not silently
+        emit is_fallback=False with empty fields."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response({})
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        assert result.is_fallback, "empty payload must mark fallback=True"
+        assert result.error is not None
+        assert "missing keys" in result.error
+        # All six required keys are missing; the error should list them.
+        for key in ("summary", "themes", "agreements", "disagreements", "surprises", "recommendation"):
+            assert key in result.error
+
+    def test_fallback_on_partial_structured_payload(self):
+        """sp-qvqx: a payload missing even one required key must fail loud."""
+        partial = {
+            "summary": "Some summary",
+            "themes": ["a", "b"],
+            "agreements": [],
+            "disagreements": [],
+            # surprises missing
+            "recommendation": "Do X",
+        }
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(partial)
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        assert result.is_fallback
+        assert result.error is not None
+        assert "surprises" in result.error
+        # Other present fields should round-trip so the operator can see
+        # what *was* returned when diagnosing.
+        assert result.summary == "Some summary"
+        assert result.themes == ["a", "b"]
+        assert result.surprises == []
+
+    def test_fallback_partial_payload_logs_warning(self, caplog):
+        """sp-qvqx: partial payload must emit a logger.warning."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response({"summary": "x"})
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.synthesis"):
+            synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        assert any("missing keys" in rec.message for rec in caplog.records)
+
     def test_prompt_version_in_result(self):
         """synthesis_prompt_version is included in the result."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- When the synthesizer tool call succeeded but the returned dict was missing required schema keys, the result silently carried empty fields with `is_fallback=False`, indistinguishable from a real-but-boring synthesis.
- Now validates required keys against `_SYNTHESIS_SCHEMA`, sets `is_fallback=True` with a descriptive error listing the missing keys, and emits `logger.warning`.

## Context
- Source issue: sp-qvqx (parent audit: sp-qtgu META-AUDIT, 2026-04-21).
- Touches `src/synth_panel/synthesis.py:248-259`.

## Test plan
- [x] `pytest tests/test_synthesis.py` — 51 new lines exercising the partial-payload path.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)