### PR TITLE
test(aliases): isolate fixture from dev ~/.synthpanel/aliases.yaml (sp-rmtj)

### DIFF
--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -16,8 +16,19 @@ from synth_panel.llm.aliases import (
 
 
 @pytest.fixture(autouse=True)
-def _clean_alias_cache():
-    """Reset the cached alias map before and after every test."""
+def _clean_alias_cache(monkeypatch, tmp_path_factory):
+    """Isolate alias resolution from the developer's real config.
+
+    Without this, tier-3 (hardcoded) tests pick up the user's
+    ~/.synthpanel/aliases.yaml or SYNTHPANEL_MODEL_ALIASES env var and
+    silently fail (see sp-rmtj). Tests that exercise the file/env tiers
+    monkeypatch these on top of the isolated baseline.
+    """
+    monkeypatch.delenv("SYNTHPANEL_MODEL_ALIASES", raising=False)
+    monkeypatch.setattr(
+        "synth_panel.llm.aliases._ALIASES_FILE",
+        tmp_path_factory.mktemp("alias-iso") / "nope.yaml",
+    )
     _reset_cache()
     yield
     _reset_cache()


### PR DESCRIPTION
## Summary
- `test_known_aliases` failed on any box with a user `~/.synthpanel/aliases.yaml` file shadowing the hardcoded tier (e.g. `haiku` → `openrouter/anthropic/claude-haiku-4.5`).
- The autouse fixture reset the cache but left `_ALIASES_FILE` and `SYNTHPANEL_MODEL_ALIASES` pointing at real config, so tier-3 tests weren't actually testing tier 3.
- Redirects `_ALIASES_FILE` to a non-existent tmp path and scrubs the env var for every test; per-test monkeypatching still layers file/env tiers on top for the tests that want them.

## Context
- Source issue: sp-rmtj (discovered on polecat branch from d21bcb0; not an aliases.py regression — real aliases bleeding into tests).

## Test plan
- [x] `pytest tests/test_aliases.py --no-cov` — passes on a box with a user aliases file installed.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)