### PR TITLE
fix(mcp): extend_panel surfaces synthesis exceptions loudly (sp-0ozi)

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -45,6 +45,7 @@ from synth_panel._runners import (
     MAX_QUESTIONS,
     PANELIST_TIMEOUT,
     PanelTotalFailureError,
+    build_synthesis_error_payload,
     detect_total_failure,
 )
 from synth_panel._runners import (
@@ -1742,7 +1743,7 @@ async def extend_panel(
     if ctx is not None:
         await ctx.report_progress(0, len(personas))
 
-    def _go() -> tuple[list[PanelistResult], Any]:
+    def _go() -> tuple[list[PanelistResult], Any, dict[str, Any] | None]:
         client = _get_shared_client()
         results, _registry, _sessions = run_panel_parallel(
             client=client,
@@ -1754,6 +1755,7 @@ async def extend_panel(
             sessions=sessions,
         )
         synth = None
+        synth_error: dict[str, Any] | None = None
         if synthesis:
             try:
                 synth = synthesize_panel(
@@ -1764,12 +1766,25 @@ async def extend_panel(
                     panelist_model=model,
                     custom_prompt=synthesis_prompt,
                 )
-            except Exception:
+            except Exception as exc:
+                # sp-0ozi: surface the failure in the tool response envelope so
+                # MCP callers can distinguish "synthesis threw" from "synthesis
+                # skipped" or "synthesis produced empty output". Stays
+                # non-fatal — panelist results are still returned.
                 logger.error("extend_panel synthesis failed (non-fatal)", exc_info=True)
                 synth = None
-        return results, synth
+                synth_error = build_synthesis_error_payload(
+                    exc,
+                    error_type="synthesis_api_error",
+                    message=f"Synthesis call failed: {exc.__class__.__name__}: {exc}",
+                    suggested_fix=(
+                        "Check provider credentials and model availability;"
+                        " retry extend_panel once the underlying issue is resolved."
+                    ),
+                )
+        return results, synth, synth_error
 
-    panelist_results, synth = await asyncio.wait_for(
+    panelist_results, synth, synthesis_error = await asyncio.wait_for(
         asyncio.to_thread(_go),
         timeout=PANELIST_TIMEOUT * len(personas),
     )
@@ -1781,15 +1796,15 @@ async def extend_panel(
 
     # Append the ad-hoc round to the existing result and persist.
     rounds = existing.get("rounds") or []
-    rounds = [
-        *list(rounds),
-        {
-            "name": f"extension-{len(rounds) + 1}",
-            "results": new_round_results,
-            "synthesis": synth.to_dict() if synth is not None and hasattr(synth, "to_dict") else None,
-            "extension": True,
-        },
-    ]
+    new_round: dict[str, Any] = {
+        "name": f"extension-{len(rounds) + 1}",
+        "results": new_round_results,
+        "synthesis": synth.to_dict() if synth is not None and hasattr(synth, "to_dict") else None,
+        "extension": True,
+    }
+    if synthesis_error is not None:
+        new_round["synthesis_error"] = synthesis_error
+    rounds = [*list(rounds), new_round]
     path = list(existing.get("path") or [])
     path.append(
         {
@@ -1806,16 +1821,18 @@ async def extend_panel(
     updated["question_count"] = int(existing.get("question_count", 0)) + len(questions)
     update_panel_result(result_id, updated)
 
-    return json.dumps(
-        {
-            "result_id": result_id,
-            "appended_round": rounds[-1]["name"],
-            "results": new_round_results,
-            "synthesis": rounds[-1]["synthesis"],
-            "path": path,
-        },
-        indent=2,
-    )
+    response: dict[str, Any] = {
+        "result_id": result_id,
+        "appended_round": rounds[-1]["name"],
+        "results": new_round_results,
+        "synthesis": rounds[-1]["synthesis"],
+        "path": path,
+    }
+    if synthesis_error is not None:
+        # sp-0ozi: top-level synthesis_error so MCP clients can gate on
+        # envelope shape without inspecting the appended round.
+        response["synthesis_error"] = synthesis_error
+    return json.dumps(response, indent=2)
 
 
 @mcp.tool()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1008,3 +1008,68 @@ class TestWeightedModelSpecRejection:
         data = json.loads(result[0][0].text)
         assert "error" in data
         assert "haiku:0.5" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# extend_panel synthesis-failure loudness (sp-0ozi)
+# ---------------------------------------------------------------------------
+
+
+class TestExtendPanelSynthesisLoudness:
+    """sp-0ozi: synthesis exceptions must surface a structured
+    ``synthesis_error`` in the MCP response envelope, not silently null
+    ``synth``. The failure stays non-fatal — panelist results are still
+    returned."""
+
+    @pytest.mark.asyncio
+    async def test_synthesis_exception_populates_synthesis_error(self, monkeypatch):
+        from synth_panel.cost import TokenUsage
+        from synth_panel.mcp import server as _server
+        from synth_panel.orchestrator import PanelistResult
+
+        fake_existing = {"rounds": [], "path": [], "question_count": 0}
+        fake_sessions = {"Alice": object()}
+        fake_panelist = PanelistResult(
+            persona_name="Alice",
+            responses=[{"question": "q?", "answer": "a"}],
+            usage=TokenUsage(),
+            model="haiku",
+        )
+
+        class BoomSynth(Exception):
+            pass
+
+        def _raise(*args, **kwargs):
+            raise BoomSynth("upstream 500")
+
+        with (
+            patch("synth_panel.mcp.server._data_get_panel_result", return_value=fake_existing),
+            patch("synth_panel.mcp.server.load_panel_sessions", return_value=fake_sessions),
+            patch(
+                "synth_panel.mcp.server.run_panel_parallel",
+                return_value=([fake_panelist], {}, fake_sessions),
+            ),
+            patch("synth_panel.mcp.server.synthesize_panel", side_effect=_raise),
+            patch("synth_panel.mcp.server.update_panel_result"),
+            patch("synth_panel.mcp.server._get_shared_client", return_value=object()),
+        ):
+            # Call the tool function directly (ctx=None). mcp.call_tool
+            # injects a request-scoped Context that fails outside a request.
+            raw = await _server.extend_panel(
+                result_id="r-test",
+                questions=[{"text": "follow-up?"}],
+                model="haiku",
+                synthesis=True,
+                ctx=None,
+            )
+
+        data = json.loads(raw)
+        # Panelist results still come through — non-fatal semantic preserved.
+        assert data.get("results"), "panelist results must still be returned"
+        # synth field is null because synthesis threw.
+        assert data.get("synthesis") is None
+        # Top-level structured synthesis_error is the new contract.
+        err = data.get("synthesis_error")
+        assert isinstance(err, dict), "synthesis_error must be a dict on the envelope"
+        assert err.get("error_type") == "synthesis_api_error"
+        assert "upstream 500" in err.get("message", "")


### PR DESCRIPTION
## Summary
- Previously, if `synthesize_panel()` raised inside `extend_panel`, the tool silently set `synth=None`. MCP callers could not distinguish "synthesis skipped", "synthesis produced empty output", and "synthesis threw" from the response envelope alone.
- Wires `extend_panel` through the existing `build_synthesis_error_payload` helper (same shape used by `run_panel` via `_runners.py`), populating a top-level `synthesis_error` on the tool response and on the appended round.
- Failure stays non-fatal — panelist results are still returned — but is now legible on the wire.

## Context
- Source issue: sp-0ozi (parent audit: sp-qtgu META-AUDIT). Related: sp-0h9x.
- Touches `src/synth_panel/mcp/server.py:1598-1601` and the `synth` serialization path.

## Test plan
- [x] `pytest tests/test_mcp_server.py` — 65 new lines exercising the exception → `synthesis_error` wire format.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)