### PR TITLE
fix(conditions): warn loudly on unknown types and missing sentiment client (sp-t5ok)

### DIFF
--- a/src/synth_panel/conditions.py
+++ b/src/synth_panel/conditions.py
@@ -24,6 +24,11 @@ log = logging.getLogger(__name__)
 # A no-op context manager used when no lock is supplied.
 _noop_lock = contextlib.nullcontext()
 
+
+class ConditionError(ValueError):
+    """Raised when a follow-up condition string is malformed or unknown."""
+
+
 # ---------------------------------------------------------------------------
 # Evaluator registry
 # ---------------------------------------------------------------------------
@@ -39,6 +44,16 @@ EVALUATORS: dict[str, Callable[[str, str], bool]] = {
     "never": lambda _kw, _resp: False,
     "response_contains": _eval_contains,
 }
+
+# All condition type tokens that parse successfully. ``response_sentiment`` is
+# handled outside the EVALUATORS registry because it needs an LLM client.
+KNOWN_CONDITION_TYPES: frozenset[str] = frozenset({*EVALUATORS.keys(), "response_sentiment"})
+
+# Dedup tables so we warn loudly once per distinct problem rather than once
+# per evaluation (which would spam logs at panel scale). Entries persist for
+# the lifetime of the process.
+_warned_unknown_types: set[str] = set()
+_warned_missing_client: bool = False
 
 _SENTIMENT_PROMPT = (
     "Classify the sentiment of the following text as exactly one of: "
@@ -164,17 +179,67 @@ def evaluate_condition(
     # Handle response_sentiment separately (needs LLM client)
     if ctype == "response_sentiment":
         if client is None:
-            # Graceful degradation: no client → default to True
-            log.debug("response_sentiment: no client, defaulting to True")
+            # Graceful degradation: no client → default to True. Warn once so
+            # operators notice the silent always-fire, which is the opposite
+            # of the author's intent in adding a condition at all (sp-t5ok).
+            global _warned_missing_client
+            if not _warned_missing_client:
+                log.warning(
+                    "response_sentiment condition evaluated without an LLM client; "
+                    "defaulting to True (fires follow-up). Pass client= to evaluate_condition "
+                    "or configure an API key so gated follow-ups actually gate."
+                )
+                _warned_missing_client = True
+            else:
+                log.debug("response_sentiment: no client, defaulting to True")
             return True
         return _eval_sentiment(arg, response_text, client, sentiment_cache, sentiment_cache_lock)
 
     evaluator = EVALUATORS.get(ctype)
     if evaluator is None:
-        # Unknown condition type -- default to always (forward-compat)
+        # Unknown condition type → default to True for forward-compat, but
+        # warn once per distinct type. The likely cause is an instrument YAML
+        # typo (e.g. ``response_contians``) that would otherwise silently
+        # promote a gated follow-up to always-fire (sp-t5ok).
+        if ctype not in _warned_unknown_types:
+            log.warning(
+                "Unknown condition type %r; defaulting to True (fires follow-up). "
+                "Check your instrument YAML for a typo — known types: %s.",
+                ctype,
+                ", ".join(sorted(KNOWN_CONDITION_TYPES)),
+            )
+            _warned_unknown_types.add(ctype)
         return True
 
     return evaluator(arg, response_text)
+
+
+def validate_condition_string(condition: Any, *, context: str = "") -> None:
+    """Raise :class:`ConditionError` if *condition* does not parse to a known type.
+
+    Intended for parse-time validation (e.g. :mod:`synth_panel.instrument`) so
+    typos like ``response_contians: foo`` fail fast at load time instead of
+    silently defaulting to always-fire during a panel run (sp-t5ok).
+
+    ``always`` is permitted with or without an argument; the other parametric
+    types (``response_contains``, ``response_sentiment``) are permitted with
+    or without an argument here — empty-argument semantics are the evaluator's
+    responsibility.
+    """
+    prefix = f"{context}: " if context else ""
+    if not isinstance(condition, str):
+        raise ConditionError(f"{prefix}condition must be a string, got {type(condition).__name__}")
+
+    stripped = condition.strip()
+    if not stripped:
+        raise ConditionError(f"{prefix}condition must be a non-empty string")
+
+    ctype = stripped.partition(":")[0].strip().lower() if ":" in stripped else stripped.lower()
+    if ctype not in KNOWN_CONDITION_TYPES:
+        raise ConditionError(
+            f"{prefix}unknown condition type {ctype!r} in {condition!r}. "
+            f"Known types: {', '.join(sorted(KNOWN_CONDITION_TYPES))}."
+        )
 
 
 def normalize_follow_up(follow_up: str | dict) -> dict:

--- a/src/synth_panel/instrument.py
+++ b/src/synth_panel/instrument.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from synth_panel.conditions import ConditionError, validate_condition_string
 from synth_panel.structured.schemas import is_known_schema
 
 END_SENTINEL = "__end__"
@@ -182,6 +183,25 @@ def _validate_questions(questions: list[dict[str, Any]], context: str) -> None:
         rs = q.get("response_schema")
         if rs is not None:
             _validate_response_schema(rs, context=context, q_index=i)
+
+        follow_ups = q.get("follow_ups")
+        if isinstance(follow_ups, list):
+            for j, fu in enumerate(follow_ups):
+                # Plain-string follow-ups default to "always" at eval time and
+                # need no validation. Only dict-form follow-ups can carry an
+                # explicit condition that might be a typo (sp-t5ok).
+                if not isinstance(fu, dict):
+                    continue
+                cond = fu.get("condition")
+                if cond is None:
+                    continue
+                try:
+                    validate_condition_string(
+                        cond,
+                        context=f"{context} question[{i}] follow_ups[{j}]",
+                    )
+                except ConditionError as e:
+                    raise InstrumentError(str(e)) from e
 
 
 def parse_instrument(data: dict[str, Any]) -> Instrument:

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -5,8 +5,27 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
-from synth_panel.conditions import evaluate_condition, normalize_follow_up
+import pytest
+
+import synth_panel.conditions as conditions_module
+from synth_panel.conditions import (
+    ConditionError,
+    evaluate_condition,
+    normalize_follow_up,
+    validate_condition_string,
+)
 from synth_panel.llm.models import CompletionResponse, TextBlock, TokenUsage
+
+
+@pytest.fixture(autouse=True)
+def _reset_condition_warn_state():
+    """Reset the module-level warn dedup tables between tests."""
+    conditions_module._warned_unknown_types.clear()
+    conditions_module._warned_missing_client = False
+    yield
+    conditions_module._warned_unknown_types.clear()
+    conditions_module._warned_missing_client = False
+
 
 # ---------------------------------------------------------------------------
 # evaluate_condition — "always"
@@ -77,6 +96,23 @@ class TestUnknownCondition:
 
     def test_unknown_without_arg(self):
         assert evaluate_condition("future_check", "text") is True
+
+    def test_unknown_emits_warning_once(self, caplog):
+        """Typos log a warning on first occurrence so instrument authors notice."""
+        with caplog.at_level("WARNING", logger="synth_panel.conditions"):
+            evaluate_condition("response_contians: yes", "I said yes")
+            evaluate_condition("response_contians: yes", "and again")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "response_contians" in warnings[0].getMessage()
+        assert "typo" in warnings[0].getMessage().lower()
+
+    def test_distinct_unknowns_warn_separately(self, caplog):
+        with caplog.at_level("WARNING", logger="synth_panel.conditions"):
+            evaluate_condition("typo_one", "text")
+            evaluate_condition("typo_two", "text")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +203,15 @@ class TestResponseSentiment:
     def test_no_client_defaults_to_true(self):
         """Graceful degradation: no client means condition passes."""
         assert evaluate_condition("response_sentiment: negative", "text") is True
+
+    def test_no_client_warns_once(self, caplog):
+        """Missing client is a loud failure mode — first occurrence warns (sp-t5ok)."""
+        with caplog.at_level("WARNING", logger="synth_panel.conditions"):
+            evaluate_condition("response_sentiment: positive", "a")
+            evaluate_condition("response_sentiment: negative", "b")
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert len(warnings) == 1
+        assert "without an LLM client" in warnings[0].getMessage()
 
     def test_cache_hit_avoids_llm_call(self):
         client = _mock_client("positive")
@@ -312,3 +357,48 @@ class TestNormalizeFollowUp:
         inp = {"text": "Q?"}
         normalize_follow_up(inp)
         assert "condition" not in inp
+
+
+# ---------------------------------------------------------------------------
+# validate_condition_string (parse-time check, sp-t5ok)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateConditionString:
+    @pytest.mark.parametrize(
+        "condition",
+        [
+            "always",
+            "never",
+            "response_contains: yes",
+            "response_contains:",
+            "response_sentiment: positive",
+            "ALWAYS",
+            "  response_contains: anything  ",
+        ],
+    )
+    def test_known_conditions_pass(self, condition):
+        # Should not raise.
+        validate_condition_string(condition)
+
+    @pytest.mark.parametrize(
+        "condition",
+        [
+            "response_contians: yes",  # classic typo from sp-t5ok
+            "sentiment: positive",  # missing response_ prefix
+            "future_check",
+            "",
+            "   ",
+        ],
+    )
+    def test_unknown_or_empty_raises(self, condition):
+        with pytest.raises(ConditionError):
+            validate_condition_string(condition)
+
+    def test_non_string_raises(self):
+        with pytest.raises(ConditionError, match="must be a string"):
+            validate_condition_string(42)
+
+    def test_error_message_includes_context(self):
+        with pytest.raises(ConditionError, match="round 'probe'"):
+            validate_condition_string("response_contians: x", context="round 'probe'")

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -226,6 +226,73 @@ class TestValidation:
 
 
 # ---------------------------------------------------------------------------
+# Follow-up condition validation (sp-t5ok)
+# ---------------------------------------------------------------------------
+
+
+class TestFollowUpConditionValidation:
+    def test_unknown_condition_in_v1_raises(self):
+        data = {
+            "version": 1,
+            "questions": [
+                {
+                    "text": "Q?",
+                    "follow_ups": [
+                        {"text": "Why?", "condition": "response_contians: yes"},
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(InstrumentError, match="response_contians"):
+            parse_instrument(data)
+
+    def test_known_condition_in_v1_passes(self):
+        data = {
+            "version": 1,
+            "questions": [
+                {
+                    "text": "Q?",
+                    "follow_ups": [
+                        {"text": "Why?", "condition": "response_contains: yes"},
+                        {"text": "And?", "condition": "always"},
+                        "Plain string follow-up",
+                    ],
+                }
+            ],
+        }
+        inst = parse_instrument(data)
+        assert len(inst.rounds[0].questions) == 1
+
+    def test_unknown_condition_in_round_raises_with_context(self):
+        data = {
+            "version": 2,
+            "rounds": [
+                {
+                    "name": "probe",
+                    "questions": [
+                        {
+                            "text": "Q?",
+                            "follow_ups": [{"text": "Why?", "condition": "typo_here"}],
+                        }
+                    ],
+                }
+            ],
+        }
+        with pytest.raises(InstrumentError, match="round 'probe'"):
+            parse_instrument(data)
+
+    def test_no_condition_field_is_fine(self):
+        """A follow-up dict without a condition key is valid (defaults to always)."""
+        data = {
+            "version": 1,
+            "questions": [
+                {"text": "Q?", "follow_ups": [{"text": "Elaborate?"}]},
+            ],
+        }
+        parse_instrument(data)
+
+
+# ---------------------------------------------------------------------------
 # Dataclass behavior
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
A YAML typo (`response_contians: yes`) or a missing-client sentiment condition previously silently defaulted to `True`, promoting a gated follow-up to always-fire — the opposite of the instrument author's intent.

- Unknown condition type now logs a warning once per distinct type (was silent).
- `response_sentiment` without a client now warns once (was `log.debug`).
- New `validate_condition_string` + `ConditionError` for parse-time typo detection.
- Instrument parser validates each follow-up's `condition` so typos raise `InstrumentError` at load time instead of lurking until eval.

## Context
- Source issue: sp-t5ok (parent audit: sp-qtgu META-AUDIT).
- Touches `src/synth_panel/conditions.py:165-175` and the instrument parser.

## Test plan
- [x] `pytest tests/test_conditions.py tests/test_instrument.py` — 159 new lines covering unknown-type / missing-client / parse-time validation paths.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)