### PR TITLE
fix(orchestrator): record follow-up exceptions loudly (sp-319x)

### DIFF
--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -460,8 +460,21 @@ def _run_panelist(
                         }
                     )
                     tracker.record_turn(fu_summary.usage)
-                except Exception:
-                    continue
+                except Exception as exc:
+                    logger.warning(
+                        "panelist %s follow-up failed: %s: %s",
+                        name,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    responses.append(
+                        {
+                            "question": fu["text"],
+                            "response": f"[error: {exc}]",
+                            "error": True,
+                            "follow_up": True,
+                        }
+                    )
 
         # Transition: running → finished
         registry.set_result(worker_id, {"responses": responses}, tracker.cumulative_usage)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -425,6 +425,42 @@ class TestRunPanelParallel:
         assert results[0].responses[0]["question"] == "Main Q"
         assert results[0].responses[1].get("follow_up") is True
 
+    def test_follow_up_exception_recorded_loudly(self):
+        """sp-319x: follow-up turn exceptions must appear as error records, not be silently dropped."""
+        call_count = 0
+        lock = threading.Lock()
+
+        def side_effect(request):
+            nonlocal call_count
+            with lock:
+                call_count += 1
+                current = call_count
+            if current == 1:
+                return _make_text_response("Main answer")
+            raise ConnectionError("follow-up API down")
+
+        client = MagicMock()
+        client.send = MagicMock(side_effect=side_effect)
+
+        personas = [{"name": "Alice"}]
+        questions = [{"text": "Main Q", "follow_ups": ["Tell me more"]}]
+
+        results, _registry, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_simple_system_prompt,
+            question_prompt_fn=_simple_question_prompt,
+        )
+
+        resp = results[0].responses
+        assert len(resp) == 2, "follow-up must appear as an error record, not vanish"
+        assert resp[1].get("follow_up") is True
+        assert resp[1].get("error") is True
+        assert resp[1]["question"] == "Tell me more"
+        assert "follow-up API down" in resp[1]["response"]
+
     def test_usage_accumulated_per_panelist(self):
         usage = LLMTokenUsage(input_tokens=100, output_tokens=50)
         responses = [_make_text_response(usage=usage) for _ in range(2)]


### PR DESCRIPTION
## Summary
- Any exception during a conditional follow-up turn was silently swallowed by `except Exception: continue`, dropping the follow-up from `responses` with no counter, warning, or `error: true` record.
- Panel JSON surfaced N-1 follow-ups out of N configured with no way to distinguish expected condition-false skips from actual failures.
- Mirrors the main-question handler: appends an `error: True, follow_up: True` record with the exception string as the response, and emits a warning log.

## Context
- Source issue: sp-319x (parent audit: sp-qtgu META-AUDIT).
- Touches `src/synth_panel/orchestrator.py:451-463`.

## Test plan
- [x] `pytest tests/test_orchestrator.py` — new regression test exercising the exception path.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)