### PR TITLE
fix(release): auto-tag fails loudly for unlabeled release PRs (sp-42i)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -31,6 +31,7 @@ jobs:
         id: check
         env:
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           SEMVER_LABELS=$(echo "$LABELS" | jq -r '.[] | select(startswith("semver:"))' | grep -v '^semver:skip$' || true)
           SKIP=$(echo "$LABELS" | jq -r '.[] | select(. == "semver:skip")' || true)
@@ -44,6 +45,15 @@ jobs:
           COUNT=$(echo "$SEMVER_LABELS" | grep -c . || true)
 
           if [ "$COUNT" -eq 0 ]; then
+            # Release PRs (titled `chore(release): ...` or `release: ...`) MUST
+            # carry an explicit semver label. v0.9.2 (PR #163) merged without
+            # one, auto-tag silently skipped, PyPI publish never fired, and the
+            # release had to be cut by hand (sp-42i). Fail loudly for release
+            # PRs so the omission surfaces as a red check instead of vanishing.
+            if printf '%s' "$PR_TITLE" | grep -Eq '^(chore\(release\)|release):'; then
+              echo "::error::Release PR '$PR_TITLE' has no semver label. Add semver:patch, semver:minor, semver:major, or semver:skip and re-run this workflow."
+              exit 1
+            fi
             echo "No semver label found — skipping release"
             echo "skipped=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -7,6 +7,9 @@ Releases follow semver and are fully automated via GitHub Actions:
 1. **Open a PR** against `main` with your changes.
 2. **Add a semver label** to the PR: `semver:patch`, `semver:minor`, or `semver:major`.
    - Use `semver:skip` to merge without creating a release.
+   - **Release PRs are enforced.** If the PR title starts with `chore(release):`
+     or `release:`, `auto-tag.yml` fails loudly when no semver label is present
+     instead of silently skipping. Add a label and re-run the workflow.
 3. **Merge the PR.** On merge, `auto-tag.yml` runs:
    - Reads the semver label to determine the bump type.
    - Computes the next version from the latest `v*.*.*` tag.


### PR DESCRIPTION
## Summary
- v0.9.2 (PR #163) merged with no semver label. `auto-tag.yml` silently skipped, no tag was created, PyPI publish never fired, and the release had to be cut by hand. Same risk for any future `chore(release): ...` PR that forgets the label.
- Gates the silent-skip branch behind a title check: if the PR title starts with `chore(release):` or `release:` and no semver/skip label is present, emit a workflow error and exit 1.
- Non-release PRs keep the existing silent-skip behavior (most merges don't need a tag).
- Documents the contract in `docs/RELEASING.md` so contributors know the release PR title + label pair is enforced.

## Context
- Source issue: sp-42i (audit discovery; prevents future release cuts from being silently dropped).

## Test plan
- [ ] CI: workflow syntax validation via lint/typecheck jobs.
- [ ] Post-merge: next `chore(release):` PR must carry a `semver:*` label or the auto-tag job will fail fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)