### PR TITLE
feat(orchestrator): panelist-level checkpointing + --resume (sp-hsk3)

### DIFF
--- a/src/synth_panel/checkpoint.py
+++ b/src/synth_panel/checkpoint.py
@@ -1,0 +1,474 @@
+"""Panelist-level checkpointing for scaled panel runs (sp-hsk3).
+
+Slice (b) of sp-i2ub. Persists run state every K completed panelists so a
+crashed, SIGINT'd, or resource-exhausted run can resume without reprocessing
+panelists that already succeeded. A companion resume loader reconstitutes
+config + completed results so the orchestrator only picks up the remaining
+personas.
+
+Layout
+------
+    <root>/<run-id>/state.json
+
+The checkpoint is a single JSON document written atomically via temp-file
+rename. Each write fully rewrites the file; there is no append-log. This is
+fine for the target scale (10k panelists at ~KB each = ~10 MB, written
+every 25 panelists = ~400 rewrites).
+
+Resume flow
+-----------
+Callers load a checkpoint, compare its config fingerprint to the current
+invocation's config (rejecting drift), and feed ``completed`` back into
+the output pipeline while re-running only ``remaining`` personas.
+
+Signal handling
+---------------
+``CheckpointWriter.install_signal_handlers`` traps SIGINT and SIGTERM to
+flush the latest state before the previously-installed handler fires. The
+trap is idempotent and always restores the prior handler in
+``remove_signal_handlers``.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import logging
+import os
+import re
+import shutil
+import signal
+import tempfile
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_CHECKPOINT_EVERY = 25
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class CheckpointError(Exception):
+    """Base class for checkpoint-related errors."""
+
+
+class CheckpointNotFoundError(CheckpointError):
+    """Raised when a resume target doesn't exist on disk."""
+
+
+class CheckpointFormatError(CheckpointError):
+    """Raised when a checkpoint file is missing required fields or malformed."""
+
+
+class CheckpointDriftError(CheckpointError):
+    """Raised when the resume config doesn't match the original run's config.
+
+    Resuming under a changed instrument/persona/model mix would silently
+    produce a mixed-config dataset — not what "resume" promises. Refuse
+    rather than paper over it.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Paths and run ids
+# ---------------------------------------------------------------------------
+
+
+def default_checkpoint_root() -> Path:
+    """Default root: ``$SYNTHPANEL_CHECKPOINT_ROOT`` or ``~/.synthpanel/checkpoints``."""
+    env = os.environ.get("SYNTHPANEL_CHECKPOINT_ROOT")
+    if env:
+        return Path(env)
+    return Path.home() / ".synthpanel" / "checkpoints"
+
+
+def new_run_id() -> str:
+    """Build a fresh UTC-timestamped run id with a short suffix for uniqueness."""
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    suffix = uuid.uuid4().hex[:6]
+    return f"run-{stamp}-{suffix}"
+
+
+def _validate_run_id(run_id: str) -> None:
+    if not _RUN_ID_RE.match(run_id):
+        raise CheckpointError(f"invalid run id {run_id!r}: only alphanumerics, dot, underscore, dash (max 128 chars)")
+
+
+def checkpoint_dir_for(run_id: str, root: Path | None = None) -> Path:
+    """Return the directory holding checkpoint state for ``run_id``."""
+    _validate_run_id(run_id)
+    r = Path(root) if root is not None else default_checkpoint_root()
+    return r / run_id
+
+
+def _state_path(directory: Path) -> Path:
+    return Path(directory) / "state.json"
+
+
+# ---------------------------------------------------------------------------
+# Config fingerprint
+# ---------------------------------------------------------------------------
+
+
+def fingerprint_config(config: dict[str, Any]) -> str:
+    """Deterministic fingerprint so resume can reject config drift."""
+    blob = json.dumps(config, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PanelCheckpoint:
+    """Snapshot of a panel run sufficient to resume without reprocessing."""
+
+    run_id: str
+    created_at: str
+    updated_at: str
+    config_fingerprint: str
+    config: dict[str, Any]
+    # One dict per completed panelist. Shape mirrors the CLI's result dict
+    # so the caller can feed ``completed`` straight back into the output
+    # pipeline without re-deriving anything.
+    completed: list[dict[str, Any]] = field(default_factory=list)
+    # Persona names still to run, in authored order.
+    remaining: list[str] = field(default_factory=list)
+    # Accumulated usage (TokenUsage.to_dict() shape) across completed panelists.
+    usage: dict[str, Any] = field(default_factory=dict)
+    # Populated on signal-triggered flush so consumers can distinguish a
+    # mid-run snapshot from a voluntary abort.
+    abort_reason: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "run_id": self.run_id,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "config_fingerprint": self.config_fingerprint,
+            "config": self.config,
+            "completed": self.completed,
+            "remaining": self.remaining,
+            "usage": self.usage,
+            "abort_reason": self.abort_reason,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> PanelCheckpoint:
+        for key in (
+            "run_id",
+            "created_at",
+            "updated_at",
+            "config_fingerprint",
+            "config",
+        ):
+            if key not in data:
+                raise CheckpointFormatError(f"checkpoint missing required field: {key!r}")
+        return cls(
+            run_id=data["run_id"],
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+            config_fingerprint=data["config_fingerprint"],
+            config=data["config"],
+            completed=list(data.get("completed", [])),
+            remaining=list(data.get("remaining", [])),
+            usage=dict(data.get("usage", {})),
+            abort_reason=data.get("abort_reason"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Atomic I/O
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".ckpt-")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, separators=(",", ":"), default=str)
+        shutil.move(tmp, str(path))
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def save_checkpoint(checkpoint: PanelCheckpoint, directory: Path | str) -> None:
+    """Write ``checkpoint`` to ``<directory>/state.json`` atomically."""
+    d = Path(directory)
+    checkpoint.updated_at = datetime.now(timezone.utc).isoformat()
+    _atomic_write_json(_state_path(d), checkpoint.to_dict())
+
+
+def load_checkpoint(run_id: str, root: Path | None = None) -> PanelCheckpoint:
+    """Load the checkpoint for ``run_id`` from ``root`` (default ~/.synthpanel/checkpoints)."""
+    directory = checkpoint_dir_for(run_id, root)
+    path = _state_path(directory)
+    if not path.exists():
+        raise CheckpointNotFoundError(f"no checkpoint at {path}")
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CheckpointFormatError(f"checkpoint at {path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise CheckpointFormatError(f"checkpoint at {path} is not a JSON object")
+    return PanelCheckpoint.from_dict(data)
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+class CheckpointWriter:
+    """Thread-safe writer that snapshots run state every K completed panelists.
+
+    Usage pattern::
+
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=checkpoint_dir_for(run_id),
+            config=config_dict,
+            all_personas=[p["name"] for p in personas],
+            every=25,
+        )
+        writer.install_signal_handlers()
+        try:
+            for result in run_panel(...):
+                writer.record_completed(result_dict, usage_increment)
+        finally:
+            writer.flush()
+            writer.remove_signal_handlers()
+
+    The writer is resume-aware: pre-populated with ``preloaded_completed``
+    and ``preloaded_usage`` on resume, new completions extend those. The
+    resulting checkpoint always contains the full set of finished panelists,
+    not just the current run's slice.
+    """
+
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        directory: Path | str,
+        config: dict[str, Any],
+        all_personas: list[str],
+        every: int = DEFAULT_CHECKPOINT_EVERY,
+        preloaded_completed: list[dict[str, Any]] | None = None,
+        preloaded_usage: dict[str, Any] | None = None,
+    ) -> None:
+        _validate_run_id(run_id)
+        if every < 1:
+            raise ValueError(f"checkpoint every must be >= 1 (got {every})")
+        self.run_id = run_id
+        self.directory = Path(directory)
+        self.config = dict(config)
+        self.config_fingerprint = fingerprint_config(self.config)
+        self.all_personas = list(all_personas)
+        self.every = every
+        self.completed: list[dict[str, Any]] = list(preloaded_completed or [])
+        self._completed_names: set[str] = {_persona_name_of(r) for r in self.completed if _persona_name_of(r)}
+        self.usage: dict[str, Any] = dict(preloaded_usage or {})
+        self._created_at = datetime.now(timezone.utc).isoformat()
+        self._lock = threading.Lock()
+        self._since_flush = 0
+        self._abort_reason: str | None = None
+        self._prev_sigint: Any = None
+        self._prev_sigterm: Any = None
+        self._handlers_installed = False
+
+    # -- Signal handling -----------------------------------------------------
+
+    def install_signal_handlers(self) -> None:
+        """Trap SIGINT/SIGTERM to flush the latest state before propagating.
+
+        Idempotent. Only installs handlers on the main thread; on other
+        threads ``signal.signal`` raises ValueError — we log and skip.
+        """
+        if self._handlers_installed:
+            return
+        try:
+            self._prev_sigint = signal.signal(signal.SIGINT, self._signal_handler)
+            self._prev_sigterm = signal.signal(signal.SIGTERM, self._signal_handler)
+            self._handlers_installed = True
+        except ValueError:
+            # Not on the main thread — caller will get uninstrumented signals.
+            # We still work correctly, just lose SIGINT flush. This happens
+            # in pytest when fixtures run checkpointing from worker threads.
+            logger.debug(
+                "checkpoint: signal handlers not installable (not on main thread); relying on explicit flush()",
+            )
+
+    def remove_signal_handlers(self) -> None:
+        if not self._handlers_installed:
+            return
+        with contextlib.suppress(ValueError):
+            signal.signal(signal.SIGINT, self._prev_sigint)
+            signal.signal(signal.SIGTERM, self._prev_sigterm)
+        self._handlers_installed = False
+
+    def _signal_handler(self, signum: int, frame: Any) -> None:
+        name = signal.Signals(signum).name if signum in (signal.SIGINT, signal.SIGTERM) else str(signum)
+        logger.warning("checkpoint: %s received — flushing state to %s", name, self.directory)
+        self._abort_reason = f"signal:{name}"
+        try:
+            self.flush(force=True)
+        except Exception as exc:  # pragma: no cover - best-effort
+            logger.error("checkpoint: flush during %s failed: %s", name, exc)
+        # Re-raise via the previously-installed handler so callers still see
+        # KeyboardInterrupt / terminate. If the previous handler is not a
+        # callable (SIG_DFL / SIG_IGN), restore it and re-send.
+        prev = self._prev_sigint if signum == signal.SIGINT else self._prev_sigterm
+        if callable(prev):
+            prev(signum, frame)
+        else:
+            with contextlib.suppress(ValueError):
+                signal.signal(signum, prev if prev is not None else signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+
+    # -- Recording / flushing -----------------------------------------------
+
+    def record_completed(
+        self,
+        result: dict[str, Any],
+        usage_increment: dict[str, Any] | None = None,
+    ) -> None:
+        """Record one finished panelist and flush if the cadence fires.
+
+        ``result`` must be the CLI-shaped dict (``persona``, ``responses``,
+        ``usage``, ``cost``, ``error``, optional ``model``). ``usage_increment``
+        is the delta to add to the running ``usage`` rollup — usually
+        ``result['usage']`` but callers may supply a pre-summed variant.
+        """
+        name = _persona_name_of(result)
+        with self._lock:
+            if name and name in self._completed_names:
+                # Idempotent on duplicate records — orchestrator shouldn't
+                # emit them but a resumed run could race with a stale write.
+                return
+            self.completed.append(result)
+            if name:
+                self._completed_names.add(name)
+            if usage_increment:
+                self.usage = _merge_usage(self.usage, usage_increment)
+            self._since_flush += 1
+            should_flush = self._since_flush >= self.every
+
+        if should_flush:
+            self.flush()
+
+    def mark_aborted(self, reason: str) -> None:
+        """Tag the next (and final) flush with a human-readable abort reason."""
+        with self._lock:
+            self._abort_reason = reason
+
+    def flush(self, force: bool = False) -> None:
+        """Persist the current state. No-op if nothing has been recorded yet.
+
+        ``force=True`` writes even when the cadence counter is zero — used
+        by the signal handler and the orchestrator's final flush.
+        """
+        with self._lock:
+            if not force and self._since_flush == 0:
+                return
+            ckpt = self._build_checkpoint_locked()
+            self._since_flush = 0
+        save_checkpoint(ckpt, self.directory)
+
+    def build_checkpoint(self) -> PanelCheckpoint:
+        """Return the current checkpoint without writing."""
+        with self._lock:
+            return self._build_checkpoint_locked()
+
+    def _build_checkpoint_locked(self) -> PanelCheckpoint:
+        return PanelCheckpoint(
+            run_id=self.run_id,
+            created_at=self._created_at,
+            updated_at=datetime.now(timezone.utc).isoformat(),
+            config_fingerprint=self.config_fingerprint,
+            config=self.config,
+            completed=list(self.completed),
+            remaining=[n for n in self.all_personas if n not in self._completed_names],
+            usage=dict(self.usage),
+            abort_reason=self._abort_reason,
+        )
+
+    # -- Accessors ----------------------------------------------------------
+
+    def remaining(self) -> list[str]:
+        with self._lock:
+            return [n for n in self.all_personas if n not in self._completed_names]
+
+    def completed_names(self) -> set[str]:
+        with self._lock:
+            return set(self._completed_names)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _persona_name_of(result: dict[str, Any]) -> str:
+    value = result.get("persona") if isinstance(result, dict) else None
+    return value if isinstance(value, str) else ""
+
+
+_USAGE_INT_KEYS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "reasoning_tokens",
+    "cached_tokens",
+)
+
+
+def _merge_usage(
+    current: dict[str, Any],
+    increment: dict[str, Any],
+) -> dict[str, Any]:
+    """Add two TokenUsage.to_dict() payloads without losing provider cost."""
+    merged = dict(current)
+    for key in _USAGE_INT_KEYS:
+        if key in increment:
+            merged[key] = int(merged.get(key, 0)) + int(increment[key])
+    if "provider_reported_cost" in increment:
+        prev = merged.get("provider_reported_cost")
+        add = increment["provider_reported_cost"]
+        if prev is None and add is None:
+            merged.pop("provider_reported_cost", None)
+        else:
+            merged["provider_reported_cost"] = float(prev or 0.0) + float(add or 0.0)
+    return merged
+
+
+def ensure_config_matches(
+    checkpoint: PanelCheckpoint,
+    current_config: dict[str, Any],
+) -> None:
+    """Raise :class:`CheckpointDriftError` if the fingerprints disagree."""
+    current_fp = fingerprint_config(current_config)
+    if current_fp != checkpoint.config_fingerprint:
+        raise CheckpointDriftError(
+            f"resume config drift: checkpoint fingerprint "
+            f"{checkpoint.config_fingerprint[:12]}... does not match current "
+            f"fingerprint {current_fp[:12]}... — rerun without --resume or "
+            f"restore the original config to continue"
+        )

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -23,6 +23,18 @@ from synth_panel._runners import (
     format_synthesis_overflow_message,
     format_total_failure_message,
 )
+from synth_panel.checkpoint import (
+    DEFAULT_CHECKPOINT_EVERY,
+    CheckpointDriftError,
+    CheckpointError,
+    CheckpointNotFoundError,
+    CheckpointWriter,
+    checkpoint_dir_for,
+    default_checkpoint_root,
+    ensure_config_matches,
+    load_checkpoint,
+    new_run_id,
+)
 from synth_panel.cli.output import OutputFormat, emit
 from synth_panel.convergence import (
     DEFAULT_CHECK_EVERY,
@@ -753,6 +765,84 @@ def _emit_dry_run_preview(
     emit(fmt, message="Dry-run preview", extra=preview)
 
 
+# ── sp-hsk3: checkpoint helpers ──────────────────────────────────────
+# These bridge :mod:`synth_panel.checkpoint` (which speaks JSON dicts,
+# no domain types) with the orchestrator's :class:`PanelistResult`.
+# Kept here rather than in ``checkpoint.py`` so that module stays free
+# of CLI / cost concerns and is reusable from the MCP surface later.
+
+
+def _panelist_result_to_ckpt_dict(pr: PanelistResult, fallback_model: str) -> dict[str, Any]:
+    """Serialize a :class:`PanelistResult` in the same shape the CLI emits."""
+    pr_model = pr.model or fallback_model
+    pricing, _is_estimated = lookup_pricing(pr_model)
+    cost = estimate_cost(pr.usage, pricing)
+    record: dict[str, Any] = {
+        "persona": pr.persona_name,
+        "responses": pr.responses,
+        "usage": pr.usage.to_dict(),
+        "cost": cost.format_usd(),
+        "error": pr.error,
+    }
+    if pr.model:
+        record["model"] = pr.model
+    return record
+
+
+def _panelist_result_from_dict(record: dict[str, Any]) -> PanelistResult:
+    """Reconstitute a :class:`PanelistResult` from a checkpoint record."""
+    usage_dict = record.get("usage") or {}
+    usage = TokenUsage.from_dict(usage_dict) if usage_dict else ZERO_USAGE
+    return PanelistResult(
+        persona_name=record.get("persona", "Anonymous"),
+        responses=list(record.get("responses") or []),
+        usage=usage,
+        error=record.get("error"),
+        model=record.get("model"),
+    )
+
+
+def _merge_usage_dicts(current: dict[str, Any], increment: dict[str, Any]) -> dict[str, Any]:
+    """Add two ``TokenUsage.to_dict()`` payloads without dropping provider cost."""
+    from synth_panel.checkpoint import _merge_usage
+
+    return _merge_usage(current, increment)
+
+
+def _build_run_config_fingerprint(
+    *,
+    personas: list[dict[str, Any]],
+    questions: list[dict[str, Any]],
+    model: str,
+    persona_models: dict[str, str] | None,
+    temperature: float | None,
+    top_p: float | None,
+    response_schema: dict[str, Any] | None,
+    extract_schema: dict[str, Any] | None,
+    template_vars: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Build a stable-key config dict whose hash detects resume drift.
+
+    Only the fields that would materially alter panelist responses are
+    included. Things like --checkpoint-every or stdout formatting are
+    deliberately excluded so a user can change them mid-resume.
+    """
+    question_texts = [(q.get("text") if isinstance(q, dict) else str(q)) for q in questions]
+    return {
+        "persona_names": [p.get("name", "Anonymous") for p in personas],
+        "persona_count": len(personas),
+        "question_texts": question_texts,
+        "question_count": len(questions),
+        "model": model,
+        "persona_models": dict(persona_models) if persona_models else None,
+        "temperature": temperature,
+        "top_p": top_p,
+        "response_schema": response_schema,
+        "extract_schema": extract_schema,
+        "template_vars": dict(template_vars) if template_vars else None,
+    }
+
+
 def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Run a panel: load personas + instrument, run panelists in parallel."""
     # ── sp-prof: profile loading ──────────────────────────────────────
@@ -1277,6 +1367,95 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     # Run all panelists in parallel via the orchestrator
     blend_result = None  # populated only when --blend is active
+
+    # ── sp-hsk3: checkpoint + resume wiring ────────────────────────────
+    # We snapshot progress every K completed panelists so a crashed or
+    # SIGINT'd run can resume via `synthpanel panel run --resume <id>`.
+    # Only wired into the standard (non-ensemble, non-blend) path: those
+    # paths have their own multi-run structure and would need their own
+    # checkpoint strategy. If the user combined them with --resume or
+    # --checkpoint-dir we fail loud earlier rather than silently ignoring
+    # the flags.
+    checkpoint_root = getattr(args, "checkpoint_dir", None)
+    resume_id = getattr(args, "resume", None)
+    checkpoint_every = getattr(args, "checkpoint_every", None) or DEFAULT_CHECKPOINT_EVERY
+    wants_checkpoint = bool(checkpoint_root) or bool(resume_id)
+    if wants_checkpoint and (blend_mode or ensemble_mode or getattr(args, "variants", None)):
+        print(
+            "Error: --checkpoint-dir and --resume are not supported with "
+            "--blend, --models ensemble runs, or --variants; rerun without "
+            "those flags.",
+            file=sys.stderr,
+        )
+        return 1
+
+    checkpoint_writer: CheckpointWriter | None = None
+    preloaded_results: list[PanelistResult] = []
+    resumed_config_note: str | None = None
+    active_personas = personas  # may be filtered below on resume
+    if wants_checkpoint:
+        root_path = Path(checkpoint_root) if checkpoint_root else default_checkpoint_root()
+        run_config_dict = _build_run_config_fingerprint(
+            personas=personas,
+            questions=questions,
+            model=model,
+            persona_models=persona_models,
+            temperature=temperature,
+            top_p=top_p,
+            response_schema=response_schema,
+            extract_schema=extract_schema,
+            template_vars=template_vars,
+        )
+        if resume_id:
+            try:
+                ckpt = load_checkpoint(resume_id, root_path)
+            except CheckpointNotFoundError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 1
+            except CheckpointError as exc:
+                print(f"Error: checkpoint load failed: {exc}", file=sys.stderr)
+                return 1
+            try:
+                ensure_config_matches(ckpt, run_config_dict)
+            except CheckpointDriftError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 1
+            # Reconstitute completed panelists as PanelistResult so the
+            # downstream output pipeline (cost/metadata/synthesis) sees
+            # a single unified list across the original + resumed slices.
+            preloaded_results = [_panelist_result_from_dict(r) for r in ckpt.completed]
+            skip = {pr.persona_name for pr in preloaded_results}
+            active_personas = [p for p in personas if p.get("name", "Anonymous") not in skip]
+            resumed_config_note = (
+                f"resumed run {resume_id}: {len(preloaded_results)} panelists "
+                f"already complete, {len(active_personas)} remaining"
+            )
+            print(resumed_config_note, file=sys.stderr)
+            run_id = resume_id
+            directory = checkpoint_dir_for(run_id, root_path)
+        else:
+            run_id = new_run_id()
+            directory = checkpoint_dir_for(run_id, root_path)
+            print(
+                f"Checkpointing enabled: run_id={run_id} dir={directory} every={checkpoint_every}",
+                file=sys.stderr,
+            )
+
+        preloaded_usage_dict = ZERO_USAGE.to_dict()
+        for pr in preloaded_results:
+            preloaded_usage_dict = _merge_usage_dicts(preloaded_usage_dict, pr.usage.to_dict())
+
+        checkpoint_writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=run_config_dict,
+            all_personas=[p.get("name", "Anonymous") for p in personas],
+            every=checkpoint_every,
+            preloaded_completed=[_panelist_result_to_ckpt_dict(pr, model) for pr in preloaded_results],
+            preloaded_usage=preloaded_usage_dict,
+        )
+        checkpoint_writer.install_signal_handlers()
+
     if blend_mode and model_spec:
         # ── Blend mode: run full panel once per model, then blend ────
         from synth_panel.ensemble import blend_distributions, ensemble_run
@@ -1301,21 +1480,48 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # Flatten all panelist results across models for output + synthesis
         panelist_results = [pr for mr in ensemble.model_results for pr in mr.panelist_results]
     else:
-        panelist_results, _registry, _sessions = run_panel_parallel(
-            client=client,
-            personas=personas,
-            questions=questions,
-            model=model,
-            system_prompt_fn=system_prompt_fn,
-            question_prompt_fn=build_question_prompt,
-            response_schema=response_schema,
-            extract_schema=extract_schema,
-            temperature=temperature,
-            top_p=top_p,
-            persona_models=persona_models,
-            max_workers=max_concurrent,
-            convergence_tracker=convergence_tracker,
-        )
+
+        def _on_complete(pr: PanelistResult) -> None:
+            if checkpoint_writer is None:
+                return
+            record = _panelist_result_to_ckpt_dict(pr, model)
+            checkpoint_writer.record_completed(record, pr.usage.to_dict())
+
+        try:
+            panelist_results, _registry, _sessions = run_panel_parallel(
+                client=client,
+                personas=active_personas,
+                questions=questions,
+                model=model,
+                system_prompt_fn=system_prompt_fn,
+                question_prompt_fn=build_question_prompt,
+                response_schema=response_schema,
+                extract_schema=extract_schema,
+                temperature=temperature,
+                top_p=top_p,
+                persona_models=persona_models,
+                max_workers=max_concurrent,
+                convergence_tracker=convergence_tracker,
+                on_panelist_complete=_on_complete if checkpoint_writer else None,
+            )
+        finally:
+            if checkpoint_writer is not None:
+                try:
+                    checkpoint_writer.flush(force=True)
+                finally:
+                    checkpoint_writer.remove_signal_handlers()
+
+        # sp-hsk3: merge preloaded (resumed) results with fresh ones, in
+        # the original persona order. Preloaded results are guaranteed to
+        # be disjoint from `panelist_results` because we filtered their
+        # names out of `active_personas`.
+        if preloaded_results:
+            by_name: dict[str, PanelistResult] = {pr.persona_name: pr for pr in preloaded_results}
+            for pr in panelist_results:
+                by_name[pr.persona_name] = pr
+            panelist_results = [
+                by_name[p.get("name", "Anonymous")] for p in personas if p.get("name", "Anonymous") in by_name
+            ]
 
     # Build output results and aggregate panelist usage
     results: list[dict[str, Any]] = []

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -396,6 +396,46 @@ def build_parser() -> argparse.ArgumentParser:
             "values (e.g. 0.5 for one request every two seconds)."
         ),
     )
+    # sp-hsk3: panelist-level checkpointing + resume
+    panel_run_parser.add_argument(
+        "--checkpoint-dir",
+        default=None,
+        metavar="PATH",
+        dest="checkpoint_dir",
+        help=(
+            "Directory under which to persist per-run checkpoints. Each run "
+            "gets its own subdirectory (<PATH>/<run-id>/state.json). "
+            "Defaults to $SYNTHPANEL_CHECKPOINT_ROOT or "
+            "~/.synthpanel/checkpoints. Setting this flag opts into "
+            "checkpointing; omit it to run without on-disk snapshots."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="checkpoint_every",
+        help=(
+            "Flush a checkpoint every N completed panelists (default: 25). "
+            "Lower values mean more frequent disk writes; higher values "
+            "risk losing more progress on abrupt termination. Only takes "
+            "effect with --checkpoint-dir or --resume."
+        ),
+    )
+    panel_run_parser.add_argument(
+        "--resume",
+        default=None,
+        metavar="RUN_ID",
+        dest="resume",
+        help=(
+            "Resume a previously-checkpointed run by id. Skips panelists "
+            "that already completed, replays the rest, and merges results "
+            "into one final output. Refuses to start if the current config "
+            "does not match the checkpointed config — rerun without "
+            "--resume or restore the original config to continue."
+        ),
+    )
     # sp-yaru: convergence telemetry for large panels
     panel_run_parser.add_argument(
         "--convergence-check-every",

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -543,6 +543,7 @@ def run_panel_parallel(
     top_p: float | None = None,
     persona_models: dict[str, str] | None = None,
     convergence_tracker: ConvergenceTracker | None = None,
+    on_panelist_complete: Callable[[PanelistResult], None] | None = None,
 ) -> tuple[list[PanelistResult], WorkerRegistry, dict[str, Session]]:
     """Run all panelists in parallel and return ordered results.
 
@@ -573,6 +574,12 @@ def run_panel_parallel(
             cancelled and ``run_panel_parallel`` returns only the panelists
             that had already finished. Errored panelists are still surfaced
             — they never contribute to the running distributions.
+        on_panelist_complete: Optional callback invoked once per panelist the
+            moment their future resolves (sp-hsk3). Used by
+            :mod:`synth_panel.checkpoint` to snapshot progress every K
+            completions so a crashed or SIGINT'd run can resume. Exceptions
+            raised by the callback are logged and suppressed — a broken
+            checkpoint writer must never kill a live run.
 
     Returns:
         Tuple of (ordered results matching persona order, registry,
@@ -655,6 +662,20 @@ def run_panel_parallel(
                     error=str(exc),
                     model=model,
                 )
+
+            # sp-hsk3: invoke the checkpoint callback for every resolved
+            # panelist, success or failure. Errored panelists still count
+            # as "done" for resume purposes — otherwise a persistent
+            # upstream outage would stall the cadence forever.
+            if on_panelist_complete is not None and results[idx] is not None:
+                try:
+                    on_panelist_complete(results[idx])  # type: ignore[arg-type]
+                except Exception as cb_exc:  # pragma: no cover - defensive
+                    logger.warning(
+                        "on_panelist_complete callback failed: %s: %s",
+                        type(cb_exc).__name__,
+                        cb_exc,
+                    )
 
             if convergence_tracker is not None and results[idx] is not None:
                 completed_result = results[idx]

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,0 +1,600 @@
+"""Panelist-level checkpointing tests (sp-hsk3 / sp-i2ub slice b).
+
+Covers:
+  - Periodic flush every K completed panelists.
+  - Signal-triggered flush on SIGINT.
+  - Resume skips already-completed panelists and merges results.
+  - Config fingerprint drift is rejected on resume.
+  - Abort reason is preserved and surfaced on resume.
+  - Usage accumulation across resume boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from synth_panel.checkpoint import (
+    CheckpointDriftError,
+    CheckpointFormatError,
+    CheckpointNotFoundError,
+    CheckpointWriter,
+    PanelCheckpoint,
+    _merge_usage,
+    checkpoint_dir_for,
+    ensure_config_matches,
+    fingerprint_config,
+    load_checkpoint,
+    new_run_id,
+    save_checkpoint,
+)
+from synth_panel.llm.models import (
+    CompletionResponse,
+    StopReason,
+    TextBlock,
+)
+from synth_panel.llm.models import (
+    TokenUsage as LLMTokenUsage,
+)
+from synth_panel.orchestrator import PanelistResult, run_panel_parallel
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(text: str = "ok") -> CompletionResponse:
+    return CompletionResponse(
+        id="resp",
+        model="claude-sonnet",
+        content=[TextBlock(text=text)],
+        stop_reason=StopReason.END_TURN,
+        usage=LLMTokenUsage(input_tokens=10, output_tokens=5),
+    )
+
+
+def _mock_client() -> MagicMock:
+    client = MagicMock()
+    client.send = MagicMock(return_value=_make_response())
+    return client
+
+
+def _persona(name: str) -> dict[str, Any]:
+    return {"name": name, "age": 30}
+
+
+def _system_prompt(persona: dict[str, Any]) -> str:
+    return f"You are {persona['name']}."
+
+
+def _question_prompt(question: dict[str, Any]) -> str:
+    return question["text"] if isinstance(question, dict) else str(question)
+
+
+def _make_config(persona_names: list[str]) -> dict[str, Any]:
+    return {
+        "persona_names": persona_names,
+        "persona_count": len(persona_names),
+        "question_texts": ["What do you think?"],
+        "question_count": 1,
+        "model": "sonnet",
+        "temperature": 0.7,
+        "top_p": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint + config drift
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprint:
+    def test_fingerprint_is_deterministic(self) -> None:
+        config = _make_config(["Alice", "Bob"])
+        assert fingerprint_config(config) == fingerprint_config(dict(config))
+
+    def test_fingerprint_sensitive_to_persona_list(self) -> None:
+        a = fingerprint_config(_make_config(["Alice", "Bob"]))
+        b = fingerprint_config(_make_config(["Alice", "Carol"]))
+        assert a != b
+
+    def test_fingerprint_sensitive_to_model(self) -> None:
+        cfg_a = _make_config(["Alice"])
+        cfg_b = dict(cfg_a)
+        cfg_b["model"] = "haiku"
+        assert fingerprint_config(cfg_a) != fingerprint_config(cfg_b)
+
+    def test_ensure_config_matches_accepts_identical(self) -> None:
+        cfg = _make_config(["Alice"])
+        ckpt = PanelCheckpoint(
+            run_id="run-x",
+            created_at="now",
+            updated_at="now",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+        )
+        ensure_config_matches(ckpt, cfg)  # no raise
+
+    def test_ensure_config_matches_rejects_drift(self) -> None:
+        cfg = _make_config(["Alice"])
+        ckpt = PanelCheckpoint(
+            run_id="run-x",
+            created_at="now",
+            updated_at="now",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+        )
+        drifted = dict(cfg)
+        drifted["model"] = "haiku"
+        with pytest.raises(CheckpointDriftError):
+            ensure_config_matches(ckpt, drifted)
+
+
+# ---------------------------------------------------------------------------
+# Save / load
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoad:
+    def test_round_trip(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice", "Bob"])
+        ckpt = PanelCheckpoint(
+            run_id="run-abc",
+            created_at="2026-04-24T00:00:00Z",
+            updated_at="2026-04-24T00:00:00Z",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+            completed=[{"persona": "Alice", "responses": [], "usage": {}, "error": None}],
+            remaining=["Bob"],
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        directory = checkpoint_dir_for("run-abc", tmp_path)
+        save_checkpoint(ckpt, directory)
+        loaded = load_checkpoint("run-abc", tmp_path)
+        assert loaded.run_id == "run-abc"
+        assert loaded.completed[0]["persona"] == "Alice"
+        assert loaded.remaining == ["Bob"]
+        assert loaded.usage["input_tokens"] == 10
+        assert loaded.config_fingerprint == ckpt.config_fingerprint
+
+    def test_load_missing_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(CheckpointNotFoundError):
+            load_checkpoint("run-does-not-exist", tmp_path)
+
+    def test_load_malformed_raises(self, tmp_path: Path) -> None:
+        directory = checkpoint_dir_for("run-bad", tmp_path)
+        directory.mkdir(parents=True)
+        (directory / "state.json").write_text("not valid json")
+        with pytest.raises(CheckpointFormatError):
+            load_checkpoint("run-bad", tmp_path)
+
+    def test_save_is_atomic(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice"])
+        ckpt = PanelCheckpoint(
+            run_id="run-atomic",
+            created_at="now",
+            updated_at="now",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+        )
+        directory = checkpoint_dir_for("run-atomic", tmp_path)
+        save_checkpoint(ckpt, directory)
+        save_checkpoint(ckpt, directory)  # rewrite should not leave tmp files
+        leftovers = [p for p in directory.iterdir() if p.name.startswith(".ckpt-")]
+        assert leftovers == []
+
+
+# ---------------------------------------------------------------------------
+# Merge usage helper
+# ---------------------------------------------------------------------------
+
+
+class TestMergeUsage:
+    def test_integers_sum(self) -> None:
+        merged = _merge_usage(
+            {"input_tokens": 10, "output_tokens": 5},
+            {"input_tokens": 3, "output_tokens": 2},
+        )
+        assert merged["input_tokens"] == 13
+        assert merged["output_tokens"] == 7
+
+    def test_provider_cost_sums(self) -> None:
+        merged = _merge_usage(
+            {"provider_reported_cost": 0.10},
+            {"provider_reported_cost": 0.05},
+        )
+        assert merged["provider_reported_cost"] == pytest.approx(0.15)
+
+    def test_provider_cost_both_none_stays_absent(self) -> None:
+        merged = _merge_usage({"input_tokens": 1}, {"output_tokens": 1})
+        assert "provider_reported_cost" not in merged
+
+
+# ---------------------------------------------------------------------------
+# CheckpointWriter cadence + remaining
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointWriter:
+    def test_flushes_every_k_panelists(self, tmp_path: Path) -> None:
+        run_id = "run-cadence"
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        cfg = _make_config(["a", "b", "c", "d", "e"])
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=cfg,
+            all_personas=["a", "b", "c", "d", "e"],
+            every=2,
+        )
+        for name in ["a", "b"]:
+            writer.record_completed(
+                {"persona": name, "responses": [], "usage": {"input_tokens": 1}, "error": None},
+                {"input_tokens": 1},
+            )
+        # 2 completions at every=2 → should have flushed
+        assert (directory / "state.json").exists()
+        loaded = load_checkpoint(run_id, tmp_path)
+        assert {c["persona"] for c in loaded.completed} == {"a", "b"}
+        assert loaded.remaining == ["c", "d", "e"]
+        assert loaded.usage["input_tokens"] == 2
+
+    def test_flush_no_op_before_first_record(self, tmp_path: Path) -> None:
+        run_id = "run-empty"
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=_make_config(["a"]),
+            all_personas=["a"],
+            every=25,
+        )
+        writer.flush()
+        assert not (directory / "state.json").exists()
+
+    def test_force_flush_writes_even_without_records(self, tmp_path: Path) -> None:
+        run_id = "run-force"
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=_make_config(["a"]),
+            all_personas=["a"],
+            every=25,
+        )
+        writer.flush(force=True)
+        assert (directory / "state.json").exists()
+
+    def test_idempotent_duplicate_records(self, tmp_path: Path) -> None:
+        run_id = "run-dupe"
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=_make_config(["a", "b"]),
+            all_personas=["a", "b"],
+            every=1,
+        )
+        record = {"persona": "a", "responses": [], "usage": {"input_tokens": 1}, "error": None}
+        writer.record_completed(record, {"input_tokens": 1})
+        writer.record_completed(record, {"input_tokens": 1})  # duplicate
+        loaded = load_checkpoint(run_id, tmp_path)
+        assert sum(1 for c in loaded.completed if c["persona"] == "a") == 1
+        # usage should only have counted once
+        assert loaded.usage["input_tokens"] == 1
+
+    def test_preloaded_state_preserved_and_extended(self, tmp_path: Path) -> None:
+        run_id = "run-preload"
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        preloaded = [{"persona": "a", "responses": [], "usage": {"input_tokens": 10}, "error": None}]
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=_make_config(["a", "b", "c"]),
+            all_personas=["a", "b", "c"],
+            every=1,
+            preloaded_completed=preloaded,
+            preloaded_usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        assert writer.remaining() == ["b", "c"]
+        writer.record_completed(
+            {"persona": "b", "responses": [], "usage": {"input_tokens": 3}, "error": None},
+            {"input_tokens": 3},
+        )
+        loaded = load_checkpoint(run_id, tmp_path)
+        assert {c["persona"] for c in loaded.completed} == {"a", "b"}
+        assert loaded.remaining == ["c"]
+        assert loaded.usage["input_tokens"] == 13
+        assert loaded.usage["output_tokens"] == 5
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator callback integration
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestratorCallback:
+    def test_callback_invoked_for_every_panelist(self, tmp_path: Path) -> None:
+        client = _mock_client()
+        personas = [_persona(n) for n in ("Alice", "Bob", "Carol")]
+        questions = [{"text": "What do you think?"}]
+        seen: list[str] = []
+        lock = threading.Lock()
+
+        def cb(pr: PanelistResult) -> None:
+            with lock:
+                seen.append(pr.persona_name)
+
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_system_prompt,
+            question_prompt_fn=_question_prompt,
+            on_panelist_complete=cb,
+        )
+        assert len(results) == 3
+        assert set(seen) == {"Alice", "Bob", "Carol"}
+
+    def test_callback_exceptions_do_not_kill_run(self) -> None:
+        client = _mock_client()
+        personas = [_persona("Alice"), _persona("Bob")]
+        questions = [{"text": "Q"}]
+
+        def cb(pr: PanelistResult) -> None:
+            raise RuntimeError("boom")
+
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="sonnet",
+            system_prompt_fn=_system_prompt,
+            question_prompt_fn=_question_prompt,
+            on_panelist_complete=cb,
+        )
+        assert len(results) == 2
+        assert all(r.error is None for r in results)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: run → "SIGINT" → resume completes all panelists
+# ---------------------------------------------------------------------------
+
+
+def _simulate_run_with_abort(
+    *,
+    tmp_path: Path,
+    persona_names: list[str],
+    abort_after: int,
+) -> tuple[str, list[PanelistResult]]:
+    """Drive a partial run whose checkpoint gets flushed after ``abort_after``.
+
+    Mirrors what happens when SIGINT fires mid-run: the writer has already
+    flushed up through ``abort_after`` because we set ``every=1``. We then
+    stop the run without completing the remaining panelists. This is the
+    equivalent of a SIGINT landing at the same cadence boundary, but lets
+    the test stay single-threaded and deterministic.
+    """
+    run_id = new_run_id()
+    directory = checkpoint_dir_for(run_id, tmp_path)
+    cfg = _make_config(persona_names)
+    writer = CheckpointWriter(
+        run_id=run_id,
+        directory=directory,
+        config=cfg,
+        all_personas=persona_names,
+        every=1,
+    )
+    partial: list[PanelistResult] = []
+    for name in persona_names[:abort_after]:
+        pr = PanelistResult(
+            persona_name=name,
+            responses=[{"question": "Q", "response": f"A from {name}"}],
+            usage=LLMTokenUsage(input_tokens=7, output_tokens=3).__class__
+            and LLMTokenUsage(input_tokens=7, output_tokens=3),
+        )
+        # We're reusing LLMTokenUsage, but PanelistResult.usage is
+        # synth_panel.cost.TokenUsage — convert.
+        from synth_panel.cost import TokenUsage as CostTokenUsage
+
+        pr.usage = CostTokenUsage(input_tokens=7, output_tokens=3)
+        partial.append(pr)
+        writer.record_completed(
+            {
+                "persona": name,
+                "responses": pr.responses,
+                "usage": pr.usage.to_dict(),
+                "error": None,
+            },
+            pr.usage.to_dict(),
+        )
+    writer.mark_aborted("signal:SIGINT")
+    writer.flush(force=True)
+    return run_id, partial
+
+
+class TestResumeEndToEnd:
+    def test_sigint_at_7_resume_finishes_all_10(self, tmp_path: Path) -> None:
+        persona_names = [f"p{i:02d}" for i in range(10)]
+        run_id, _partial = _simulate_run_with_abort(tmp_path=tmp_path, persona_names=persona_names, abort_after=7)
+
+        # Resume path: load checkpoint, verify config, rerun remaining.
+        ckpt = load_checkpoint(run_id, tmp_path)
+        assert ckpt.abort_reason == "signal:SIGINT"
+        assert {c["persona"] for c in ckpt.completed} == set(persona_names[:7])
+        assert ckpt.remaining == persona_names[7:]
+
+        cfg = _make_config(persona_names)
+        ensure_config_matches(ckpt, cfg)
+
+        # Rerun only the remaining personas via orchestrator with a fresh
+        # writer that carries the preloaded slice.
+        remaining_personas = [_persona(n) for n in ckpt.remaining]
+        client = _mock_client()
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=cfg,
+            all_personas=persona_names,
+            every=25,
+            preloaded_completed=ckpt.completed,
+            preloaded_usage=ckpt.usage,
+        )
+        assert writer.remaining() == persona_names[7:]
+
+        def cb(pr: PanelistResult) -> None:
+            writer.record_completed(
+                {
+                    "persona": pr.persona_name,
+                    "responses": pr.responses,
+                    "usage": pr.usage.to_dict(),
+                    "error": pr.error,
+                },
+                pr.usage.to_dict(),
+            )
+
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=remaining_personas,
+            questions=[{"text": "What do you think?"}],
+            model="sonnet",
+            system_prompt_fn=_system_prompt,
+            question_prompt_fn=_question_prompt,
+            on_panelist_complete=cb,
+        )
+        writer.flush(force=True)
+        assert sorted(r.persona_name for r in results) == sorted(persona_names[7:])
+
+        # Final checkpoint: contains all 10 panelists.
+        final = load_checkpoint(run_id, tmp_path)
+        assert sorted(c["persona"] for c in final.completed) == sorted(persona_names)
+        assert final.remaining == []
+
+    def test_resume_rejects_config_drift(self, tmp_path: Path) -> None:
+        run_id, _ = _simulate_run_with_abort(tmp_path=tmp_path, persona_names=["a", "b", "c"], abort_after=1)
+        ckpt = load_checkpoint(run_id, tmp_path)
+        drifted = _make_config(["a", "b", "c"])
+        drifted["model"] = "haiku"  # user changed model between runs
+        with pytest.raises(CheckpointDriftError):
+            ensure_config_matches(ckpt, drifted)
+
+
+# ---------------------------------------------------------------------------
+# Signal handler trap (main thread only)
+# ---------------------------------------------------------------------------
+
+
+class TestSignalHandlers:
+    def test_sigint_triggers_flush_and_propagates(self, tmp_path: Path) -> None:
+        """Send SIGINT to ourselves → writer flushes, KeyboardInterrupt fires."""
+        run_id = "run-sig"
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=_make_config(["a", "b", "c"]),
+            all_personas=["a", "b", "c"],
+            every=25,
+        )
+        writer.install_signal_handlers()
+        try:
+            # Record one completion so flush has something to write.
+            writer.record_completed(
+                {"persona": "a", "responses": [], "usage": {"input_tokens": 1}, "error": None},
+                {"input_tokens": 1},
+            )
+            with pytest.raises(KeyboardInterrupt):
+                os.kill(os.getpid(), signal.SIGINT)
+                # The default SIGINT handler raises KeyboardInterrupt
+                # synchronously after our handler returns. Give the
+                # interpreter a tick to deliver the signal.
+                time.sleep(0.05)
+            assert (directory / "state.json").exists()
+            loaded = load_checkpoint(run_id, tmp_path)
+            assert loaded.abort_reason == "signal:SIGINT"
+            assert {c["persona"] for c in loaded.completed} == {"a"}
+        finally:
+            writer.remove_signal_handlers()
+
+    def test_install_handlers_idempotent(self, tmp_path: Path) -> None:
+        run_id = "run-sig-idem"
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=checkpoint_dir_for(run_id, tmp_path),
+            config=_make_config(["a"]),
+            all_personas=["a"],
+            every=1,
+        )
+        writer.install_signal_handlers()
+        writer.install_signal_handlers()  # no-op, no raise
+        writer.remove_signal_handlers()
+        writer.remove_signal_handlers()  # no-op, no raise
+
+
+# ---------------------------------------------------------------------------
+# CLI helpers smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestCLIHelpers:
+    def test_panelist_result_round_trips_through_dict(self) -> None:
+        from synth_panel.cli.commands import (
+            _panelist_result_from_dict,
+            _panelist_result_to_ckpt_dict,
+        )
+        from synth_panel.cost import TokenUsage as CostTokenUsage
+
+        pr = PanelistResult(
+            persona_name="Alice",
+            responses=[{"question": "Q", "response": "A"}],
+            usage=CostTokenUsage(input_tokens=10, output_tokens=5),
+            error=None,
+            model="sonnet",
+        )
+        record = _panelist_result_to_ckpt_dict(pr, fallback_model="sonnet")
+        # Survives a JSON round trip (important for on-disk persistence).
+        record = json.loads(json.dumps(record))
+        restored = _panelist_result_from_dict(record)
+        assert restored.persona_name == "Alice"
+        assert restored.usage.input_tokens == 10
+        assert restored.usage.output_tokens == 5
+        assert restored.responses == [{"question": "Q", "response": "A"}]
+        assert restored.model == "sonnet"
+
+    def test_build_run_config_fingerprint_is_stable(self) -> None:
+        from synth_panel.cli.commands import _build_run_config_fingerprint
+
+        cfg_a = _build_run_config_fingerprint(
+            personas=[{"name": "Alice"}, {"name": "Bob"}],
+            questions=[{"text": "Q"}],
+            model="sonnet",
+            persona_models=None,
+            temperature=0.7,
+            top_p=None,
+            response_schema=None,
+            extract_schema=None,
+            template_vars=None,
+        )
+        cfg_b = _build_run_config_fingerprint(
+            personas=[{"name": "Alice"}, {"name": "Bob"}],
+            questions=[{"text": "Q"}],
+            model="sonnet",
+            persona_models=None,
+            temperature=0.7,
+            top_p=None,
+            response_schema=None,
+            extract_schema=None,
+            template_vars=None,
+        )
+        assert fingerprint_config(cfg_a) == fingerprint_config(cfg_b)


### PR DESCRIPTION
## Summary

- Adds `src/synth_panel/checkpoint.py`: atomic on-disk snapshots, `CheckpointWriter` that flushes every K panelists and traps SIGINT/SIGTERM, resume-aware `load_checkpoint` + fingerprint drift detection.
- Wires `--checkpoint-dir`, `--checkpoint-every`, `--resume RUN_ID` into `synthpanel panel run`. Resume rejects config drift, filters to remaining personas, and merges preloaded results back into the final output in original order.
- Orchestrator gains an `on_panelist_complete` callback so checkpointing stays decoupled from the run loop. Callback failures are logged and swallowed.
- Combining checkpointing with `--blend` / `--models` ensemble / `--variants` fails loud — those paths need their own strategies (out of scope for slice b).

Slice (b) of sp-i2ub: rate limits + checkpointing + cost gates + partial results. Slice (a) (rate limits) shipped in #225. This PR is slice (b) only.

## Test plan

- [x] `ruff check src/ tests/` — passes
- [x] `ruff format --check src/ tests/` — passes
- [x] `pytest tests/ -q --no-cov --ignore=tests/test_aliases.py --ignore=tests/test_mcp_stdio_sampling.py` — 1561 passed
- [x] New `tests/test_checkpoint.py` (25 tests): fingerprint drift, atomic save/load, cadence, preloaded state, orchestrator callback, signal-triggered flush, and the acceptance-grade end-to-end (run 10, abort after 7, resume → final has all 10).
- [x] `synthpanel panel run --help` surfaces the new flags with clear copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)