### PR TITLE
feat(cost): --max-cost mid-run projected-total gate (sp-utnk)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -38,6 +38,7 @@ from synth_panel.convergence import (
 from synth_panel.cost import (
     ZERO_USAGE,
     CostEstimate,
+    CostGate,
     TokenUsage,
     aggregate_per_model,
     build_cost_fallback_warnings,
@@ -1050,6 +1051,21 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             file=sys.stderr,
         )
 
+    # sp-utnk: optional mid-run cost gate. Declared before mode branching
+    # so downstream reporting code can inspect gate state regardless of
+    # which runner path executed. Only the parallel single-model path
+    # wires it into the orchestrator — ensemble/blend runs ignore it
+    # because their cost-accounting structure is richer and needs a
+    # separate design.
+    cost_gate: CostGate | None = None
+    max_cost_usd = getattr(args, "max_cost", None)
+    if max_cost_usd is not None and max_cost_usd <= 0:
+        print(
+            f"Error: --max-cost must be > 0, got {max_cost_usd}.",
+            file=sys.stderr,
+        )
+        return 1
+
     # ── Ensemble mode: run with each model, compare across models ────────
     if ensemble_mode:
         from synth_panel.ensemble import build_ensemble_output, ensemble_run
@@ -1301,6 +1317,9 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # Flatten all panelist results across models for output + synthesis
         panelist_results = [pr for mr in ensemble.model_results for pr in mr.panelist_results]
     else:
+        if max_cost_usd is not None:
+            cost_gate = CostGate(max_cost_usd=max_cost_usd, total_panelists=len(personas))
+
         panelist_results, _registry, _sessions = run_panel_parallel(
             client=client,
             personas=personas,
@@ -1315,6 +1334,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             persona_models=persona_models,
             max_workers=max_concurrent,
             convergence_tracker=convergence_tracker,
+            cost_gate=cost_gate,
         )
 
     # Build output results and aggregate panelist usage
@@ -1382,6 +1402,18 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     )
     if missing_input_invalid:
         run_invalid = True
+
+    # sp-utnk: mid-run cost gate tripped. The orchestrator has already
+    # cancelled pending futures, so ``panelist_results`` is a valid
+    # prefix. Mark the run invalid and carry the gate snapshot so
+    # consumers (CI, MCP) can key on ``cost_exceeded`` without parsing
+    # banner text.
+    cost_gate_halted = cost_gate is not None and cost_gate.should_halt()
+    if cost_gate_halted:
+        run_invalid = True
+        # Skip synthesis on a halted partial — synthesizing a
+        # deliberately-truncated panel would burn more budget without
+        # delivering a trustworthy result.
 
     # Compute panelist costs (needed before synthesis for cost estimate).
     # For multi-model runs, sum the per-model costs so the total reflects
@@ -1591,6 +1623,19 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         missing_input_invalid=missing_input_invalid,
         total_failure=total_failure,
     )
+    # sp-utnk: if the cost gate tripped, the failure-stats banner may not
+    # render (no errored pairs, no refusals). Synthesize a dedicated line
+    # so TEXT-mode operators and stderr-grepping CI both see the halt.
+    if cost_gate_halted and cost_gate is not None:
+        snap = cost_gate.snapshot()
+        cost_banner = (
+            "⚠️  PANEL RUN HALTED: cost ceiling exceeded — "
+            f"projected ${snap['projected_total_usd']:.4f} > "
+            f"max ${snap['max_cost_usd']:.4f} after "
+            f"{snap['completed']}/{snap['total_panelists']} panelists "
+            f"(running ${snap['running_cost_usd']:.4f})"
+        )
+        banner = f"{banner}\n{cost_banner}" if banner else cost_banner
 
     if fmt is OutputFormat.TEXT:
         if banner:
@@ -1773,6 +1818,12 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         extra["failure_stats"] = failure_stats
         extra["missing_input_stats"] = missing_input_stats
         extra["run_invalid"] = bool(run_invalid or strict_violation)
+        # sp-utnk: surface cost-gate outcome for CI/MCP consumers.
+        if cost_gate_halted and cost_gate is not None:
+            extra["cost_exceeded"] = True
+            extra["halted_at_panelist"] = cost_gate.completed
+            extra["cost_gate"] = cost_gate.snapshot()
+            extra["abort_reason"] = "cost_exceeded"
         if total_failure is not None:
             # sp-efip: carry the structured total-failure diagnostic so
             # CI/MCP consumers can detect the "every panelist failed"

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -396,6 +396,22 @@ def build_parser() -> argparse.ArgumentParser:
             "values (e.g. 0.5 for one request every two seconds)."
         ),
     )
+    # sp-utnk: mid-run cost gate (projected-total ceiling)
+    panel_run_parser.add_argument(
+        "--max-cost",
+        type=float,
+        default=None,
+        metavar="USD",
+        dest="max_cost",
+        help=(
+            "Hard ceiling on total panel spend, in USD. After each "
+            "panelist completes, running_cost / completed_n * total_n is "
+            "compared against this ceiling; if the projected total "
+            "exceeds it, the run halts gracefully and produces a valid "
+            "partial JSON result with run_invalid: true and "
+            "cost_exceeded: true. Exit code 2. Default: off."
+        ),
+    )
     # sp-yaru: convergence telemetry for large panels
     panel_run_parser.add_argument(
         "--convergence-check-every",

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
@@ -711,3 +712,119 @@ class BudgetGate:
     @property
     def remaining(self) -> int:
         return max(0, self.max_tokens - self._tracker.cumulative_usage.total_tokens)
+
+
+# ---------------------------------------------------------------------------
+# sp-utnk: Mid-run cost gate (projected-total ceiling)
+# ---------------------------------------------------------------------------
+
+
+class CostGate:
+    """Projected-total USD cost ceiling for a panel run.
+
+    Records each panelist's completed cost as the panel progresses, then
+    extrapolates the remaining spend linearly:
+
+        projected_total = running_cost / completed * total_panelists
+
+    When ``projected_total`` exceeds ``max_cost_usd``, :meth:`should_halt`
+    returns ``True`` and callers should stop dispatching further panelists
+    and surface a partial, ``run_invalid`` result.
+
+    Thread-safe: all mutations and reads are guarded by an internal lock
+    so the orchestrator can call :meth:`record` from completion callbacks
+    in any worker thread.
+
+    The first panelist's completion is always allowed — a single-sample
+    projection ``cost * total_panelists`` is noisy and the projection only
+    has meaning once at least one panelist has finished. Once halted, the
+    gate stays halted (idempotent) so late-arriving completions do not
+    flip it back off.
+    """
+
+    def __init__(self, max_cost_usd: float, total_panelists: int) -> None:
+        if max_cost_usd <= 0:
+            raise ValueError(f"max_cost_usd must be > 0, got {max_cost_usd!r}")
+        if total_panelists <= 0:
+            raise ValueError(f"total_panelists must be > 0, got {total_panelists!r}")
+        self.max_cost_usd = float(max_cost_usd)
+        self.total_panelists = int(total_panelists)
+        self._lock = threading.Lock()
+        self._running_cost: float = 0.0
+        self._completed: int = 0
+        self._halted: bool = False
+        self._halted_projection: float | None = None
+
+    def record(self, panelist_cost_usd: float) -> bool:
+        """Record one panelist's final cost; return True if the gate is now halted.
+
+        ``panelist_cost_usd`` should already include synthesis overhead
+        attributable to that panelist *if* the caller is tracking it that
+        way; otherwise pass just the panelist's LLM turn costs. Negative
+        values are treated as 0.
+        """
+        cost = max(0.0, float(panelist_cost_usd))
+        with self._lock:
+            self._running_cost += cost
+            self._completed += 1
+            projected = self._projected_total_locked()
+            if projected > self.max_cost_usd and not self._halted:
+                self._halted = True
+                self._halted_projection = projected
+                logger.warning(
+                    "cost gate tripped: projected $%.4f > max $%.4f after %d/%d panelists (running $%.4f)",
+                    projected,
+                    self.max_cost_usd,
+                    self._completed,
+                    self.total_panelists,
+                    self._running_cost,
+                )
+            return self._halted
+
+    def should_halt(self) -> bool:
+        with self._lock:
+            return self._halted
+
+    @property
+    def running_cost(self) -> float:
+        with self._lock:
+            return self._running_cost
+
+    @property
+    def completed(self) -> int:
+        with self._lock:
+            return self._completed
+
+    @property
+    def halted_projection(self) -> float | None:
+        """The projected total at the moment the gate halted, or None."""
+        with self._lock:
+            return self._halted_projection
+
+    def projected_total(self) -> float:
+        """Linear extrapolation of running cost to all panelists.
+
+        Returns 0.0 before any panelist completes.
+        """
+        with self._lock:
+            return self._projected_total_locked()
+
+    def _projected_total_locked(self) -> float:
+        if self._completed == 0:
+            return 0.0
+        return self._running_cost / self._completed * self.total_panelists
+
+    def snapshot(self) -> dict[str, float | int | bool | None]:
+        """Machine-readable status for structured output."""
+        with self._lock:
+            return {
+                "max_cost_usd": self.max_cost_usd,
+                "running_cost_usd": round(self._running_cost, 6),
+                "completed": self._completed,
+                "total_panelists": self.total_panelists,
+                "projected_total_usd": round(self._projected_total_locked(), 6),
+                "halted": self._halted,
+                "halted_projection_usd": (
+                    round(self._halted_projection, 6) if self._halted_projection is not None else None
+                ),
+            }

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -19,7 +19,7 @@ from typing import Any
 
 from synth_panel.conditions import evaluate_condition, normalize_follow_up
 from synth_panel.convergence import ConvergenceTracker, extract_categorical_responses
-from synth_panel.cost import ZERO_USAGE, TokenUsage, UsageTracker
+from synth_panel.cost import ZERO_USAGE, CostGate, TokenUsage, UsageTracker, resolve_cost
 from synth_panel.instrument import END_SENTINEL, Instrument, Round
 from synth_panel.llm.client import LLMClient
 from synth_panel.llm.models import InputMessage, TextBlock
@@ -543,6 +543,7 @@ def run_panel_parallel(
     top_p: float | None = None,
     persona_models: dict[str, str] | None = None,
     convergence_tracker: ConvergenceTracker | None = None,
+    cost_gate: CostGate | None = None,
 ) -> tuple[list[PanelistResult], WorkerRegistry, dict[str, Session]]:
     """Run all panelists in parallel and return ordered results.
 
@@ -573,6 +574,12 @@ def run_panel_parallel(
             cancelled and ``run_panel_parallel`` returns only the panelists
             that had already finished. Errored panelists are still surfaced
             — they never contribute to the running distributions.
+        cost_gate: Optional :class:`CostGate`. Each completing panelist's
+            priced cost is recorded against the gate; if the projected run
+            total exceeds the gate's ceiling, pending futures are cancelled
+            and only finished panelists are returned. The caller is expected
+            to inspect ``cost_gate.should_halt()`` on return and surface a
+            partial, ``run_invalid`` result.
 
     Returns:
         Tuple of (ordered results matching persona order, registry,
@@ -675,6 +682,28 @@ def run_panel_parallel(
                             if not pending_future.done():
                                 pending_future.cancel()
                         break
+
+            # sp-utnk: cost-gate check. Price the completed panelist using
+            # its per-panelist model (falls back to the run-level default)
+            # and record against the gate. If the projected run total
+            # exceeds the gate, cancel pending futures and return what we
+            # have — the caller synthesizes a partial, run_invalid result.
+            if cost_gate is not None and results[idx] is not None:
+                completed_result = results[idx]
+                assert completed_result is not None
+                pr_model = completed_result.model or model
+                priced = resolve_cost(completed_result.usage, pr_model)
+                halted = cost_gate.record(priced.total_cost)
+                if halted:
+                    logger.info(
+                        "cost gate tripped after %d/%d panelists; cancelling pending futures",
+                        cost_gate.completed,
+                        len(personas),
+                    )
+                    for pending_future in future_to_index:
+                        if not pending_future.done():
+                            pending_future.cancel()
+                    break
 
     # All slots should be filled (unless auto-stop cancelled some); drop Nones
     return [r for r in results if r is not None], registry, out_sessions

--- a/tests/test_cost_gate.py
+++ b/tests/test_cost_gate.py
@@ -1,0 +1,452 @@
+"""Tests for sp-utnk: mid-run --max-cost gate.
+
+Covers three layers:
+
+* ``CostGate`` unit semantics — projection math, halt-on-trip idempotency,
+  thread safety, snapshot shape.
+* Orchestrator integration — gate trips cancel pending futures and return
+  the already-completed prefix of panelists.
+* CLI integration — ``panel run --max-cost`` produces a valid partial
+  JSON result with ``run_invalid``, ``cost_exceeded``, ``halted_at_panelist``
+  and a non-zero exit code.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synth_panel.cost import CostGate
+from synth_panel.cost import TokenUsage as CostTokenUsage
+from synth_panel.llm.models import CompletionResponse, StopReason, TextBlock
+from synth_panel.llm.models import TokenUsage as LLMTokenUsage
+from synth_panel.main import main
+from synth_panel.orchestrator import run_panel_parallel
+from synth_panel.persistence import ConversationMessage
+from synth_panel.runtime import TurnSummary
+
+# ---------------------------------------------------------------------------
+# CostGate unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCostGateUnit:
+    def test_rejects_non_positive_max_cost(self):
+        with pytest.raises(ValueError):
+            CostGate(max_cost_usd=0, total_panelists=10)
+        with pytest.raises(ValueError):
+            CostGate(max_cost_usd=-1.0, total_panelists=10)
+
+    def test_rejects_non_positive_total(self):
+        with pytest.raises(ValueError):
+            CostGate(max_cost_usd=1.0, total_panelists=0)
+
+    def test_no_halt_before_any_completion(self):
+        gate = CostGate(max_cost_usd=1.00, total_panelists=10)
+        assert gate.should_halt() is False
+        assert gate.projected_total() == 0.0
+        assert gate.completed == 0
+        assert gate.running_cost == 0.0
+
+    def test_single_completion_projects_linearly(self):
+        """Projection = running / completed * total."""
+        gate = CostGate(max_cost_usd=10.00, total_panelists=10)
+        # First panelist costs $0.50 → projected total = 0.50 / 1 * 10 = $5.00
+        halted = gate.record(0.50)
+        assert halted is False
+        assert gate.projected_total() == pytest.approx(5.00)
+        assert gate.completed == 1
+        assert gate.running_cost == pytest.approx(0.50)
+
+    def test_halts_when_projection_exceeds_ceiling(self):
+        gate = CostGate(max_cost_usd=1.00, total_panelists=10)
+        # First panelist costs $0.20 → projected = 0.20 / 1 * 10 = $2.00 > $1.00
+        halted = gate.record(0.20)
+        assert halted is True
+        assert gate.should_halt() is True
+        assert gate.halted_projection == pytest.approx(2.00)
+
+    def test_halt_is_idempotent(self):
+        """Once halted the gate stays halted and records don't flip it back."""
+        gate = CostGate(max_cost_usd=1.00, total_panelists=10)
+        gate.record(0.20)  # trips
+        first_proj = gate.halted_projection
+        # Later sample with lower amortized cost still leaves gate halted.
+        gate.record(0.0)
+        assert gate.should_halt() is True
+        # ``halted_projection`` captures the first trip, not later state.
+        assert gate.halted_projection == first_proj
+
+    def test_projection_tightens_with_more_samples(self):
+        """Late samples change the projection but do not un-halt."""
+        gate = CostGate(max_cost_usd=1.00, total_panelists=4)
+        # $0.10 * 4 = $0.40 — safe
+        assert gate.record(0.10) is False
+        # running=$0.20, completed=2 → projected = 0.20 / 2 * 4 = $0.40 — safe
+        assert gate.record(0.10) is False
+        assert gate.should_halt() is False
+        # Spike the third panelist: running=$0.80, completed=3 →
+        # projected = 0.80 / 3 * 4 ≈ $1.067 > $1.00 — trips.
+        assert gate.record(0.60) is True
+        assert gate.should_halt() is True
+
+    def test_negative_cost_clamped_to_zero(self):
+        gate = CostGate(max_cost_usd=1.0, total_panelists=10)
+        gate.record(-5.0)
+        assert gate.running_cost == 0.0
+        assert gate.should_halt() is False
+
+    def test_snapshot_is_machine_readable(self):
+        gate = CostGate(max_cost_usd=1.00, total_panelists=10)
+        gate.record(0.20)  # halts
+        snap = gate.snapshot()
+        assert snap["halted"] is True
+        assert snap["completed"] == 1
+        assert snap["total_panelists"] == 10
+        assert snap["max_cost_usd"] == pytest.approx(1.00)
+        assert snap["running_cost_usd"] == pytest.approx(0.20)
+        assert snap["projected_total_usd"] == pytest.approx(2.00)
+        assert snap["halted_projection_usd"] == pytest.approx(2.00)
+
+    def test_snapshot_when_not_halted(self):
+        gate = CostGate(max_cost_usd=100.00, total_panelists=10)
+        gate.record(0.01)
+        snap = gate.snapshot()
+        assert snap["halted"] is False
+        assert snap["halted_projection_usd"] is None
+
+    def test_thread_safety_concurrent_records(self):
+        """Concurrent record() calls must not lose accounting."""
+        gate = CostGate(max_cost_usd=1_000_000.0, total_panelists=10_000)
+        n_threads = 32
+        per_thread = 200
+        barrier = threading.Barrier(n_threads)
+
+        def worker() -> None:
+            barrier.wait()
+            for _ in range(per_thread):
+                gate.record(0.001)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        expected_completed = n_threads * per_thread
+        assert gate.completed == expected_completed
+        assert gate.running_cost == pytest.approx(expected_completed * 0.001, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration
+# ---------------------------------------------------------------------------
+
+
+def _heavy_response() -> CompletionResponse:
+    """A response with enough tokens to have a non-trivial priced cost."""
+    # sonnet pricing: $3/MTok input, $15/MTok output → 100k/50k ≈ $0.30 + $0.75 = $1.05 per panelist.
+    return CompletionResponse(
+        id="resp",
+        model="claude-sonnet-4-6",
+        content=[TextBlock(text="ok")],
+        stop_reason=StopReason.END_TURN,
+        usage=LLMTokenUsage(input_tokens=100_000, output_tokens=50_000),
+    )
+
+
+def _light_response() -> CompletionResponse:
+    return CompletionResponse(
+        id="resp",
+        model="claude-sonnet-4-6",
+        content=[TextBlock(text="ok")],
+        stop_reason=StopReason.END_TURN,
+        usage=LLMTokenUsage(input_tokens=10, output_tokens=5),
+    )
+
+
+def _system(p: dict[str, Any]) -> str:
+    return f"You are {p['name']}"
+
+
+def _question(q: dict[str, Any]) -> str:
+    return q["text"]
+
+
+class TestOrchestratorCostGateIntegration:
+    def test_gate_halts_and_returns_partial_prefix(self):
+        """When projection trips after first panelist, pending are cancelled.
+
+        10 panelists, each priced around $1.05 at sonnet rates → projection
+        after the first panelist is ~$10.50, which vastly exceeds the $1.00
+        ceiling. The gate trips and we get back only the completed prefix.
+        """
+        client = MagicMock()
+        client.send = MagicMock(return_value=_heavy_response())
+
+        personas = [{"name": f"P{i}"} for i in range(10)]
+        questions = [{"text": "Q1"}]
+        gate = CostGate(max_cost_usd=1.00, total_panelists=10)
+
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="claude-sonnet-4-6",
+            system_prompt_fn=_system,
+            question_prompt_fn=_question,
+            max_workers=1,  # serialize so cancellations actually bite
+            cost_gate=gate,
+        )
+
+        assert gate.should_halt() is True
+        # At least one completed (to trip the gate); fewer than all 10 (gate
+        # cancelled the rest).
+        assert 1 <= len(results) <= 9
+        # Every returned result must be a real completion (not a cancel fallback).
+        for r in results:
+            assert r.error is None
+
+    def test_gate_does_not_halt_when_cost_is_well_under_ceiling(self):
+        """Light usage should let the full panel complete."""
+        client = MagicMock()
+        client.send = MagicMock(return_value=_light_response())
+
+        personas = [{"name": f"P{i}"} for i in range(5)]
+        questions = [{"text": "Q"}]
+        # A generous ceiling — 5 panelists * light response << $100
+        gate = CostGate(max_cost_usd=100.00, total_panelists=5)
+
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="claude-sonnet-4-6",
+            system_prompt_fn=_system,
+            question_prompt_fn=_question,
+            cost_gate=gate,
+        )
+
+        assert gate.should_halt() is False
+        assert len(results) == 5
+
+    def test_no_gate_means_no_behaviour_change(self):
+        """Sanity: omitting cost_gate keeps the existing fast path."""
+        client = MagicMock()
+        client.send = MagicMock(return_value=_heavy_response())
+
+        personas = [{"name": f"P{i}"} for i in range(3)]
+        questions = [{"text": "Q"}]
+
+        results, _reg, _sessions = run_panel_parallel(
+            client=client,
+            personas=personas,
+            questions=questions,
+            model="claude-sonnet-4-6",
+            system_prompt_fn=_system,
+            question_prompt_fn=_question,
+        )
+
+        assert len(results) == 3
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — exercises --max-cost through main() with a mocked
+# AgentRuntime so we can inject expensive usage without real API calls.
+# ---------------------------------------------------------------------------
+
+
+def _expensive_turn_summary(text: str = "expensive response") -> TurnSummary:
+    """Turn summary with enough tokens to trip a $1 ceiling at sonnet rates.
+
+    Sonnet: $3/MTok input, $15/MTok output.
+    100k input + 50k output → $0.30 + $0.75 = $1.05 per turn.
+    """
+    usage = CostTokenUsage(input_tokens=100_000, output_tokens=50_000)
+    msg = ConversationMessage(
+        role="assistant",
+        content=[{"type": "text", "text": text}],
+        usage=usage,
+    )
+    return TurnSummary(
+        assistant_messages=[msg],
+        iterations=1,
+        usage=usage,
+    )
+
+
+def _cheap_turn_summary(text: str = "cheap response") -> TurnSummary:
+    usage = CostTokenUsage(input_tokens=10, output_tokens=5)
+    msg = ConversationMessage(
+        role="assistant",
+        content=[{"type": "text", "text": text}],
+        usage=usage,
+    )
+    return TurnSummary(
+        assistant_messages=[msg],
+        iterations=1,
+        usage=usage,
+    )
+
+
+@patch("synth_panel.orchestrator.AgentRuntime")
+@patch("synth_panel.cli.commands.LLMClient")
+def test_cli_max_cost_emits_valid_partial_json(
+    mock_client_cls: MagicMock,
+    mock_runtime_cls: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """End-to-end: --max-cost trips, CLI emits parseable JSON with the
+    expected ``run_invalid`` / ``cost_exceeded`` / ``halted_at_panelist``
+    fields and exits 2.
+    """
+    mock_runtime = MagicMock()
+    mock_runtime.run_turn.return_value = _expensive_turn_summary()
+    mock_runtime_cls.return_value = mock_runtime
+
+    personas_file = tmp_path / "personas.yaml"
+    personas_file.write_text(
+        textwrap.dedent(
+            """
+            personas:
+              - name: P1
+              - name: P2
+              - name: P3
+              - name: P4
+              - name: P5
+              - name: P6
+              - name: P7
+              - name: P8
+              - name: P9
+              - name: P10
+            """
+        ).strip()
+    )
+    survey_file = tmp_path / "survey.yaml"
+    survey_file.write_text("instrument:\n  version: 1\n  questions:\n    - text: What do you think?\n")
+
+    code = main(
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            "--max-cost",
+            "1.00",
+            "--max-concurrent",
+            "1",
+            "--no-synthesis",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert code == 2, f"expected exit 2 on cost-gate halt; got {code}\nstdout={captured.out!r}\nstderr={captured.err!r}"
+
+    payload = json.loads(captured.out)
+    assert payload.get("run_invalid") is True
+    assert payload.get("cost_exceeded") is True
+    assert payload.get("abort_reason") == "cost_exceeded"
+    halted_at = payload.get("halted_at_panelist")
+    assert isinstance(halted_at, int) and halted_at >= 1
+
+    # Cost-gate diagnostics surfaced at top level.
+    gate_snap = payload.get("cost_gate")
+    assert gate_snap is not None
+    assert gate_snap["halted"] is True
+    assert gate_snap["completed"] == halted_at
+    assert gate_snap["max_cost_usd"] == pytest.approx(1.00)
+    assert gate_snap["projected_total_usd"] > 1.00
+
+    # Partial result array present — every returned persona has a response
+    # or an error record, and the count matches the halt point.
+    rounds = payload.get("rounds") or []
+    assert len(rounds) == 1
+    round_results = rounds[0].get("results") or []
+    assert len(round_results) == halted_at, (
+        f"round result count {len(round_results)} should equal halted_at_panelist={halted_at}"
+    )
+    for r in round_results:
+        assert "persona" in r
+        assert "responses" in r
+
+    # Operators grep stderr for the halt banner in CI.
+    assert "cost" in captured.err.lower() and "halt" in captured.err.lower()
+
+
+@patch("synth_panel.orchestrator.AgentRuntime")
+@patch("synth_panel.cli.commands.LLMClient")
+def test_cli_below_ceiling_completes_normally(
+    mock_client_cls: MagicMock,
+    mock_runtime_cls: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Generous --max-cost must not disturb a normal panel run."""
+    mock_runtime = MagicMock()
+    mock_runtime.run_turn.return_value = _cheap_turn_summary()
+    mock_runtime_cls.return_value = mock_runtime
+
+    personas_file = tmp_path / "personas.yaml"
+    personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n  - name: Carol\n")
+    survey_file = tmp_path / "survey.yaml"
+    survey_file.write_text("instrument:\n  version: 1\n  questions:\n    - text: Q?\n")
+
+    code = main(
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            "--max-cost",
+            "100.00",
+            "--no-synthesis",
+        ]
+    )
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload.get("run_invalid") is False
+    assert "cost_exceeded" not in payload
+    assert payload.get("persona_count") == 3
+
+
+def test_cli_rejects_non_positive_max_cost(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
+    personas_file = tmp_path / "personas.yaml"
+    personas_file.write_text("personas:\n  - name: P1\n")
+    survey_file = tmp_path / "survey.yaml"
+    survey_file.write_text("instrument:\n  version: 1\n  questions:\n    - text: Q?\n")
+
+    code = main(
+        [
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            "--max-cost",
+            "0",
+            "--no-synthesis",
+        ]
+    )
+    assert code == 1
+    err = capsys.readouterr().err
+    assert "max-cost" in err.lower()


### PR DESCRIPTION
## Summary
Slice (c) of sp-i2ub: a projected-total USD ceiling for panel runs.

- After each panelist completes, `running_cost / completed_n * total_n` is compared against `--max-cost`; if the projected spend exceeds the limit, pending futures are cancelled and the run emits a valid partial JSON with `run_invalid: true`, `cost_exceeded: true`, and `halted_at_panelist: <n>`. Exit code 2.
- `CostGate`: thread-safe projection tracker with idempotent halt + snapshot.
- Orchestrator: cost-gate integration mirrors the convergence-tracker cancellation pattern.
- CLI: `--max-cost` flag + `cost_exceeded` / `abort_reason` / `cost_gate` surfaced in output.

## Context
- Source issue: sp-utnk (slice (c) of parent sp-i2ub). Independent of checkpointing (slice b, sp-hsk3) and file-based abort paths (slice d).

## Test plan
- [x] `pytest tests/test_cost_gate.py` — 17 tests covering unit semantics, orchestrator integration, and end-to-end CLI partial-JSON shape.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.
- [ ] Manual: `synthpanel panel run --max-cost 0.05 --personas big-panel.yaml` → partial JSON with `cost_exceeded: true` + exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)