### PR TITLE
ci(security): ignore CVE-2026-3219 in pip-audit (sp-kdya)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,10 @@ jobs:
         run: pip install -e ".[dev,mcp]"
 
       - name: pip-audit
-        run: pip-audit
+        # CVE-2026-3219 affects pip 26.0.1 (the runner default) with no patched
+        # release yet. Ignore until a fixed pip ships, then drop this flag.
+        # Tracking: https://nvd.nist.gov/vuln/detail/CVE-2026-3219
+        run: pip-audit --ignore-vuln CVE-2026-3219
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds `--ignore-vuln CVE-2026-3219` to the pip-audit invocation in `.github/workflows/ci.yml`.
- No patched pip is available for CVE-2026-3219 affecting the runner's default pip 26.0.1, so every PR has been failing the security job (mayor has been admin-merging as a workaround).
- Unblocks PR CI until a fixed pip is released — drop the ignore flag then.

## Context
- Source issue: sp-kdya. Evidence from PR #266 security run and PR #267 security run: `Found 1 known vulnerability: pip 26.0.1 CVE-2026-3219` with no fix version.
- Option (a) from the audit — straightforward ignore with a code comment noting the removal trigger.

## Test plan
- [ ] CI: security job on this PR should pass (the very change being validated).
- [ ] When a patched pip lands: remove the `--ignore-vuln` flag + the comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)