### PR TITLE
feat(orchestrator): valid partial JSON on every abort path (sp-56pb)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -62,7 +62,7 @@ from synth_panel.credentials import has_credential
 from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
 from synth_panel.metadata import PanelTimer, build_metadata
-from synth_panel.orchestrator import PanelistResult, run_panel_parallel
+from synth_panel.orchestrator import PanelistResult, RunAbortedError, run_panel_parallel
 from synth_panel.persistence import Session
 from synth_panel.perturbation import generate_panel_variants
 from synth_panel.prompts import (
@@ -1472,6 +1472,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         )
         checkpoint_writer.install_signal_handlers()
 
+    # sp-56pb: initialized pre-branch so the aggregator block after the
+    # blend vs. standard if/else can reference it unconditionally.
+    sigint_halted = False
+
     if blend_mode and model_spec:
         # ── Blend mode: run full panel once per model, then blend ────
         from synth_panel.ensemble import blend_distributions, ensemble_run
@@ -1527,6 +1531,20 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 convergence_tracker=convergence_tracker,
                 on_panelist_complete=_on_complete if checkpoint_writer else None,
                 cost_gate=cost_gate,
+            )
+        except RunAbortedError as abort_exc:
+            # sp-56pb: SIGINT path. Surface whatever panelists finished
+            # before the signal landed as a valid partial JSON envelope;
+            # exit non-zero so automation detects the abort without parsing
+            # banner text.
+            sigint_halted = abort_exc.reason == "sigint"
+            panelist_results = abort_exc.results
+            _registry = abort_exc.registry
+            _sessions = abort_exc.sessions
+            print(
+                "panel run interrupted (SIGINT); emitting partial result for "
+                f"{len(panelist_results)}/{len(active_personas)} panelist(s)",
+                file=sys.stderr,
             )
         finally:
             if checkpoint_writer is not None:
@@ -1624,6 +1642,14 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     if cost_gate_halted:
         run_invalid = True
 
+    # sp-56pb: SIGINT aborts the run-panel loop. Whatever panelists
+    # already landed are preserved as the partial prefix — mark the run
+    # invalid so consumers don't mistake the truncated output for a
+    # successful run, and skip synthesis for the same reason we skip it
+    # on a cost-halt (truncated panel ≠ trustworthy synthesis input).
+    if sigint_halted:
+        run_invalid = True
+
     # Compute panelist costs (needed before synthesis for cost estimate).
     # For multi-model runs, sum the per-model costs so the total reflects
     # each provider's real rate; single-model runs keep the legacy path.
@@ -1639,6 +1665,11 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     skip_synthesis = getattr(args, "no_synthesis", False)
     if run_invalid or strict_violation:
         skip_synthesis = True  # don't synthesize garbage
+    if sigint_halted:
+        # sp-56pb: SIGINT halts the panel loop; synthesizing over a
+        # user-interrupted partial wastes spend and produces a result
+        # the operator never asked for.
+        skip_synthesis = True
     synthesis_result = None
     synthesis_error_payload: dict[str, Any] | None = None
 
@@ -2038,6 +2069,26 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             # CI/MCP consumers can detect the "every panelist failed"
             # case without parsing banner text.
             extra["total_failure"] = total_failure
+            # sp-56pb: specific abort_reason so downstream tooling can
+            # distinguish total-failure from other invalid runs without
+            # parsing diagnostic text. When every sampled error points at
+            # the LLM client's rate-limit budget running out, classify
+            # the abort as rate-limit-exhausted so operators know to
+            # raise --rate-limit-rps or --max-retries instead of chasing
+            # a model issue. Cost-exceeded takes precedence (it got in
+            # first above) because a halted prefix is a more specific
+            # explanation than "every panelist failed".
+            if "abort_reason" not in extra:
+                extra["abort_reason"] = _classify_total_failure_abort_reason(total_failure)
+        # sp-56pb: SIGINT is a first-class abort path. Surface a
+        # top-level ``abort_reason`` so MCP/CI consumers can key on it
+        # without scraping stderr. If a prior clause (cost gate, total
+        # failure) already claimed abort_reason we leave that value
+        # alone — those are the *cause* of the halt; SIGINT arrived on
+        # top of it.
+        if sigint_halted and "abort_reason" not in extra:
+            extra["abort_reason"] = "sigint"
+            extra["halted_at_panelist"] = len(panelist_results)
         if synthesis_error_payload is not None:
             # sp-avmm: top-level synthesis_error so JSON/NDJSON consumers
             # see the failure without walking into the synthesis dict.
@@ -2141,6 +2192,45 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     if run_invalid:
         return 2
     return 0
+
+
+# sp-56pb: substrings that mark a panelist failure as rooted in rate-limit
+# exhaustion. The LLM client raises ``LLMError`` with category
+# ``RETRIES_EXHAUSTED`` after the rate-limit retry budget is spent; the
+# stringified form leaks "retries exhausted" and/or "rate limit" into
+# the panelist error message. Matching on substrings keeps us resilient
+# to future wording changes as long as one of these tokens survives.
+_RATE_LIMIT_ABORT_MARKERS = (
+    "retries_exhausted",
+    "retries exhausted",
+    "rate_limit",
+    "rate limit",
+    "429",
+)
+
+
+def _classify_total_failure_abort_reason(diagnostic: dict[str, Any]) -> str:
+    """Map a total-failure diagnostic to a specific ``abort_reason`` tag.
+
+    Returns ``"rate_limit_exhausted"`` when every sampled panelist error
+    name-checks a rate-limit marker, otherwise ``"total_failure"``. The
+    caller surfaces this at the top level of the JSON output so consumers
+    can treat "the whole panel rate-limited out" distinctly from other
+    total failures without having to parse the diagnostic envelope.
+    """
+    sample_errors = diagnostic.get("sample_errors") or []
+    if not sample_errors:
+        return "total_failure"
+    for entry in sample_errors:
+        # ``sample_errors`` is a list of (persona, error_message) tuples
+        # on construction, but JSON round-trip turns them into lists.
+        if isinstance(entry, (tuple, list)) and len(entry) >= 2:
+            msg = str(entry[1]).lower()
+        else:
+            msg = str(entry).lower()
+        if not any(marker in msg for marker in _RATE_LIMIT_ABORT_MARKERS):
+            return "total_failure"
+    return "rate_limit_exhausted"
 
 
 def _analyze_failures(

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -32,6 +32,34 @@ from synth_panel.structured.output import StructuredOutputConfig, StructuredOutp
 logger = logging.getLogger(__name__)
 
 
+class RunAbortedError(Exception):
+    """Raised by :func:`run_panel_parallel` when the run aborts mid-flight (sp-56pb).
+
+    Carries the partial panelist results (the prefix 0..k that completed
+    before the abort) plus the registry and session dicts, so the caller
+    can still surface a valid partial JSON with ``run_invalid: true`` and
+    a specific ``abort_reason`` instead of losing the work entirely.
+
+    Currently the only trigger is ``KeyboardInterrupt`` (SIGINT). The cost
+    gate and convergence auto-stop paths do not raise — they return
+    normally with ``results`` truncated to the completed prefix because
+    the caller needs to inspect gate/tracker state to classify the halt.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        results: list[PanelistResult],
+        registry: WorkerRegistry,
+        sessions: dict[str, Session],
+    ) -> None:
+        super().__init__(f"panel run aborted: {reason}")
+        self.reason = reason
+        self.results = results
+        self.registry = registry
+        self.sessions = sessions
+
+
 def _convert_llm_usage(llm_usage: LLMTokenUsage) -> TokenUsage:
     """Convert LLM-layer TokenUsage to cost-layer TokenUsage."""
     return TokenUsage(
@@ -626,6 +654,7 @@ def run_panel_parallel(
             (i, k, q) for i, k, q in _inspect_bounded_questions(questions) if k in set(convergence_tracker.tracked_keys)
         ]
 
+    sigint_aborted = False
     with ThreadPoolExecutor(max_workers=effective_workers) as executor:
         future_to_index = {}
         for idx, (persona, worker_id) in enumerate(zip(personas, worker_ids)):
@@ -653,81 +682,104 @@ def run_panel_parallel(
             )
             future_to_index[future] = idx
 
-        for future in as_completed(future_to_index):
-            idx = future_to_index[future]
-            try:
-                result, sess = future.result()
-                results[idx] = result
-                with session_lock:
-                    out_sessions[result.persona_name] = sess
-            except Exception as exc:
-                name = personas[idx].get("name", "Anonymous")
-                results[idx] = PanelistResult(
-                    persona_name=name,
-                    responses=[],
-                    usage=ZERO_USAGE,
-                    error=str(exc),
-                    model=model,
-                )
-
-            # sp-hsk3: invoke the checkpoint callback for every resolved
-            # panelist, success or failure. Errored panelists still count
-            # as "done" for resume purposes — otherwise a persistent
-            # upstream outage would stall the cadence forever.
-            if on_panelist_complete is not None and results[idx] is not None:
+        try:
+            for future in as_completed(future_to_index):
+                idx = future_to_index[future]
                 try:
-                    on_panelist_complete(results[idx])  # type: ignore[arg-type]
-                except Exception as cb_exc:  # pragma: no cover - defensive
-                    logger.warning(
-                        "on_panelist_complete callback failed: %s: %s",
-                        type(cb_exc).__name__,
-                        cb_exc,
+                    result, sess = future.result()
+                    results[idx] = result
+                    with session_lock:
+                        out_sessions[result.persona_name] = sess
+                except Exception as exc:
+                    name = personas[idx].get("name", "Anonymous")
+                    results[idx] = PanelistResult(
+                        persona_name=name,
+                        responses=[],
+                        usage=ZERO_USAGE,
+                        error=str(exc),
+                        model=model,
                     )
 
-            if convergence_tracker is not None and results[idx] is not None:
-                completed_result = results[idx]
-                assert completed_result is not None  # help mypy; checked above
-                if completed_result.error is None:
-                    categorical = extract_categorical_responses(completed_result, tracked_questions)
+                # sp-hsk3: invoke the checkpoint callback for every resolved
+                # panelist, success or failure. Errored panelists still count
+                # as "done" for resume purposes — otherwise a persistent
+                # upstream outage would stall the cadence forever.
+                if on_panelist_complete is not None and results[idx] is not None:
                     try:
-                        should_stop = convergence_tracker.record(categorical)
-                    except Exception as track_exc:  # pragma: no cover - defensive
-                        logger.warning("convergence tracker record failed: %s", track_exc)
-                        should_stop = False
-                    if should_stop:
+                        on_panelist_complete(results[idx])  # type: ignore[arg-type]
+                    except Exception as cb_exc:  # pragma: no cover - defensive
+                        logger.warning(
+                            "on_panelist_complete callback failed: %s: %s",
+                            type(cb_exc).__name__,
+                            cb_exc,
+                        )
+
+                if convergence_tracker is not None and results[idx] is not None:
+                    completed_result = results[idx]
+                    assert completed_result is not None  # help mypy; checked above
+                    if completed_result.error is None:
+                        categorical = extract_categorical_responses(completed_result, tracked_questions)
+                        try:
+                            should_stop = convergence_tracker.record(categorical)
+                        except Exception as track_exc:  # pragma: no cover - defensive
+                            logger.warning("convergence tracker record failed: %s", track_exc)
+                            should_stop = False
+                        if should_stop:
+                            logger.info(
+                                "auto-stop: convergence reached at n=%d; cancelling pending futures",
+                                convergence_tracker.overall_converged_at or 0,
+                            )
+                            for pending_future in future_to_index:
+                                if not pending_future.done():
+                                    pending_future.cancel()
+                            break
+
+                # sp-utnk: cost-gate check. Price the completed panelist using
+                # its per-panelist model (falls back to the run-level default)
+                # and record against the gate. If the projected run total
+                # exceeds the gate, cancel pending futures and return what we
+                # have — the caller synthesizes a partial, run_invalid result.
+                if cost_gate is not None and results[idx] is not None:
+                    completed_result = results[idx]
+                    assert completed_result is not None
+                    pr_model = completed_result.model or model
+                    priced = resolve_cost(completed_result.usage, pr_model)
+                    halted = cost_gate.record(priced.total_cost)
+                    if halted:
                         logger.info(
-                            "auto-stop: convergence reached at n=%d; cancelling pending futures",
-                            convergence_tracker.overall_converged_at or 0,
+                            "cost gate tripped after %d/%d panelists; cancelling pending futures",
+                            cost_gate.completed,
+                            len(personas),
                         )
                         for pending_future in future_to_index:
                             if not pending_future.done():
                                 pending_future.cancel()
                         break
-
-            # sp-utnk: cost-gate check. Price the completed panelist using
-            # its per-panelist model (falls back to the run-level default)
-            # and record against the gate. If the projected run total
-            # exceeds the gate, cancel pending futures and return what we
-            # have — the caller synthesizes a partial, run_invalid result.
-            if cost_gate is not None and results[idx] is not None:
-                completed_result = results[idx]
-                assert completed_result is not None
-                pr_model = completed_result.model or model
-                priced = resolve_cost(completed_result.usage, pr_model)
-                halted = cost_gate.record(priced.total_cost)
-                if halted:
-                    logger.info(
-                        "cost gate tripped after %d/%d panelists; cancelling pending futures",
-                        cost_gate.completed,
-                        len(personas),
-                    )
-                    for pending_future in future_to_index:
-                        if not pending_future.done():
-                            pending_future.cancel()
-                    break
+        except KeyboardInterrupt:
+            # sp-56pb: surface partial results instead of losing them. SIGINT
+            # is one of the four abort paths that must produce a valid,
+            # partial JSON result. We cancel pending futures so the executor
+            # does not block on work the user has already given up on, then
+            # raise RunAbortedError so the caller can classify the halt and
+            # emit the standard partial-JSON envelope.
+            logger.warning(
+                "panel run interrupted by SIGINT after %d panelist(s)", sum(1 for r in results if r is not None)
+            )
+            sigint_aborted = True
+            for pending_future in future_to_index:
+                if not pending_future.done():
+                    pending_future.cancel()
 
     # All slots should be filled (unless auto-stop cancelled some); drop Nones
-    return [r for r in results if r is not None], registry, out_sessions
+    final_results = [r for r in results if r is not None]
+    if sigint_aborted:
+        raise RunAbortedError(
+            reason="sigint",
+            results=final_results,
+            registry=registry,
+            sessions=out_sessions,
+        )
+    return final_results, registry, out_sessions
 
 
 def _inspect_bounded_questions(

--- a/tests/test_abort_paths.py
+++ b/tests/test_abort_paths.py
@@ -1,0 +1,620 @@
+"""Abort-path coverage for scaled panel runs (sp-56pb / sp-i2ub slice d).
+
+Every abort path — rate-limit exhaustion, SIGINT, cost gate, and total
+panelist failure — must produce a *valid* partial JSON document with
+``run_invalid: true`` and a specific ``abort_reason``, and exit non-zero
+so automation can detect the abort without scraping banner text.
+
+These tests cover the CLI envelope end-to-end: they exercise ``main()``
+with a mocked ``AgentRuntime`` so no real API calls fire, then assert
+that the emitted JSON is parseable and carries the fields downstream
+consumers (MCP, CI, dashboards) key on.
+
+Integration: the final test simulates the bead's worked example —
+n=50 with a 10% rate-limit error rate and an abort at panelist 30,
+followed by a clean resume that finishes all 50.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from synth_panel.checkpoint import (
+    CheckpointWriter,
+    checkpoint_dir_for,
+    load_checkpoint,
+    new_run_id,
+)
+from synth_panel.cli.commands import _classify_total_failure_abort_reason
+from synth_panel.cost import TokenUsage as CostTokenUsage
+from synth_panel.llm.errors import LLMError, LLMErrorCategory
+from synth_panel.llm.models import CompletionResponse, StopReason, TextBlock
+from synth_panel.llm.models import TokenUsage as LLMTokenUsage
+from synth_panel.main import main
+from synth_panel.orchestrator import (
+    PanelistResult,
+    RunAbortedError,
+    run_panel_parallel,
+)
+from synth_panel.persistence import ConversationMessage
+from synth_panel.runtime import TurnSummary
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _personas_yaml(names: list[str]) -> str:
+    lines = ["personas:"]
+    for n in names:
+        lines.append(f"  - name: {n}")
+    return "\n".join(lines) + "\n"
+
+
+def _write_inputs(tmp_path: Path, persona_names: list[str]) -> tuple[Path, Path]:
+    personas_file = tmp_path / "personas.yaml"
+    personas_file.write_text(_personas_yaml(persona_names))
+    survey_file = tmp_path / "survey.yaml"
+    survey_file.write_text("instrument:\n  version: 1\n  questions:\n    - text: What do you think?\n")
+    return personas_file, survey_file
+
+
+def _cheap_turn_summary(text: str = "ok") -> TurnSummary:
+    usage = CostTokenUsage(input_tokens=10, output_tokens=5)
+    msg = ConversationMessage(
+        role="assistant",
+        content=[{"type": "text", "text": text}],
+        usage=usage,
+    )
+    return TurnSummary(assistant_messages=[msg], iterations=1, usage=usage)
+
+
+def _expensive_turn_summary(text: str = "ok") -> TurnSummary:
+    # Enough tokens to trip a $1 cost gate at sonnet rates (~$1.05/panelist).
+    usage = CostTokenUsage(input_tokens=100_000, output_tokens=50_000)
+    msg = ConversationMessage(
+        role="assistant",
+        content=[{"type": "text", "text": text}],
+        usage=usage,
+    )
+    return TurnSummary(assistant_messages=[msg], iterations=1, usage=usage)
+
+
+def _assert_valid_partial_json(stdout: str) -> dict[str, Any]:
+    """Parse stdout as JSON and assert the partial-result contract holds."""
+    assert stdout.strip(), "expected JSON on stdout, got empty output"
+    payload = json.loads(stdout)
+    assert isinstance(payload, dict), f"expected JSON object, got {type(payload).__name__}"
+    assert payload.get("run_invalid") is True, f"run_invalid must be true on abort; payload={payload}"
+    assert isinstance(payload.get("abort_reason"), str) and payload["abort_reason"], (
+        f"abort_reason must be a non-empty string; got {payload.get('abort_reason')!r}"
+    )
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# _classify_total_failure_abort_reason unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTotalFailureAbortReason:
+    def test_empty_sample_errors_falls_through_to_total_failure(self) -> None:
+        assert _classify_total_failure_abort_reason({}) == "total_failure"
+        assert _classify_total_failure_abort_reason({"sample_errors": []}) == "total_failure"
+
+    def test_all_rate_limit_markers_classified_as_rate_limit_exhausted(self) -> None:
+        diag = {
+            "sample_errors": [
+                ("P1", "RATE_LIMIT: retries_exhausted after 6 attempts"),
+                ("P2", "LLMError category=rate_limit status=429"),
+                ("P3", "Retries exhausted for this panelist"),
+            ]
+        }
+        assert _classify_total_failure_abort_reason(diag) == "rate_limit_exhausted"
+
+    def test_any_non_rate_limit_error_degrades_to_total_failure(self) -> None:
+        # One sample pointing at a 400 (bad model) breaks the classification;
+        # treating this as rate-limit-exhausted would send operators down
+        # the wrong debugging path.
+        diag = {
+            "sample_errors": [
+                ("P1", "rate_limit: retries_exhausted"),
+                ("P2", "HTTP 400: invalid model name"),
+            ]
+        }
+        assert _classify_total_failure_abort_reason(diag) == "total_failure"
+
+    def test_handles_list_shaped_sample_errors(self) -> None:
+        # sample_errors are tuples on construction; a JSON round-trip turns
+        # them into lists. The classifier must handle both shapes.
+        diag = {"sample_errors": [["P1", "429 rate_limit exhausted"]]}
+        assert _classify_total_failure_abort_reason(diag) == "rate_limit_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator layer: RunAbortedError carries partial results on SIGINT
+# ---------------------------------------------------------------------------
+
+
+def _persona(name: str) -> dict[str, Any]:
+    return {"name": name, "age": 30}
+
+
+def _system(p: dict[str, Any]) -> str:
+    return f"You are {p['name']}"
+
+
+def _question(q: dict[str, Any]) -> str:
+    return q["text"] if isinstance(q, dict) else str(q)
+
+
+def _mock_response() -> CompletionResponse:
+    return CompletionResponse(
+        id="resp",
+        model="claude-sonnet-4-6",
+        content=[TextBlock(text="ok")],
+        stop_reason=StopReason.END_TURN,
+        usage=LLMTokenUsage(input_tokens=10, output_tokens=5),
+    )
+
+
+class TestOrchestratorSigint:
+    def test_run_aborted_error_carries_partial_prefix(self) -> None:
+        """KeyboardInterrupt in a worker thread propagates via future.result()
+        to the main-thread ``as_completed`` loop, where run_panel_parallel
+        catches it and raises ``RunAbortedError`` with the finished prefix.
+        """
+        calls = {"n": 0}
+
+        def flaky_send(_req: Any) -> CompletionResponse:
+            calls["n"] += 1
+            if calls["n"] > 2:
+                # Simulate user hitting Ctrl-C mid-run.
+                raise KeyboardInterrupt
+            return _mock_response()
+
+        client = MagicMock()
+        client.send = flaky_send
+
+        personas = [_persona(f"P{i}") for i in range(5)]
+        questions = [{"text": "Q"}]
+
+        with pytest.raises(RunAbortedError) as exc_info:
+            run_panel_parallel(
+                client=client,
+                personas=personas,
+                questions=questions,
+                model="claude-sonnet-4-6",
+                system_prompt_fn=_system,
+                question_prompt_fn=_question,
+                max_workers=1,  # serialize so the first 2 land before abort
+            )
+
+        aborted = exc_info.value
+        assert aborted.reason == "sigint"
+        # At least one panelist completed before the abort fired; no results
+        # past the abort were dropped silently (checked via count vs. total).
+        assert 0 <= len(aborted.results) < len(personas)
+        # Every returned result is a real PanelistResult (no None sentinels).
+        for r in aborted.results:
+            assert isinstance(r, PanelistResult)
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — each abort path emits valid partial JSON + abort_reason
+# ---------------------------------------------------------------------------
+
+
+@patch("synth_panel.orchestrator.AgentRuntime")
+@patch("synth_panel.cli.commands.LLMClient")
+def test_cli_cost_exceeded_emits_partial_json(
+    _mock_client_cls: MagicMock,
+    mock_runtime_cls: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Cost-gate halt produces valid JSON with abort_reason=cost_exceeded.
+
+    Smoke-test the contract this slice promises — the full cost-gate
+    behaviour is already covered by ``tests/test_cost_gate.py``; here
+    we only assert the envelope fields the bead calls out so the
+    abort-path test suite is self-contained.
+    """
+    mock_runtime = MagicMock()
+    mock_runtime.run_turn.return_value = _expensive_turn_summary()
+    mock_runtime_cls.return_value = mock_runtime
+
+    personas_file, survey_file = _write_inputs(tmp_path, [f"P{i}" for i in range(10)])
+
+    code = main(
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            "--max-cost",
+            "1.00",
+            "--max-concurrent",
+            "1",
+            "--no-synthesis",
+        ]
+    )
+    assert code == 2
+
+    captured = capsys.readouterr()
+    payload = _assert_valid_partial_json(captured.out)
+    assert payload["abort_reason"] == "cost_exceeded"
+    assert payload.get("cost_exceeded") is True
+    halted_at = payload.get("halted_at_panelist")
+    assert isinstance(halted_at, int) and halted_at >= 1
+    # Partial round present; every emitted panelist slot has the shape
+    # consumers depend on.
+    rounds = payload.get("rounds") or []
+    assert len(rounds) == 1
+    for row in rounds[0].get("results") or []:
+        assert "persona" in row
+        assert "responses" in row
+
+
+@patch("synth_panel.orchestrator.AgentRuntime")
+@patch("synth_panel.cli.commands.LLMClient")
+def test_cli_sigint_emits_partial_json(
+    _mock_client_cls: MagicMock,
+    mock_runtime_cls: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """SIGINT mid-run produces valid JSON with abort_reason=sigint.
+
+    Implementation detail: we simulate the signal by making the third
+    panelist's ``run_turn`` raise ``KeyboardInterrupt``. That mirrors
+    what Python's default signal handler does after our checkpoint
+    writer flushes — the main thread sees a KeyboardInterrupt while
+    iterating ``as_completed``, which the orchestrator classifies as
+    the ``sigint`` abort reason.
+    """
+    mock_runtime = MagicMock()
+    turn_calls = {"n": 0}
+
+    def flaky_run_turn(*_args: Any, **_kwargs: Any) -> TurnSummary:
+        turn_calls["n"] += 1
+        if turn_calls["n"] > 2:
+            raise KeyboardInterrupt
+        return _cheap_turn_summary()
+
+    mock_runtime.run_turn.side_effect = flaky_run_turn
+    mock_runtime_cls.return_value = mock_runtime
+
+    personas_file, survey_file = _write_inputs(tmp_path, [f"P{i}" for i in range(5)])
+
+    code = main(
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            # Serialize so the KeyboardInterrupt lands after a deterministic
+            # number of completed panelists; otherwise the parallel workers
+            # race and the partial count becomes non-deterministic.
+            "--max-concurrent",
+            "1",
+            "--no-synthesis",
+        ]
+    )
+    assert code == 2, f"SIGINT abort must exit 2; got {code}"
+
+    captured = capsys.readouterr()
+    payload = _assert_valid_partial_json(captured.out)
+    assert payload["abort_reason"] == "sigint"
+    # Partial prefix is present and bounded below the full panel size.
+    halted_at = payload.get("halted_at_panelist")
+    assert isinstance(halted_at, int)
+    assert 0 <= halted_at < 5
+    # Operators grep stderr for the interrupt notice in CI.
+    assert "interrupted" in captured.err.lower() or "sigint" in captured.err.lower()
+
+
+@patch("synth_panel.orchestrator.AgentRuntime")
+@patch("synth_panel.cli.commands.LLMClient")
+def test_cli_rate_limit_exhausted_emits_partial_json(
+    _mock_client_cls: MagicMock,
+    mock_runtime_cls: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Every panelist hits RETRIES_EXHAUSTED → abort_reason=rate_limit_exhausted.
+
+    The LLM client exhausts its rate-limit retry budget after max_retries
+    429s and raises ``LLMError(category=RETRIES_EXHAUSTED)``. The runtime
+    re-raises that into the orchestrator's per-panelist Exception catch,
+    so each panelist lands with ``error`` set to the stringified exception.
+    When *every* panelist fails that way, detect_total_failure trips and
+    the classifier tags the run as rate_limit_exhausted.
+    """
+    mock_runtime = MagicMock()
+    mock_runtime.run_turn.side_effect = LLMError(
+        "rate limit retries exhausted after 6 attempts",
+        LLMErrorCategory.RETRIES_EXHAUSTED,
+        status_code=429,
+    )
+    mock_runtime_cls.return_value = mock_runtime
+
+    personas_file, survey_file = _write_inputs(tmp_path, [f"P{i}" for i in range(3)])
+
+    code = main(
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            "--no-synthesis",
+        ]
+    )
+    assert code == 2
+
+    captured = capsys.readouterr()
+    payload = _assert_valid_partial_json(captured.out)
+    assert payload["abort_reason"] == "rate_limit_exhausted", f"expected rate_limit_exhausted; payload={payload}"
+    # total_failure envelope is also present so consumers can grab the
+    # sample errors for the triage message.
+    tf = payload.get("total_failure")
+    assert tf is not None
+    assert tf.get("sample_errors"), "total_failure envelope must carry sample errors"
+
+
+@patch("synth_panel.orchestrator.AgentRuntime")
+@patch("synth_panel.cli.commands.LLMClient")
+def test_cli_total_failure_non_rate_limit_emits_total_failure_reason(
+    _mock_client_cls: MagicMock,
+    mock_runtime_cls: MagicMock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Non-rate-limit total failure → abort_reason=total_failure.
+
+    Here every panelist hits a 400 (e.g. bad model name). detect_total_failure
+    trips and the classifier falls back to the generic ``total_failure``
+    tag — operators shouldn't be told to raise --rate-limit-rps when the
+    real problem is an invalid model id.
+    """
+    mock_runtime = MagicMock()
+    mock_runtime.run_turn.side_effect = RuntimeError("HTTP 400: invalid model name")
+    mock_runtime_cls.return_value = mock_runtime
+
+    personas_file, survey_file = _write_inputs(tmp_path, [f"P{i}" for i in range(3)])
+
+    code = main(
+        [
+            "--model",
+            "claude-sonnet-4-6",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            str(personas_file),
+            "--instrument",
+            str(survey_file),
+            "--no-synthesis",
+        ]
+    )
+    assert code == 2
+
+    captured = capsys.readouterr()
+    payload = _assert_valid_partial_json(captured.out)
+    assert payload["abort_reason"] == "total_failure"
+    # Rate-limit classifier should NOT have misfired.
+    assert payload["abort_reason"] != "rate_limit_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# Integration: n=50 with 10% rate-limit errors, abort at 30, resume clean
+# ---------------------------------------------------------------------------
+
+
+def _rate_limit_error() -> LLMError:
+    return LLMError(
+        "simulated 429",
+        LLMErrorCategory.RATE_LIMIT,
+        status_code=429,
+        retry_after=0.001,
+    )
+
+
+def _ok_turn_summary(persona_name: str) -> TurnSummary:
+    usage = CostTokenUsage(input_tokens=10, output_tokens=5)
+    msg = ConversationMessage(
+        role="assistant",
+        content=[{"type": "text", "text": f"ok from {persona_name}"}],
+        usage=usage,
+    )
+    return TurnSummary(assistant_messages=[msg], iterations=1, usage=usage)
+
+
+class TestEndToEndResume:
+    def test_n50_10pct_rate_errors_abort_at_30_resume_finishes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """n=50 panel, 10% of calls 429, "SIGINT" at 30, resume completes all 50.
+
+        This mirrors the bead's worked example without actually spawning
+        50 real LLM sessions. We exercise the checkpoint writer + the
+        orchestrator callback pipeline end-to-end:
+
+          1. Stage 1: run 30 of 50 panelists. Every 10th panelist's first
+             attempt simulates a 429; the 429 contributes to ``usage``
+             but the panelist still completes (the client retry budget
+             absorbs the failure). After 30 completions the writer's
+             ``mark_aborted`` is called — equivalent to SIGINT landing
+             at the cadence boundary.
+          2. Stage 2: load the checkpoint, rerun only the remaining 20
+             panelists through ``run_panel_parallel`` with a fresh writer
+             preloaded from stage 1.
+          3. Final assertion: the final checkpoint covers all 50 personas
+             with ``remaining == []`` and abort_reason cleared.
+
+        Keeps the test deterministic and single-threaded (max_workers=1)
+        so the "abort at 30" boundary is exact.
+        """
+        persona_names = [f"p{i:02d}" for i in range(50)]
+        personas = [_persona(n) for n in persona_names]
+        questions = [{"text": "What do you think?"}]
+
+        # Build a mock client whose send() raises a RATE_LIMIT on every 10th
+        # call, then succeeds. We never route through the real retry
+        # loop — the point of the integration test is that the orchestrator
+        # and writer cope with the error signal landing on a panelist.
+        send_count = {"n": 0}
+
+        def flaky_send(_req: Any) -> CompletionResponse:
+            send_count["n"] += 1
+            if send_count["n"] % 10 == 0:
+                raise _rate_limit_error()
+            return _mock_response()
+
+        # Stage 1: run the first 30 panelists with a writer flushing every 1.
+        run_id = new_run_id()
+        directory = checkpoint_dir_for(run_id, tmp_path)
+        cfg = {
+            "persona_names": persona_names,
+            "persona_count": 50,
+            "question_texts": ["What do you think?"],
+            "question_count": 1,
+            "model": "claude-sonnet-4-6",
+            "temperature": 0.7,
+            "top_p": None,
+        }
+        writer = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=cfg,
+            all_personas=persona_names,
+            every=5,
+        )
+
+        # Prime partial results by driving the orchestrator against the
+        # first 30 personas. The remaining 20 stay unrun.
+        client_stage1 = MagicMock()
+        client_stage1.send = flaky_send
+
+        def record_cb(pr: PanelistResult) -> None:
+            writer.record_completed(
+                {
+                    "persona": pr.persona_name,
+                    "responses": pr.responses,
+                    "usage": pr.usage.to_dict(),
+                    "error": pr.error,
+                },
+                pr.usage.to_dict(),
+            )
+
+        stage1_results, _reg, _sess = run_panel_parallel(
+            client=client_stage1,
+            personas=personas[:30],
+            questions=questions,
+            model="claude-sonnet-4-6",
+            system_prompt_fn=_system,
+            question_prompt_fn=_question,
+            max_workers=1,
+            on_panelist_complete=record_cb,
+        )
+        # Panelists whose single call hit a rate-limit error carry a
+        # response-level error on that question; the panelist itself
+        # still completes and counts toward the checkpoint cadence. The
+        # orchestrator's inner per-question exception handler is what
+        # keeps a transient 429 from taking down the whole panelist.
+        assert len(stage1_results) == 30
+        errored_responses = sum(
+            1 for pr in stage1_results for resp in pr.responses if isinstance(resp, dict) and resp.get("error")
+        )
+        # Every 10th send raised a 429 → expect ~3 error responses in 30
+        # panelists; allow slop for the first-call vs. retry ordering.
+        assert 1 <= errored_responses <= 5, (
+            f"expected roughly 10% of 30 panelists to carry rate-limit response errors; got {errored_responses}"
+        )
+
+        writer.mark_aborted("signal:SIGINT")
+        writer.flush(force=True)
+
+        # The checkpoint on disk now carries 30 completed + 20 remaining.
+        mid_ckpt = load_checkpoint(run_id, tmp_path)
+        assert len(mid_ckpt.completed) == 30
+        assert mid_ckpt.remaining == persona_names[30:]
+        assert mid_ckpt.abort_reason == "signal:SIGINT"
+
+        # Stage 2: resume — rerun the remaining 20 with a writer preloaded
+        # from the stage 1 checkpoint. Use a clean client so no rate-limit
+        # errors interfere with the resume (if the resume also failed,
+        # the bead's claim "resume clean" would be false).
+        client_stage2 = MagicMock()
+        client_stage2.send = MagicMock(return_value=_mock_response())
+
+        writer_resume = CheckpointWriter(
+            run_id=run_id,
+            directory=directory,
+            config=cfg,
+            all_personas=persona_names,
+            every=5,
+            preloaded_completed=mid_ckpt.completed,
+            preloaded_usage=mid_ckpt.usage,
+        )
+
+        def record_cb_resume(pr: PanelistResult) -> None:
+            writer_resume.record_completed(
+                {
+                    "persona": pr.persona_name,
+                    "responses": pr.responses,
+                    "usage": pr.usage.to_dict(),
+                    "error": pr.error,
+                },
+                pr.usage.to_dict(),
+            )
+
+        stage2_results, _reg, _sess = run_panel_parallel(
+            client=client_stage2,
+            personas=personas[30:],
+            questions=questions,
+            model="claude-sonnet-4-6",
+            system_prompt_fn=_system,
+            question_prompt_fn=_question,
+            max_workers=1,
+            on_panelist_complete=record_cb_resume,
+        )
+        writer_resume.flush(force=True)
+
+        # Final checkpoint: all 50 personas present, remaining empty, no
+        # abort left dangling.
+        final = load_checkpoint(run_id, tmp_path)
+        completed_names = sorted(c["persona"] for c in final.completed)
+        assert completed_names == sorted(persona_names), (
+            f"final checkpoint should cover all 50 personas; got {len(completed_names)}"
+        )
+        assert final.remaining == []
+        # Sanity: the resume slice got real, clean responses for the
+        # panelists who didn't finish stage 1.
+        assert len(stage2_results) == 20
+        assert all(r.error is None for r in stage2_results)


### PR DESCRIPTION
## Summary
Slice (d) of sp-i2ub — completes the scaled-orchestration trilogy (checkpoint + cost gate + abort paths).

Every abort path now produces a valid partial JSON document with `run_invalid: true`, a specific top-level `abort_reason`, and exit code 2 — so automation can detect the abort without scraping banner text.

- **`RunAbortedError`**: orchestrator catches `KeyboardInterrupt` in the `as_completed` loop, cancels pending futures, and raises with the finished-prefix results so the CLI can still emit an envelope.
- **CLI abort classification**:
  - `cost_exceeded` (existing — from sp-4hhk)
  - `sigint` (new — wired from `RunAbortedError`)
  - `rate_limit_exhausted` and `total_failure` (new — via `_classify_total_failure_abort_reason` scanning total-failure sample errors for rate-limit markers).

## Context
- Source issue: sp-56pb (slice (d) of parent sp-i2ub). Depends on sp-hsk3 (checkpoint, #266) and sp-4hhk (cost gate, #269), both now on main.

## Test plan
- [x] `pytest tests/test_abort_paths.py` — 620 LOC covering classifier unit tests, orchestrator `RunAbortedError` prefix, CLI smoke per abort path, and the integration scenario from the bead: n=50 with 10% rate errors, abort at 30, resume clean.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.
- [ ] Manual: SIGINT mid-run → valid partial JSON with `abort_reason: sigint`, exit 2; `--max-cost` overflow → `abort_reason: cost_exceeded`, exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)