### PR TITLE
fix(inspect): bucket per-model rollup by canonical id (sp-f9jg)

### DIFF
--- a/src/synth_panel/analysis/inspect.py
+++ b/src/synth_panel/analysis/inspect.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from synth_panel.llm.aliases import resolve_alias
+
 _SYNTH_SUMMARY_PEEK = 300
 
 
@@ -247,7 +249,8 @@ def _collect_model_rollup(
 
     for p in panelists:
         model = p.get("model") or fallback_model or "unknown"
-        bucket = _bucket(str(model))
+        # Bucket by canonical id to match metadata.cost.per_model keys.
+        bucket = _bucket(resolve_alias(str(model)))
         bucket["personas"] += 1
         usage = p.get("usage") or {}
         if isinstance(usage, dict):
@@ -270,7 +273,7 @@ def _collect_model_rollup(
             for model, stats in per_model.items():
                 if not isinstance(stats, dict):
                     continue
-                bucket = _bucket(str(model))
+                bucket = _bucket(resolve_alias(str(model)))
                 cost_val = stats.get("cost_usd")
                 if isinstance(cost_val, (int, float)):
                     bucket["cost_usd"] = float(cost_val)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -7,6 +7,7 @@ import tempfile
 from pathlib import Path
 
 from synth_panel.analysis.inspect import build_inspect_report, format_inspect_text
+from synth_panel.llm.aliases import resolve_alias
 from synth_panel.main import main
 
 
@@ -152,8 +153,9 @@ def test_inspect_rounds_shape_full():
     assert report.synthesis.theme_count == 2
     assert report.synthesis.summary_peek and report.synthesis.summary_peek.startswith("The panel converged")
     per_model = {m.model: m for m in report.model_rollup}
-    assert per_model["haiku"].cost_usd == 0.009
-    assert per_model["sonnet"].cost_usd == 0.02
+    # Rollup keys are canonical model ids (aliases resolved).
+    assert per_model[resolve_alias("haiku")].cost_usd == 0.009
+    assert per_model[resolve_alias("sonnet")].cost_usd == 0.02
     assert report.warnings == ["low-n: 3 panelists"]
     assert report.instrument_name == "pricing-discovery"
 
@@ -184,6 +186,60 @@ def test_inspect_summary_peek_truncates_long_summary():
     report = build_inspect_report(data)
     assert report.synthesis.summary_peek is not None
     assert len(report.synthesis.summary_peek) == 301  # 300 + ellipsis
+
+
+def test_inspect_model_rollup_merges_alias_and_canonical(monkeypatch):
+    """Regression for sp-f9jg: panelist keyed by alias must bucket with
+    metadata.cost.per_model keyed by canonical id (no duplicate rows)."""
+    # Pin a deterministic alias map so the test doesn't depend on the
+    # user's ~/.synthpanel/aliases.yaml or env overrides.
+    monkeypatch.setenv(
+        "SYNTHPANEL_MODEL_ALIASES",
+        json.dumps({"haiku": "claude-haiku-4-5-20251001"}),
+    )
+    from synth_panel.llm import aliases as aliases_mod
+
+    aliases_mod._reset_cache()
+    try:
+        data = {
+            "id": "result-merge",
+            "created_at": "2026-04-25T00:00:00+00:00",
+            "model": "haiku",
+            "persona_count": 1,
+            "question_count": 1,
+            "results": [
+                {
+                    "persona": "P0",
+                    "responses": [{"question": "q", "response": "a", "follow_up": False}],
+                    "usage": {"input_tokens": 30, "output_tokens": 20},
+                    "model": "haiku",  # alias
+                }
+            ],
+            "metadata": {
+                "cost": {
+                    "per_model": {
+                        # Canonical id, as written by metadata.py:135.
+                        "claude-haiku-4-5-20251001": {"tokens": 50, "cost_usd": 0.001},
+                    }
+                }
+            },
+        }
+
+        report = build_inspect_report(data)
+
+        assert len(report.model_rollup) == 1, (
+            f"alias and canonical must merge into one row, got "
+            f"{[m.model for m in report.model_rollup]}"
+        )
+        row = report.model_rollup[0]
+        assert row.model == "claude-haiku-4-5-20251001"
+        assert row.input_tokens == 30
+        assert row.output_tokens == 20
+        assert row.total_tokens == 50
+        assert row.cost_usd == 0.001
+        assert row.personas == 1
+    finally:
+        aliases_mod._reset_cache()
 
 
 def test_format_inspect_text_includes_all_sections():

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -228,8 +228,7 @@ def test_inspect_model_rollup_merges_alias_and_canonical(monkeypatch):
         report = build_inspect_report(data)
 
         assert len(report.model_rollup) == 1, (
-            f"alias and canonical must merge into one row, got "
-            f"{[m.model for m in report.model_rollup]}"
+            f"alias and canonical must merge into one row, got {[m.model for m in report.model_rollup]}"
         )
         row = report.model_rollup[0]
         assert row.model == "claude-haiku-4-5-20251001"


### PR DESCRIPTION
## Summary
`_collect_model_rollup` keyed panelist usage by the raw model string (typically a short alias like `haiku`) while `metadata.cost.per_model` is keyed by canonical id (e.g. `claude-haiku-4-5-20251001`). The two sources merged via string equality, producing **two rows per model** in the Per-Model Rollup section: one with tokens but no cost (alias), one with cost but zero tokens (canonical).

- Applies `resolve_alias()` on both code paths in `analysis/inspect.py` so they always bucket on the same canonical key (mirroring what `metadata.py:135` already does).
- Adds a regression test covering the alias → canonical merge.

## Context
- Source issue: sp-f9jg (visible in `synthpanel report` Per-Model Rollup after any `--models 'haiku:...,gemini-flash-lite:...'` run).
- Out of scope: optional alias-display field on `ModelRollup` for showing user-friendly alias alongside canonical id.

## Test plan
- [x] `pytest tests/test_inspect.py` — 60 new lines exercising the merged-bucket case.
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.
- [ ] Manual: `synthpanel panel run --models 'haiku:0.5,gemini-flash-lite:0.5' ...` then `synthpanel report <result.json>` → single row per model in the rollup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)