### PR TITLE
feat(reporting): render full synthesis sections in markdown report (sp-xltd)

### DIFF
--- a/src/synth_panel/reporting/markdown.py
+++ b/src/synth_panel/reporting/markdown.py
@@ -58,7 +58,7 @@ def render_markdown(
     parts.extend(_persona_summary_block(report))
     parts.append("")
 
-    parts.extend(_synthesis_block(report))
+    parts.extend(_synthesis_block(report, raw))
     parts.append("")
 
     parts.extend(_failure_stats_block(report))
@@ -219,8 +219,12 @@ def _persona_summary_block(report: InspectReport) -> list[str]:
     return lines
 
 
-def _synthesis_block(report: InspectReport) -> list[str]:
-    """Section 7 — synthesis status, themes, summary peek."""
+def _synthesis_block(report: InspectReport, raw: dict[str, Any]) -> list[str]:
+    """Section 7 — synthesis status, meta, summary peek, plus the full
+    themes / agreements / disagreements / recommendation lists pulled
+    straight from ``raw['synthesis']`` so the report is no longer just a
+    240-char peek over a black-box JSON blob (sp-xltd).
+    """
     lines: list[str] = ["## Synthesis", ""]
     s = report.synthesis
     if not s.ran and s.error is None and s.summary_peek is None:
@@ -245,6 +249,35 @@ def _synthesis_block(report: InspectReport) -> list[str]:
         lines.append("**Summary peek:**")
         lines.append("")
         lines.append("> " + s.summary_peek.replace("\n", "\n> "))
+
+    synth = raw.get("synthesis") if isinstance(raw.get("synthesis"), dict) else {}
+
+    themes = synth.get("themes")
+    if isinstance(themes, list) and themes:
+        lines.append("")
+        lines.append("**Themes:**")
+        lines.append("")
+        for item in themes:
+            lines.append(_render_theme_item(item))
+
+    for label, key in (("Agreements", "agreements"), ("Disagreements", "disagreements")):
+        items = synth.get(key)
+        if isinstance(items, list) and items:
+            lines.append("")
+            lines.append(f"**{label}:**")
+            lines.append("")
+            for i, entry in enumerate(items, 1):
+                lines.append(f"{i}. {_format_synth_item(entry)}")
+
+    recommendation = synth.get("recommendation")
+    rec_text = _coerce_str(recommendation).strip() if recommendation else ""
+    if rec_text:
+        lines.append("")
+        lines.append("**Recommendation:**")
+        lines.append("")
+        text = _truncate(rec_text, _SYNTH_ITEM_CAP)
+        lines.append("> " + _escape_inline(text).replace("\n", "\n> "))
+
     return lines
 
 
@@ -280,6 +313,75 @@ def _warnings_block(report: InspectReport) -> list[str]:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+# Cap individual synthesis bullets so a runaway 5000-char dump doesn't
+# turn the report into a wall of text. 500 chars ≈ a long paragraph,
+# generous enough that real synthesis output fits without truncation
+# but short enough that pathological cases stay scannable.
+_SYNTH_ITEM_CAP = 500
+
+
+def _coerce_str(value: Any) -> str:
+    """Best-effort string coercion for synthesizer outputs that may be
+    either strings or dicts.
+
+    Dict shape preference order: ``title``/``name``/``theme`` for the
+    headline, ``description``/``summary``/``detail``/``text`` for the
+    body. Falls back to ``str(value)`` so we never raise on weird inputs.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict):
+        title = value.get("title") or value.get("name") or value.get("theme")
+        desc = value.get("description") or value.get("summary") or value.get("detail") or value.get("text")
+        if title and desc:
+            return f"{title}: {desc}"
+        if title:
+            return str(title)
+        if desc:
+            return str(desc)
+        return ", ".join(f"{k}={v}" for k, v in value.items())
+    return str(value)
+
+
+def _truncate(s: str, cap: int) -> str:
+    if len(s) <= cap:
+        return s
+    return s[: cap - 1].rstrip() + "…"
+
+
+def _render_theme_item(item: Any) -> str:
+    """Render a single themes[] entry as a Markdown list bullet.
+
+    Dict items with both ``title`` and ``description`` render as
+    ``- **Title** — description``. String items render verbatim. All
+    text is truncated to ``_SYNTH_ITEM_CAP`` and inline-escaped so
+    stray angle brackets don't break the surrounding HTML preview.
+    """
+    if isinstance(item, dict):
+        title = item.get("title") or item.get("name") or item.get("theme")
+        desc = item.get("description") or item.get("summary") or item.get("detail")
+        if title and desc:
+            t = _escape_inline(_truncate(str(title), _SYNTH_ITEM_CAP))
+            d = _escape_inline(_truncate(str(desc), _SYNTH_ITEM_CAP))
+            return f"- **{t}** — {d}"
+        text = _truncate(_coerce_str(item), _SYNTH_ITEM_CAP)
+        return f"- {_escape_inline(text)}"
+    return f"- {_escape_inline(_truncate(_coerce_str(item), _SYNTH_ITEM_CAP))}"
+
+
+def _format_synth_item(item: Any) -> str:
+    """Render an agreements/disagreements entry inline (no leading bullet).
+
+    Newlines collapse to spaces so a numbered list stays one item per
+    line; truncation + inline escaping mirrors :func:`_render_theme_item`.
+    """
+    text = _truncate(_coerce_str(item), _SYNTH_ITEM_CAP)
+    text = text.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    return _escape_inline(text)
 
 
 def _banner() -> str:

--- a/tests/fixtures/reporting/rounds_shape.json
+++ b/tests/fixtures/reporting/rounds_shape.json
@@ -72,6 +72,14 @@
     "strategy": "single",
     "summary": "Panelists agree that pricing opacity is the key blocker; fair-price band clusters around $15-20/month per seat.",
     "themes": ["pricing", "onboarding"],
+    "agreements": [
+      "Pricing transparency is the single largest blocker to adoption.",
+      "Onboarding friction compounds the pricing concern."
+    ],
+    "disagreements": [
+      "Acceptable per-seat price band ranges from $15 to $20 depending on team size."
+    ],
+    "recommendation": "Publish a tiered pricing page with per-seat costs and an interactive estimator before the next campaign.",
     "cost": "$0.0010"
   },
   "failure_stats": {

--- a/tests/fixtures/reporting/synthesis_dict_shape.json
+++ b/tests/fixtures/reporting/synthesis_dict_shape.json
@@ -1,0 +1,52 @@
+{
+  "id": "dict-shape-panel",
+  "created_at": "2026-04-23T10:00:00Z",
+  "model": "claude-sonnet-4-6",
+  "persona_count": 1,
+  "question_count": 1,
+  "total_usage": {
+    "input_tokens": 50,
+    "output_tokens": 20,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 0
+  },
+  "total_cost": "$0.0006",
+  "results": [
+    {
+      "persona": "Anon",
+      "model": "claude-sonnet-4-6",
+      "responses": [
+        {
+          "question": "How does the workflow feel?",
+          "response": "Tedious and slow.",
+          "usage": {"input_tokens": 50, "output_tokens": 20}
+        }
+      ]
+    }
+  ],
+  "synthesis": {
+    "ran": true,
+    "model": "claude-sonnet-4-6",
+    "strategy": "single",
+    "summary": "Workflow tedium dominates the qualitative signal.",
+    "themes": [
+      {"title": "Tedium", "description": "Repeated manual steps slow every panelist down."},
+      {"title": "Speed expectations", "description": "Panelists expect sub-second feedback for common actions."}
+    ],
+    "agreements": [
+      {"title": "Manual steps", "description": "All panelists call out the same three manual steps as redundant."}
+    ],
+    "disagreements": [
+      {"text": "Whether to fix UX first or rebuild the data model first."}
+    ],
+    "recommendation": "Cut the three redundant steps in the next sprint; defer the data-model debate.",
+    "cost": "$0.0008"
+  },
+  "failure_stats": {
+    "total_pairs": 1,
+    "errored_pairs": 0,
+    "failure_rate": 0.0,
+    "failed_panelists": 0,
+    "errored_personas": []
+  }
+}

--- a/tests/test_reporting_markdown.py
+++ b/tests/test_reporting_markdown.py
@@ -236,5 +236,157 @@ def test_render_escapes_pipes_in_persona_names() -> None:
     assert "| Alice | Evil |" not in md
 
 
+# ---------------------------------------------------------------------------
+# 8. Synthesis renders full themes/agreements/disagreements/recommendation
+#    (sp-xltd) for string-shape items.
+# ---------------------------------------------------------------------------
+
+
+def test_render_synthesis_full_string_shape() -> None:
+    md, raw = _render("rounds_shape.json")
+
+    # All four substantive sections render under ## Synthesis.
+    synth_idx = md.index("## Synthesis")
+    failure_idx = md.index("## Failure Stats")
+    synth_block = md[synth_idx:failure_idx]
+
+    assert "**Themes:**" in synth_block
+    assert "**Agreements:**" in synth_block
+    assert "**Disagreements:**" in synth_block
+    assert "**Recommendation:**" in synth_block
+
+    # Theme bullet content (string shape).
+    assert "- pricing" in synth_block
+    assert "- onboarding" in synth_block
+
+    # Agreements/disagreements as numbered lists with verbatim text.
+    assert "1. Pricing transparency is the single largest blocker" in synth_block
+    assert "2. Onboarding friction" in synth_block
+    assert "1. Acceptable per-seat price band" in synth_block
+
+    # Recommendation as a blockquote.
+    assert "> Publish a tiered pricing page" in synth_block
+
+    # Existing summary peek still renders — the detail sections are
+    # additive, not a replacement.
+    assert "Panelists agree that pricing opacity" in synth_block
+
+
+# ---------------------------------------------------------------------------
+# 9. Synthesis renders dict-shape themes/agreements (sp-xltd).
+# ---------------------------------------------------------------------------
+
+
+def test_render_synthesis_full_dict_shape() -> None:
+    md, _ = _render("synthesis_dict_shape.json")
+
+    synth_idx = md.index("## Synthesis")
+    failure_idx = md.index("## Failure Stats")
+    synth_block = md[synth_idx:failure_idx]
+
+    # Dict-shape themes render as "**Title** — description".
+    assert "- **Tedium** — Repeated manual steps" in synth_block
+    assert "- **Speed expectations** — Panelists expect sub-second" in synth_block
+
+    # Dict-shape agreement (title+description) collapses to "title: desc"
+    # in numbered-list form.
+    assert "1. Manual steps: All panelists call out" in synth_block
+
+    # Dict-shape disagreement keyed only on `text` still surfaces.
+    assert "1. Whether to fix UX first" in synth_block
+
+    # Recommendation (string) still rendered.
+    assert "> Cut the three redundant steps" in synth_block
+
+
+# ---------------------------------------------------------------------------
+# 10. Synthesis sections truncate runaway items (sp-xltd).
+# ---------------------------------------------------------------------------
+
+
+def test_render_synthesis_truncates_long_items() -> None:
+    raw: dict = {
+        "id": "long-synth-panel",
+        "model": "claude-sonnet-4-6",
+        "question_count": 1,
+        "persona_count": 1,
+        "results": [
+            {
+                "persona": "Anon",
+                "model": "claude-sonnet-4-6",
+                "responses": [
+                    {
+                        "question": "q?",
+                        "response": "a",
+                        "usage": {"input_tokens": 1, "output_tokens": 1},
+                    }
+                ],
+            }
+        ],
+        "synthesis": {
+            "ran": True,
+            "model": "claude-sonnet-4-6",
+            "summary": "ok",
+            "themes": ["x" * 800],
+            "agreements": ["y" * 800],
+            "disagreements": [],
+            "recommendation": "z" * 800,
+        },
+    }
+
+    report = build_inspect_report(raw)
+    md = render_markdown(report, raw)
+
+    # Truncation marker is the ellipsis; raw 800-char strings must not
+    # appear verbatim.
+    assert "x" * 800 not in md
+    assert "y" * 800 not in md
+    assert "z" * 800 not in md
+    assert "…" in md
+
+
+# ---------------------------------------------------------------------------
+# 11. Empty synthesis fields don't emit empty section headers (sp-xltd).
+# ---------------------------------------------------------------------------
+
+
+def test_render_synthesis_skips_empty_sections() -> None:
+    raw: dict = {
+        "id": "minimal-synth-panel",
+        "model": "claude-sonnet-4-6",
+        "question_count": 1,
+        "persona_count": 1,
+        "results": [
+            {
+                "persona": "Anon",
+                "model": "claude-sonnet-4-6",
+                "responses": [
+                    {"question": "q?", "response": "a", "usage": {"input_tokens": 1, "output_tokens": 1}}
+                ],
+            }
+        ],
+        "synthesis": {
+            "ran": True,
+            "model": "claude-sonnet-4-6",
+            "summary": "minimal",
+            "themes": [],
+            "agreements": [],
+            "disagreements": [],
+            "recommendation": "",
+        },
+    }
+
+    report = build_inspect_report(raw)
+    md = render_markdown(report, raw)
+
+    # No empty bullet sections.
+    assert "**Themes:**" not in md
+    assert "**Agreements:**" not in md
+    assert "**Disagreements:**" not in md
+    assert "**Recommendation:**" not in md
+    # Status still renders.
+    assert "**Status:** ran" in md
+
+
 if __name__ == "__main__":  # pragma: no cover - convenience
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_reporting_markdown.py
+++ b/tests/test_reporting_markdown.py
@@ -243,7 +243,7 @@ def test_render_escapes_pipes_in_persona_names() -> None:
 
 
 def test_render_synthesis_full_string_shape() -> None:
-    md, raw = _render("rounds_shape.json")
+    md, _raw = _render("rounds_shape.json")
 
     # All four substantive sections render under ## Synthesis.
     synth_idx = md.index("## Synthesis")

--- a/tests/test_reporting_markdown.py
+++ b/tests/test_reporting_markdown.py
@@ -360,9 +360,7 @@ def test_render_synthesis_skips_empty_sections() -> None:
             {
                 "persona": "Anon",
                 "model": "claude-sonnet-4-6",
-                "responses": [
-                    {"question": "q?", "response": "a", "usage": {"input_tokens": 1, "output_tokens": 1}}
-                ],
+                "responses": [{"question": "q?", "response": "a", "usage": {"input_tokens": 1, "output_tokens": 1}}],
             }
         ],
         "synthesis": {


### PR DESCRIPTION
## Summary
Markdown v1 reporter now renders the substantive synthesis output — themes, agreements, disagreements, and recommendation — instead of just status + theme count + 240-char summary peek.

- Handles both string-list and dict-list item shapes (synthesizers emit either) with per-item truncation at 500 chars to keep reports scannable.
- Empty sections are omitted so minimal panels stay terse.

## Context
- Source issue: sp-xltd (sp-viz-layer v2). Surfaced by SynthPanel's n=100 self-audit on v0.11.0: panelists explicitly flagged the synthesis step as a "black box" because the substantive lists lived only in JSON, not the report.
- Predecessor: sp-z3uy / sp-u88v (markdown v1 in v0.11.0) — this PR closes the visibility gap that v1 deliberately deferred.

## Test plan
- [x] `pytest tests/test_reporting_markdown.py` — 152 LOC of new tests + two fixture files (`rounds_shape.json`, `synthesis_dict_shape.json`).
- [ ] CI: test 3.10–3.14, coverage, security, lint, typecheck, CodeQL, dependency-review.
- [ ] Manual: `synthpanel report results/<panel>.json` → themes/agreements/disagreements/recommendation visible inline; minimal panels still terse (empty sections omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)