### PR TITLE
feat(pack): add 'synthpanel pack calibrate' CLI subcommand (sp-sghl)

### DIFF
--- a/docs/calibration.md
+++ b/docs/calibration.md
@@ -1,0 +1,133 @@
+# Pack calibration
+
+Calibration is how a persona pack proves its fit to a known human
+baseline. Run `synthpanel pack calibrate` and the result is written
+back into the pack YAML so the manifest is self-describing.
+
+```
+synthpanel pack calibrate <PACK_YAML>
+  --against DATASET:QUESTION   # e.g. gss:HAPPY (v1 allowlist: gss, ntia)
+  [--n 50]                     # panel size
+  [--models MODELS]            # default: panel run default
+  [--samples-per-question 15]  # for stable JSD
+  [--output PATH]              # default: rewrite PACK_YAML in place
+  [--dry-run]                  # print what would be written
+  [--yes]                      # skip overwrite confirm
+```
+
+After a successful run the pack YAML gains a top-level `calibration:`
+list:
+
+```yaml
+calibration:
+  - dataset: gss
+    question: HAPPY
+    jsd: 0.18
+    n: 100
+    samples_per_question: 15
+    models: [haiku:0.30, gemini-flash-lite:0.30, qwen3-plus:0.20, deepseek-v3:0.20]
+    extractor: pick_one:auto-derived
+    panelist_cost_usd: 0.6451
+    calibrated_at: 2026-04-26T14:23:00Z
+    synthpanel_version: 0.11.1
+    methodology_url: https://synthpanel.dev/docs/calibration
+```
+
+## What JSD means
+
+Calibration reports **Jensen-Shannon divergence** between the pack's
+extracted answer distribution and the dataset's published human
+distribution. JSD is bounded in `[0, 1]` (using `log2`):
+
+| JSD       | Interpretation                                          |
+|-----------|---------------------------------------------------------|
+| < 0.05    | Tightly aligned — pack mirrors the human distribution.  |
+| 0.05–0.15 | Strong alignment — small but real distributional drift. |
+| 0.15–0.30 | Moderate — usable for directional research, not census. |
+| 0.30–0.50 | Weak — major disagreement on at least one mode.         |
+| > 0.50    | Effectively uncalibrated.                               |
+
+JSD is computed locally via the same metric the convergence tracker
+uses (see `src/synth_panel/convergence.py`); the pack YAML is the
+**only** durable artifact — calibration does not phone home and is
+distinct from `--submit-to-synthbench`.
+
+## When to calibrate
+
+Calibrate a pack when **any** of the following is true:
+
+- The pack will be cited in a research artifact and you need a
+  defensible fit-to-baseline number.
+- You have changed the pack (added/removed personas, edited
+  `personality_traits`, regenerated descriptions) and want to know
+  whether your edits drifted the distribution.
+- You are comparing two packs that target the same audience and need a
+  shared yardstick.
+
+You do **not** need to calibrate before every panel run. The
+`calibration:` list is a snapshot, not a runtime guard.
+
+## Choosing a baseline
+
+The `--against DATASET:QUESTION` flag accepts the same v1
+inline-publishable allowlist as `panel run --calibrate-against`:
+
+| Dataset | Notes                                                          |
+|---------|----------------------------------------------------------------|
+| `gss`   | General Social Survey aggregates. `HAPPY` is the canonical     |
+|         | demo question (3-option Likert); `HEALTH` and `LIFE` also work.|
+| `ntia`  | NTIA Internet Use Survey. Useful for technology-adoption packs.|
+
+Other datasets (OpinionsQA, PewTech, GlobalOpinionQA, WVS, ...) are
+**gated** for redistribution and require post-hoc calibration via
+`synthbench` directly. They are intentionally not exposed here so a
+calibrated pack YAML can be checked into a public repo without
+relicensing concerns.
+
+To override the allowlist for internal use:
+
+```
+SYNTHBENCH_ALLOW_GATED=1 synthpanel pack calibrate ... --against wvs:Q1
+```
+
+## Methodology
+
+For each calibration run:
+
+1. The SynthBench baseline payload is fetched (same loader as
+   `panel run --calibrate-against`).
+2. A `pick_one` extraction schema is auto-derived from the baseline's
+   small-enum distribution. If the baseline is Likert/ranking or
+   too-wide, the command hard-fails with a hint to supply
+   `--extract-schema` via `panel run` instead.
+3. A panel of `--n` panelists is run against the dataset's question
+   text. Each panelist answers `--samples-per-question` times.
+4. The model distribution is compared against the baseline's
+   `human_distribution` via Jensen-Shannon divergence.
+5. The resulting JSD, plus provenance (extractor, models, cost,
+   timestamp, synthpanel version), is merged into the pack YAML's
+   `calibration:` list. Re-running against the same `(dataset,
+   question)` pair **replaces** the prior entry rather than appending,
+   so the list is always a clean record of one-result-per-baseline.
+
+## Idempotence and re-runs
+
+- Re-running calibration against the same `dataset:question` replaces
+  the prior entry — newest wins.
+- Calibration against a different `dataset:question` appends a new
+  entry alongside any existing ones.
+- `--dry-run` prints the rewritten YAML to stdout without touching the
+  file. Use this to preview what would change before committing.
+
+## Limitations
+
+- Auto-discovering "which question should this pack calibrate
+  against?" is **out of scope** for the v1 command. You pick the
+  baseline.
+- Calibration measures distributional fit on **one** answer
+  distribution. A low JSD on `gss:HAPPY` does not imply low JSD on a
+  different question — calibrate against multiple baselines if you
+  need broad coverage.
+- The command requires the `synthpanel[convergence]` extra (for the
+  `synthbench` baseline loader). Install with
+  `pip install 'synthpanel[convergence]'` if not already present.

--- a/src/synth_panel/calibration.py
+++ b/src/synth_panel/calibration.py
@@ -1,0 +1,222 @@
+"""Pack-YAML calibration block read/merge/write (sp-sghl).
+
+Helpers used by ``synthpanel pack calibrate`` to splice a freshly-computed
+calibration entry into a persona pack YAML without disturbing the
+surrounding persona definitions, comments, or whitespace.
+
+The strategy is *targeted text surgery* rather than a full YAML
+round-trip:
+
+1. Parse the YAML once with :mod:`pyyaml` to validate it and obtain the
+   current top-level structure (so we can reason about whether a
+   ``calibration:`` block already exists).
+2. Locate the existing top-level ``calibration:`` region in the raw
+   text — if any — and replace it. If absent, append a new block at the
+   end of the file.
+3. The replacement block is rendered with ``yaml.safe_dump`` so the
+   serialized fields are well-formed; only the calibration region is
+   touched.
+
+This keeps comments and persona definitions outside the calibration
+block exactly as the user wrote them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class CalibrationEntry:
+    """One calibration result against a single SynthBench baseline.
+
+    A pack's ``calibration:`` field is a list of these. Re-running
+    calibration against the same ``(dataset, question)`` pair replaces
+    the prior entry rather than appending a duplicate (newest wins).
+    """
+
+    dataset: str
+    question: str
+    jsd: float
+    n: int
+    samples_per_question: int
+    models: list[str]
+    extractor: str
+    panelist_cost_usd: float
+    calibrated_at: str
+    synthpanel_version: str
+    methodology_url: str = "https://synthpanel.dev/docs/calibration"
+    alignment_error: str | None = field(default=None)
+
+    def to_yaml_dict(self) -> dict[str, Any]:
+        """Render as an ordered plain dict suitable for YAML emission."""
+        d = asdict(self)
+        # Drop None alignment_error so the wire shape matches the bead's
+        # example for the happy path.
+        if d.get("alignment_error") is None:
+            d.pop("alignment_error", None)
+        return d
+
+
+def now_iso_utc() -> str:
+    """RFC3339 UTC timestamp with second precision (no microseconds)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_pack_yaml(path: str) -> tuple[str, dict[str, Any]]:
+    """Read a pack YAML and return ``(raw_text, parsed_dict)``.
+
+    Raises ``ValueError`` on parse failure or non-mapping top level.
+    """
+    with open(path, encoding="utf-8") as f:
+        raw = f.read()
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise ValueError(f"failed to parse {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"pack YAML at {path} must be a mapping at top level")
+    return raw, data
+
+
+def merge_calibration(
+    existing: list[dict[str, Any]] | None,
+    new_entry: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Merge ``new_entry`` into ``existing`` calibration list.
+
+    Replaces any prior entry with the same ``(dataset, question)`` pair
+    so re-running calibration is idempotent — newest wins.
+    """
+    if existing is None:
+        existing = []
+    if not isinstance(existing, list):
+        raise ValueError(f"pack 'calibration:' must be a list of calibration entries; got {type(existing).__name__}")
+    target_dataset = new_entry.get("dataset")
+    target_question = new_entry.get("question")
+    out: list[dict[str, Any]] = []
+    replaced = False
+    for entry in existing:
+        if not isinstance(entry, dict):
+            out.append(entry)
+            continue
+        if entry.get("dataset") == target_dataset and entry.get("question") == target_question:
+            if not replaced:
+                out.append(new_entry)
+                replaced = True
+            continue
+        out.append(entry)
+    if not replaced:
+        out.append(new_entry)
+    return out
+
+
+def _render_calibration_block(entries: list[dict[str, Any]]) -> str:
+    """Render the ``calibration:`` block as YAML text.
+
+    The output always ends with a single trailing newline. ``sort_keys``
+    is disabled so field order matches the dataclass declaration.
+    """
+    rendered = yaml.safe_dump(
+        {"calibration": entries},
+        default_flow_style=False,
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    if not rendered.endswith("\n"):
+        rendered += "\n"
+    return rendered
+
+
+_TOP_LEVEL_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*:")
+
+
+def _is_top_level_key_line(line: str) -> bool:
+    """True when *line* begins (column 0) with a ``key:`` declaration.
+
+    Excludes block list items (``- foo``), document separators (``---``),
+    and continuation lines indented under a parent key.
+    """
+    return bool(_TOP_LEVEL_KEY_RE.match(line))
+
+
+def _find_top_level_block(raw: str, key: str) -> tuple[int, int] | None:
+    """Locate the byte span of an existing top-level ``key:`` block.
+
+    Returns ``(start, end)`` where ``raw[start:end]`` covers the whole
+    block including the trailing newline of its last line, or ``None``
+    if no top-level ``key:`` is present.
+
+    "Top level" means the line begins with ``key:`` at column 0. The
+    block extends until the next top-level key or EOF. List items
+    (``- ...``) rendered at column 0 by ``yaml.safe_dump`` are treated as
+    continuations of the prior key, not as new top-level boundaries.
+    """
+    lines = raw.splitlines(keepends=True)
+    start_line: int | None = None
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        if stripped.startswith("#") or not stripped.strip():
+            continue
+        if _is_top_level_key_line(line) and stripped.startswith(f"{key}:"):
+            start_line = i
+            break
+    if start_line is None:
+        return None
+
+    end_line = len(lines)
+    for j in range(start_line + 1, len(lines)):
+        line = lines[j]
+        stripped = line.lstrip()
+        if not stripped.strip() or stripped.startswith("#"):
+            continue
+        if _is_top_level_key_line(line):
+            # Another top-level key starts here.
+            end_line = j
+            break
+
+    start = sum(len(line) for line in lines[:start_line])
+    end = sum(len(line) for line in lines[:end_line])
+    return start, end
+
+
+def write_pack_calibration(
+    raw_text: str,
+    entries: list[dict[str, Any]],
+) -> str:
+    """Return ``raw_text`` with the ``calibration:`` block replaced/appended.
+
+    Persona definitions and any other top-level keys outside the
+    ``calibration:`` block are preserved verbatim.
+    """
+    new_block = _render_calibration_block(entries)
+    span = _find_top_level_block(raw_text, "calibration")
+    if span is None:
+        sep = "" if raw_text.endswith("\n") or raw_text == "" else "\n"
+        # Always separate from prior content with one blank line.
+        prefix = raw_text + sep
+        if prefix and not prefix.endswith("\n\n"):
+            prefix += "\n"
+        return prefix + new_block
+    start, end = span
+    return raw_text[:start] + new_block + raw_text[end:]
+
+
+def update_pack_calibration_text(
+    raw_text: str,
+    parsed: dict[str, Any],
+    new_entry: dict[str, Any],
+) -> str:
+    """High-level helper: merge ``new_entry`` into the pack and re-emit.
+
+    Validates that the parsed pack's ``calibration`` field (if present)
+    is a list, replaces any matching entry, and rewrites the YAML.
+    """
+    existing = parsed.get("calibration")
+    merged = merge_calibration(existing if isinstance(existing, list) else None, new_entry)
+    return write_pack_calibration(raw_text, merged)

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3241,6 +3241,266 @@ def handle_pack_generate(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# Pack calibrate (sp-sghl)
+# ---------------------------------------------------------------------------
+
+
+def _run_calibration_panel(
+    *,
+    pack_yaml_path: str,
+    against: str,
+    n: int,
+    samples_per_question: int,
+    models: str | None,
+) -> dict[str, Any]:
+    """Drive the actual calibration run and return a dict the YAML writer consumes.
+
+    Shells out to ``synthpanel panel run`` so this command composes from the
+    same orchestrator the user would invoke manually. Tests monkeypatch this
+    function, so the real subprocess path is exercised only at integration
+    time.
+
+    The returned dict has keys: ``jsd``, ``extractor``, ``models`` (list of
+    ``model:weight`` strings), ``panelist_cost_usd``, and optionally
+    ``alignment_error``.
+    """
+    import contextlib
+    import subprocess
+    import tempfile
+
+    # The instrument used here is intentionally minimal — a single open-text
+    # question whose text comes from the SynthBench baseline payload (when
+    # available). The panelists' answers are extracted via the auto-derived
+    # pick_one schema (see convergence.derive_pick_one_schema_from_baseline)
+    # and compared against the baseline's human distribution to compute JSD.
+    try:
+        baseline = load_synthbench_baseline(against)
+    except SynthbenchUnavailableError as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    question_text = baseline.get("question_text") or baseline.get("prompt")
+    if not question_text:
+        dataset, _, question = against.partition(":")
+        question_text = f"Please answer the SynthBench {dataset} question {question} as honestly as you can."
+
+    instrument_payload = {
+        "instrument": {
+            "version": 1,
+            "questions": [{"text": str(question_text)}],
+        }
+    }
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False, encoding="utf-8") as inst_fh:
+        yaml.safe_dump(instrument_payload, inst_fh, sort_keys=False)
+        instrument_path = inst_fh.name
+
+    try:
+        cmd = [
+            sys.executable,
+            "-m",
+            "synth_panel",
+            "--output-format",
+            "json",
+            "panel",
+            "run",
+            "--personas",
+            pack_yaml_path,
+            "--instrument",
+            instrument_path,
+            "--n",
+            str(n),
+            "--samples-per-question",
+            str(samples_per_question),
+            "--calibrate-against",
+            against,
+        ]
+        if models:
+            cmd.extend(["--models", models])
+
+        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    finally:
+        with contextlib.suppress(OSError):
+            os.unlink(instrument_path)
+
+    if proc.returncode != 0:
+        raise RuntimeError(f"panel run for calibration failed (exit {proc.returncode}): {proc.stderr.strip()[:500]}")
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"could not parse panel run JSON output: {exc}") from exc
+
+    convergence = payload.get("convergence") or {}
+    per_question = convergence.get("per_question") or {}
+    if not per_question:
+        raise RuntimeError("panel run produced no convergence.per_question — calibration JSD unavailable")
+    # We expect exactly one tracked question (instrument has one).
+    first_key = next(iter(per_question))
+    calib = (per_question[first_key] or {}).get("calibration") or {}
+    if "jsd" not in calib:
+        raise RuntimeError("panel run convergence report has no calibration.jsd — was --calibrate-against rejected?")
+
+    panelist_cost_usd = 0.0
+    cost_section = payload.get("total_cost") or payload.get("cost") or {}
+    if isinstance(cost_section, dict):
+        panelist_cost_usd = float(
+            cost_section.get("usd") or cost_section.get("total_usd") or cost_section.get("cost_usd") or 0.0
+        )
+
+    return {
+        "jsd": float(calib["jsd"]),
+        "extractor": calib.get("extractor") or "pick_one:auto-derived",
+        "models": _split_models_arg(models) if models else _default_models_list(payload),
+        "panelist_cost_usd": panelist_cost_usd,
+        "alignment_error": calib.get("alignment_error"),
+    }
+
+
+def _split_models_arg(models: str | None) -> list[str]:
+    """Split a comma-separated --models argument into a list."""
+    if not models:
+        return []
+    return [m.strip() for m in models.split(",") if m.strip()]
+
+
+def _default_models_list(payload: dict[str, Any]) -> list[str]:
+    """Best-effort recovery of the default model used when --models was not set."""
+    model = payload.get("model")
+    if isinstance(model, str) and model:
+        return [model]
+    metadata = payload.get("metadata") or {}
+    model_meta = metadata.get("model")
+    if isinstance(model_meta, str) and model_meta:
+        return [model_meta]
+    return []
+
+
+def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Calibrate a persona pack against a SynthBench baseline (sp-sghl).
+
+    Orchestrates a panel run with ``--calibrate-against`` and writes the
+    resulting JSD into the pack YAML's ``calibration:`` list. Re-running
+    against the same dataset+question replaces the prior entry.
+    """
+    from synth_panel import calibration as calib_mod
+    from synth_panel.__version__ import __version__
+
+    pack_yaml_path = args.pack_yaml
+    against = args.against
+    output_path = args.output or pack_yaml_path
+    dry_run = bool(args.dry_run)
+    yes = bool(args.yes)
+
+    # ── Validate --against spec + allowlist before any work ───────────
+    dataset, sep, question = against.partition(":")
+    if not sep or not dataset or not question:
+        print(
+            "Error: --against requires DATASET:QUESTION (colon-separated, both non-empty).",
+            file=sys.stderr,
+        )
+        return 2
+    if dataset not in _INLINE_CALIBRATION_ALLOWED and os.environ.get("SYNTHBENCH_ALLOW_GATED") != "1":
+        allowed = ", ".join(sorted(_INLINE_CALIBRATION_ALLOWED))
+        print(
+            f"Error: --against only supports inline-publishable datasets ({allowed}). "
+            f"For gated datasets use post-hoc calibration.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # ── Load + validate the pack YAML ────────────────────────────────
+    if not Path(pack_yaml_path).exists():
+        print(f"Error: pack YAML not found: {pack_yaml_path}", file=sys.stderr)
+        return 1
+    try:
+        raw_text, parsed = calib_mod.load_pack_yaml(pack_yaml_path)
+    except (OSError, ValueError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # ── Run the calibration panel ────────────────────────────────────
+    try:
+        run_result = _run_calibration_panel(
+            pack_yaml_path=pack_yaml_path,
+            against=against,
+            n=int(args.n),
+            samples_per_question=int(args.samples_per_question),
+            models=args.models,
+        )
+    except RuntimeError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    # ── Build the calibration entry ──────────────────────────────────
+    entry = calib_mod.CalibrationEntry(
+        dataset=dataset,
+        question=question,
+        jsd=round(float(run_result["jsd"]), 6),
+        n=int(args.n),
+        samples_per_question=int(args.samples_per_question),
+        models=list(run_result.get("models") or []),
+        extractor=str(run_result.get("extractor") or "pick_one:auto-derived"),
+        panelist_cost_usd=round(float(run_result.get("panelist_cost_usd") or 0.0), 4),
+        calibrated_at=calib_mod.now_iso_utc(),
+        synthpanel_version=str(__version__),
+        alignment_error=run_result.get("alignment_error"),
+    )
+    new_dict = entry.to_yaml_dict()
+    new_yaml = calib_mod.update_pack_calibration_text(raw_text, parsed, new_dict)
+
+    # ── Dry-run: print, don't write ──────────────────────────────────
+    if dry_run:
+        if fmt is OutputFormat.TEXT:
+            print(f"# DRY RUN — would write to {output_path}")
+            print(new_yaml, end="")
+        else:
+            emit(
+                fmt,
+                message="Dry-run preview",
+                extra={
+                    "pack_yaml": pack_yaml_path,
+                    "output": output_path,
+                    "calibration_entry": new_dict,
+                    "rendered_yaml": new_yaml,
+                },
+            )
+        return 0
+
+    # ── Confirm overwrite when output path already exists ────────────
+    out_exists = Path(output_path).exists()
+    if out_exists and not yes and sys.stdin.isatty():
+        prompt = f"Overwrite {output_path}? [y/N]: "
+        try:
+            answer = input(prompt).strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print("\nAborted.", file=sys.stderr)
+            return 1
+        if answer not in {"y", "yes"}:
+            print("Aborted.", file=sys.stderr)
+            return 1
+
+    try:
+        Path(output_path).write_text(new_yaml, encoding="utf-8")
+    except OSError as exc:
+        print(f"Error: failed to write {output_path}: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.TEXT:
+        print(f"Wrote calibration entry ({dataset}:{question}, JSD {entry.jsd}) → {output_path}")
+    else:
+        emit(
+            fmt,
+            message="Pack calibrated",
+            extra={
+                "pack_yaml": pack_yaml_path,
+                "output": output_path,
+                "calibration_entry": new_dict,
+            },
+        )
+    return 0
+
+
 def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """Start the MCP server on stdio transport."""
     from synth_panel.mcp.server import serve

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -761,6 +761,65 @@ def build_parser() -> argparse.ArgumentParser:
         help="Custom pack ID (default: auto-generated).",
     )
 
+    # pack calibrate (sp-sghl): calibrate a pack against a SynthBench baseline
+    # and write the resulting JSD into the pack manifest.
+    pack_calibrate_parser = pack_subparsers.add_parser(
+        "calibrate",
+        help="Calibrate a persona pack against a SynthBench human baseline.",
+    )
+    pack_calibrate_parser.add_argument(
+        "pack_yaml",
+        metavar="PACK_YAML",
+        help="Path to the persona pack YAML file to calibrate.",
+    )
+    pack_calibrate_parser.add_argument(
+        "--against",
+        required=True,
+        metavar="DATASET:QUESTION",
+        dest="against",
+        help=("SynthBench baseline to calibrate against, e.g. gss:HAPPY. v1 inline-publishable allowlist: gss, ntia."),
+    )
+    pack_calibrate_parser.add_argument(
+        "--n",
+        type=int,
+        default=50,
+        help="Panel size (default: 50).",
+    )
+    pack_calibrate_parser.add_argument(
+        "--models",
+        default=None,
+        metavar="MODELS",
+        help=(
+            "Models to use for the calibration panel (same format as 'panel run --models'). Default: panel run default."
+        ),
+    )
+    pack_calibrate_parser.add_argument(
+        "--samples-per-question",
+        type=int,
+        default=15,
+        dest="samples_per_question",
+        help="Samples per question for stable JSD (default: 15).",
+    )
+    pack_calibrate_parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        metavar="PATH",
+        help="Write the updated pack to PATH (default: rewrite PACK_YAML in place).",
+    )
+    pack_calibrate_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        dest="dry_run",
+        help="Print what would be written to the YAML without touching the file.",
+    )
+    pack_calibrate_parser.add_argument(
+        "--yes",
+        action="store_true",
+        dest="yes",
+        help="Non-interactive overwrite confirm (skip the y/N prompt).",
+    )
+
     # instruments
     instruments_parser = subparsers.add_parser(
         "instruments",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -17,6 +17,7 @@ from synth_panel.cli.commands import (
     handle_login,
     handle_logout,
     handle_mcp_serve,
+    handle_pack_calibrate,
     handle_pack_export,
     handle_pack_generate,
     handle_pack_import,
@@ -77,6 +78,8 @@ def main(argv: list[str] | None = None) -> int:
             return handle_pack_generate(args, output_format)
         elif sub == "search":
             return handle_pack_search(args, output_format)
+        elif sub == "calibrate":
+            return handle_pack_calibrate(args, output_format)
         else:
             parser.parse_args(["pack", "--help"])
             return 1

--- a/tests/test_pack_calibrate.py
+++ b/tests/test_pack_calibrate.py
@@ -1,0 +1,424 @@
+"""Tests for ``synthpanel pack calibrate`` (sp-sghl).
+
+Two surfaces under test:
+
+1. ``synth_panel.calibration`` — pure pack-YAML round-trip helpers
+   (load, merge by ``(dataset, question)``, splice block back in).
+2. ``synth_panel.cli.commands.handle_pack_calibrate`` — CLI wiring,
+   dry-run, allowlist gating, in-place rewrite. The actual panel run
+   is mocked via ``_run_calibration_panel`` so tests stay hermetic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from synth_panel import calibration as calib_mod
+from synth_panel.calibration import (
+    CalibrationEntry,
+    merge_calibration,
+    update_pack_calibration_text,
+    write_pack_calibration,
+)
+from synth_panel.main import main
+
+# ── calibration.py: data + merge logic ────────────────────────────────
+
+
+def test_calibration_entry_to_yaml_dict_drops_none_alignment_error():
+    entry = CalibrationEntry(
+        dataset="gss",
+        question="HAPPY",
+        jsd=0.18,
+        n=100,
+        samples_per_question=15,
+        models=["haiku:0.5", "gemini-flash-lite:0.5"],
+        extractor="pick_one:auto-derived",
+        panelist_cost_usd=0.6451,
+        calibrated_at="2026-04-26T14:23:00Z",
+        synthpanel_version="0.11.1",
+    )
+    d = entry.to_yaml_dict()
+    assert "alignment_error" not in d
+    assert d["dataset"] == "gss"
+    assert d["jsd"] == 0.18
+    assert d["models"] == ["haiku:0.5", "gemini-flash-lite:0.5"]
+    assert d["methodology_url"].startswith("https://synthpanel.dev")
+
+
+def test_calibration_entry_keeps_alignment_error_when_set():
+    entry = CalibrationEntry(
+        dataset="gss",
+        question="HAPPY",
+        jsd=1.0,
+        n=50,
+        samples_per_question=15,
+        models=[],
+        extractor="pick_one:auto-derived",
+        panelist_cost_usd=0.0,
+        calibrated_at="2026-04-26T14:23:00Z",
+        synthpanel_version="0.11.1",
+        alignment_error="['x'] vs ['y']",
+    )
+    d = entry.to_yaml_dict()
+    assert d["alignment_error"] == "['x'] vs ['y']"
+
+
+def test_merge_calibration_appends_when_no_existing_match():
+    existing = [
+        {"dataset": "gss", "question": "HAPPY", "jsd": 0.9},
+    ]
+    new = {"dataset": "ntia", "question": "USE", "jsd": 0.2}
+    out = merge_calibration(existing, new)
+    assert len(out) == 2
+    assert out[0]["dataset"] == "gss"
+    assert out[1]["dataset"] == "ntia"
+
+
+def test_merge_calibration_replaces_matching_dataset_question_in_place():
+    existing = [
+        {"dataset": "gss", "question": "HAPPY", "jsd": 0.9},
+        {"dataset": "ntia", "question": "USE", "jsd": 0.2},
+    ]
+    new = {"dataset": "gss", "question": "HAPPY", "jsd": 0.18}
+    out = merge_calibration(existing, new)
+    # Order preserved; matching entry replaced; no duplicate added.
+    assert len(out) == 2
+    assert out[0]["dataset"] == "gss"
+    assert out[0]["jsd"] == 0.18
+    assert out[1]["dataset"] == "ntia"
+
+
+def test_merge_calibration_handles_none_existing():
+    out = merge_calibration(None, {"dataset": "gss", "question": "HAPPY", "jsd": 0.5})
+    assert out == [{"dataset": "gss", "question": "HAPPY", "jsd": 0.5}]
+
+
+def test_merge_calibration_rejects_non_list_existing():
+    with pytest.raises(ValueError, match="must be a list"):
+        merge_calibration({"oops": "not-a-list"}, {"dataset": "gss", "question": "HAPPY"})
+
+
+# ── calibration.py: text round-trip preserves persona content ─────────
+
+
+PACK_YAML_NO_CALIBRATION = """\
+name: General Consumers
+description: >
+  Broad demographic cross-section.
+
+# Persona definitions (hand-curated).
+personas:
+  - name: Emily Nakamura
+    age: 33
+    occupation: Marketing Manager
+    background: >
+      Lives in a mid-size city.
+    personality_traits:
+      - convenience-driven
+      - brand-aware
+"""
+
+
+PACK_YAML_WITH_CALIBRATION = """\
+name: General Consumers
+description: >
+  Broad demographic cross-section.
+
+personas:
+  - name: Emily Nakamura
+    age: 33
+    occupation: Marketing Manager
+    background: >
+      Lives in a mid-size city.
+    personality_traits:
+      - convenience-driven
+
+calibration:
+  - dataset: gss
+    question: HAPPY
+    jsd: 0.42
+    n: 20
+"""
+
+
+def test_write_pack_calibration_appends_when_absent():
+    entries = [{"dataset": "gss", "question": "HAPPY", "jsd": 0.18, "n": 100}]
+    out = write_pack_calibration(PACK_YAML_NO_CALIBRATION, entries)
+    # Persona content preserved verbatim.
+    assert "Emily Nakamura" in out
+    assert "convenience-driven" in out
+    assert "# Persona definitions (hand-curated)." in out
+    # New calibration block appended.
+    assert "calibration:" in out
+    assert "dataset: gss" in out
+    assert out.endswith("\n")
+    # Round-trip parses cleanly.
+    parsed = yaml.safe_load(out)
+    assert parsed["name"] == "General Consumers"
+    assert parsed["calibration"][0]["dataset"] == "gss"
+    assert parsed["calibration"][0]["jsd"] == 0.18
+
+
+def test_write_pack_calibration_replaces_existing_block():
+    entries = [{"dataset": "gss", "question": "HAPPY", "jsd": 0.18, "n": 100}]
+    out = write_pack_calibration(PACK_YAML_WITH_CALIBRATION, entries)
+    # Original Emily persona preserved.
+    assert "Emily Nakamura" in out
+    parsed = yaml.safe_load(out)
+    assert parsed["calibration"] == [{"dataset": "gss", "question": "HAPPY", "jsd": 0.18, "n": 100}]
+    # The old jsd: 0.42 is gone.
+    assert "0.42" not in out
+
+
+def test_update_pack_calibration_text_idempotent_for_same_dataset_question():
+    raw = PACK_YAML_NO_CALIBRATION
+    parsed = yaml.safe_load(raw)
+    new_entry = {"dataset": "gss", "question": "HAPPY", "jsd": 0.5}
+    after_first = update_pack_calibration_text(raw, parsed, new_entry)
+    parsed_after = yaml.safe_load(after_first)
+    new_entry_2 = {"dataset": "gss", "question": "HAPPY", "jsd": 0.7}
+    after_second = update_pack_calibration_text(after_first, parsed_after, new_entry_2)
+    final = yaml.safe_load(after_second)
+    assert len(final["calibration"]) == 1
+    assert final["calibration"][0]["jsd"] == 0.7
+
+
+def test_update_pack_calibration_text_appends_distinct_baseline():
+    raw = PACK_YAML_WITH_CALIBRATION
+    parsed = yaml.safe_load(raw)
+    new_entry = {"dataset": "ntia", "question": "USE", "jsd": 0.3}
+    out = update_pack_calibration_text(raw, parsed, new_entry)
+    final = yaml.safe_load(out)
+    # Both old (gss:HAPPY) and new (ntia:USE) entries present.
+    datasets = [(e["dataset"], e["question"]) for e in final["calibration"]]
+    assert ("gss", "HAPPY") in datasets
+    assert ("ntia", "USE") in datasets
+
+
+# ── CLI: handle_pack_calibrate ────────────────────────────────────────
+
+
+def _write_pack(tmp_path: Path) -> Path:
+    p = tmp_path / "pack.yaml"
+    p.write_text(PACK_YAML_NO_CALIBRATION, encoding="utf-8")
+    return p
+
+
+def _mock_panel_run_result() -> dict:
+    return {
+        "jsd": 0.234567,
+        "extractor": "pick_one:auto-derived",
+        "models": ["haiku:1.0"],
+        "panelist_cost_usd": 0.1234,
+        "alignment_error": None,
+    }
+
+
+def test_cli_pack_calibrate_dry_run_does_not_write(tmp_path, capsys):
+    pack = _write_pack(tmp_path)
+    original = pack.read_text(encoding="utf-8")
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        return_value=_mock_panel_run_result(),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--dry-run",
+            ]
+        )
+    assert rc == 0
+    # File untouched.
+    assert pack.read_text(encoding="utf-8") == original
+    out = capsys.readouterr().out
+    assert "calibration:" in out
+    assert "dataset: gss" in out
+    assert "jsd: 0.234567" in out
+
+
+def test_cli_pack_calibrate_writes_in_place(tmp_path):
+    pack = _write_pack(tmp_path)
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        return_value=_mock_panel_run_result(),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--yes",
+            ]
+        )
+    assert rc == 0
+    parsed = yaml.safe_load(pack.read_text(encoding="utf-8"))
+    assert parsed["name"] == "General Consumers"
+    assert "Emily Nakamura" in pack.read_text(encoding="utf-8")
+    cal = parsed["calibration"]
+    assert len(cal) == 1
+    assert cal[0]["dataset"] == "gss"
+    assert cal[0]["question"] == "HAPPY"
+    assert cal[0]["n"] == 20
+    assert cal[0]["samples_per_question"] == 5
+    assert cal[0]["extractor"] == "pick_one:auto-derived"
+    assert isinstance(cal[0]["jsd"], float)
+    assert "calibrated_at" in cal[0]
+    assert "synthpanel_version" in cal[0]
+
+
+def test_cli_pack_calibrate_replaces_prior_entry(tmp_path):
+    pack = tmp_path / "pack.yaml"
+    pack.write_text(PACK_YAML_WITH_CALIBRATION, encoding="utf-8")
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        return_value=_mock_panel_run_result(),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--yes",
+            ]
+        )
+    assert rc == 0
+    parsed = yaml.safe_load(pack.read_text(encoding="utf-8"))
+    cal = parsed["calibration"]
+    # Replaced (not appended) — still exactly one entry for gss:HAPPY.
+    matching = [e for e in cal if e["dataset"] == "gss" and e["question"] == "HAPPY"]
+    assert len(matching) == 1
+    assert matching[0]["jsd"] != 0.42  # the old value is gone
+
+
+def test_cli_pack_calibrate_writes_to_output_path(tmp_path):
+    pack = _write_pack(tmp_path)
+    out = tmp_path / "out.yaml"
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        return_value=_mock_panel_run_result(),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--output",
+                str(out),
+                "--yes",
+            ]
+        )
+    assert rc == 0
+    # Source untouched.
+    assert "calibration:" not in pack.read_text(encoding="utf-8")
+    # New file has the calibration block.
+    parsed = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert parsed["calibration"][0]["dataset"] == "gss"
+
+
+def test_cli_pack_calibrate_rejects_bad_against_format(tmp_path, capsys):
+    pack = _write_pack(tmp_path)
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(pack),
+            "--against",
+            "gss",  # missing :QUESTION
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "DATASET:QUESTION" in err
+
+
+def test_cli_pack_calibrate_rejects_gated_dataset(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("SYNTHBENCH_ALLOW_GATED", raising=False)
+    pack = _write_pack(tmp_path)
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(pack),
+            "--against",
+            "wvs:Q1",
+        ]
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "inline-publishable" in err
+
+
+def test_cli_pack_calibrate_missing_pack_yaml(tmp_path, capsys):
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(tmp_path / "nope.yaml"),
+            "--against",
+            "gss:HAPPY",
+        ]
+    )
+    assert rc == 1
+    assert "not found" in capsys.readouterr().err
+
+
+def test_cli_pack_calibrate_propagates_panel_failure(tmp_path, capsys):
+    pack = _write_pack(tmp_path)
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        side_effect=RuntimeError("panel run for calibration failed (exit 2): boom"),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--yes",
+            ]
+        )
+    assert rc == 1
+    assert "boom" in capsys.readouterr().err
+
+
+def test_now_iso_utc_format():
+    s = calib_mod.now_iso_utc()
+    # RFC3339 UTC, second precision, trailing Z.
+    assert s.endswith("Z")
+    assert len(s) == len("2026-04-26T14:23:00Z")


### PR DESCRIPTION
## Summary
- Adds `synthpanel pack calibrate` CLI subcommand that calibrates a persona pack against a SynthBench human baseline and writes results back into the pack manifest.
- New module `src/synth_panel/calibration.py` plus parser/command wiring and CLI tests.
- Adds docs at `docs/calibration.md`.

Closes sp-sghl.

## Test plan
- [ ] `pytest tests/test_pack_calibrate.py`
- [ ] CI: lint, typecheck, security, coverage, test 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)