### PR TITLE
feat(synthesis): warn on degenerate structured output (sp-g59o)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Changed (loudness)
+- (sp-g59o) Detection: warn loudly when synthesis output appears unstructured (likely model schema-adherence flake). Triggered when every list field — themes, agreements, disagreements, surprises — is empty while the recommendation slot carries >600 chars of prose. Surfaces as a `synth_panel.synthesis` `logger.warning`, on `SynthesisResult.warnings`, and propagated up to `PanelResult.warnings`. Schema-honoring runs are unchanged. Observed at ~25% on `gemini-flash-lite` synthesis; detection is provider-agnostic.
+
 ## [0.12.0] - 2026-04-26
 
 Minor bump shipping two new CLI features (`--best-model-for`,

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -360,6 +360,10 @@ def _build_panel_result_from_single_round(
     # so MCP/CI consumers can branch on run validity without walking into
     # the nested synthesis envelope.
     synthesis_error = synthesis_dict.get("synthesis_error") if isinstance(synthesis_dict, dict) else None
+    # sp-g59o: surface synthesis-level heuristic warnings (e.g. degenerate
+    # structured output) at the top level so MCP consumers don't have to
+    # walk into the nested synthesis dict to find them.
+    synthesis_warnings = list(synthesis_dict.get("warnings") or []) if isinstance(synthesis_dict, dict) else []
     return PanelResult(
         result_id=result_id,
         model=model,
@@ -376,7 +380,7 @@ def _build_panel_result_from_single_round(
         synthesis=synthesis_dict,
         total_cost=total_cost.format_usd(),
         total_usage=total_usage.to_dict(),
-        warnings=list(cost_warnings),
+        warnings=[*cost_warnings, *synthesis_warnings],
         cost_is_estimated=bool(cost_warnings),
         terminal_round=None,
         results=result_dicts,
@@ -428,6 +432,18 @@ def _build_panel_result_from_multi_round(
     synth_model = getattr(mr.final_synthesis, "model", None) if mr.final_synthesis else None
     cost_warnings = build_cost_fallback_warnings([*sorted(contributing), synth_model])
 
+    # sp-g59o: gather synthesis-level heuristic warnings from per-round
+    # syntheses + the final reduce so the degenerate-output detector
+    # surfaces uniformly across single and multi-round runs.
+    synthesis_warnings: list[str] = []
+    for rr in mr.rounds:
+        round_warnings = getattr(rr.synthesis, "warnings", None)
+        if round_warnings:
+            synthesis_warnings.extend(round_warnings)
+    final_warnings = getattr(mr.final_synthesis, "warnings", None) if mr.final_synthesis else None
+    if final_warnings:
+        synthesis_warnings.extend(final_warnings)
+
     return PanelResult(
         result_id=result_id,
         model=model,
@@ -438,7 +454,7 @@ def _build_panel_result_from_multi_round(
         synthesis=final_synth_dict,
         total_cost=total_cost.format_usd(),
         total_usage=mr.usage.to_dict(),
-        warnings=list(mr.warnings) + list(cost_warnings),
+        warnings=list(mr.warnings) + list(cost_warnings) + synthesis_warnings,
         cost_is_estimated=bool(cost_warnings),
         terminal_round=mr.terminal_round,
         results=flat_results,

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -99,6 +99,40 @@ _SYNTHESIS_SCHEMA: dict[str, Any] = {
 _DEFAULT_MODEL = "sonnet"
 _MAX_TOKENS = 4096
 
+# sp-g59o: heuristic threshold for detecting "schema honored in form, not in
+# spirit" output — when every list field is empty but the recommendation
+# field carries a long prose dump, the synthesizer most likely ignored the
+# structure and consolidated everything into the unstructured slot. The
+# 600-char cutoff sits comfortably between the largest healthy
+# recommendation observed in the v0.12 variance probe (~507) and the
+# smallest degenerate one (~1078).
+_UNSTRUCTURED_RECOMMENDATION_CHAR_THRESHOLD = 600
+_UNSTRUCTURED_OUTPUT_WARNING = (
+    "synthesis structured output appears unstructured — model may have "
+    "ignored schema (themes/agreements/disagreements/surprises all empty "
+    "while recommendation carries long prose). Consider rerunning or "
+    "switching synthesis model."
+)
+
+
+def _detect_unstructured_output(
+    themes: list[str],
+    agreements: list[str],
+    disagreements: list[str],
+    surprises: list[str],
+    recommendation: str,
+) -> bool:
+    """Heuristic for the gemini-flash-lite-style schema-adherence flake.
+
+    Returns True when every list field is empty AND the recommendation is
+    longer than the threshold. The information content is similar in that
+    case — the model just packed the whole synthesis into the one
+    unstructured slot instead of partitioning across the schema.
+    """
+    if themes or agreements or disagreements or surprises:
+        return False
+    return len(recommendation) > _UNSTRUCTURED_RECOMMENDATION_CHAR_THRESHOLD
+
 
 @dataclass
 class SynthesisResult:
@@ -123,6 +157,11 @@ class SynthesisResult:
     per_question_synthesis: dict[int, str] | None = None
     map_cost_breakdown: list[dict[str, Any]] | None = None
     reduce_cost_breakdown: dict[str, Any] | None = None
+    # sp-g59o: post-parse heuristic warnings (e.g. degenerate structured
+    # output where every list field is empty but the recommendation field
+    # carries long prose). Empty by default; included in to_dict() only
+    # when non-empty so the serialized shape is unchanged for healthy runs.
+    warnings: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a plain dict."""
@@ -144,6 +183,8 @@ class SynthesisResult:
             # JSON requires string keys; keep indices as strings in the
             # serialized shape so MCP / file persistence round-trips cleanly.
             d["per_question_synthesis"] = {str(k): v for k, v in self.per_question_synthesis.items()}
+        if self.warnings:
+            d["warnings"] = list(self.warnings)
         return d
 
 
@@ -302,16 +343,38 @@ def synthesize_panel(
             error=error_msg,
         )
 
+    themes = data.get("themes", [])
+    agreements = data.get("agreements", [])
+    disagreements = data.get("disagreements", [])
+    surprises = data.get("surprises", [])
+    recommendation = data.get("recommendation", "")
+    warnings: list[str] = []
+    # sp-g59o: detect-and-warn for schema-adherence flake (gemini-flash-lite
+    # was the trigger but this is provider-agnostic). The synthesis call
+    # technically returned every required key, but every list is empty and
+    # the recommendation slot carries a long prose dump — the model
+    # ignored the structure. Surface a warning rather than silently
+    # accepting degenerate output. Cheap, no retry, no extra cost.
+    if _detect_unstructured_output(themes, agreements, disagreements, surprises, recommendation):
+        logger.warning(
+            "synthesis output appears unstructured (model=%s, recommendation_chars=%d): %s",
+            resolved_model,
+            len(recommendation),
+            _UNSTRUCTURED_OUTPUT_WARNING,
+        )
+        warnings.append(_UNSTRUCTURED_OUTPUT_WARNING)
+
     return SynthesisResult(
         summary=data.get("summary", ""),
-        themes=data.get("themes", []),
-        agreements=data.get("agreements", []),
-        disagreements=data.get("disagreements", []),
-        surprises=data.get("surprises", []),
-        recommendation=data.get("recommendation", ""),
+        themes=themes,
+        agreements=agreements,
+        disagreements=disagreements,
+        surprises=surprises,
+        recommendation=recommendation,
         usage=usage,
         cost=cost,
         model=resolved_model,
+        warnings=warnings,
     )
 
 

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -385,3 +385,109 @@ class TestSynthesisSchema:
         props = _SYNTHESIS_SCHEMA["properties"]
         assert props["summary"]["type"] == "string"
         assert props["recommendation"]["type"] == "string"
+
+
+# sp-g59o: gemini-flash-lite-style schema-adherence flake. The synthesizer
+# returns every required key but every list is empty and the recommendation
+# field carries the full prose. We must detect-and-warn at consume time.
+_UNSTRUCTURED_SYNTHESIS_DATA = {
+    "summary": "Panel discussed product reception.",
+    "themes": [],
+    "agreements": [],
+    "disagreements": [],
+    "surprises": [],
+    "recommendation": (
+        "The panel had a wide-ranging discussion about productivity, "
+        "pricing concerns, and ease of use. Several participants felt the "
+        "tool saves time on repetitive tasks while others questioned "
+        "whether the price is justified for small teams. There were also "
+        "unexpected comments about using it for unintended use cases. "
+        "Overall the recommendation would be to focus messaging on "
+        "productivity gains while considering a small-team tier and "
+        "improving onboarding for new users. The team should also "
+        "consider gathering more data on which user segments derive the "
+        "most value, since pricing concerns appeared to vary widely "
+        "across panelist backgrounds and team sizes."
+    ),
+}
+
+
+class TestUnstructuredOutputDetection:
+    def test_warns_when_empty_lists_and_long_recommendation(self):
+        """sp-g59o: degenerate output (empty lists + long recommendation)
+        emits a warning on result.warnings without flipping is_fallback."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_UNSTRUCTURED_SYNTHESIS_DATA)
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        # The schema was technically honored — every required key is present —
+        # so we accept the result rather than treat it as a fallback.
+        assert not result.is_fallback
+        assert result.error is None
+        # But we surface a heuristic warning so the operator knows the
+        # output is degenerate.
+        assert result.warnings, "expected unstructured-output warning"
+        assert any("unstructured" in w for w in result.warnings)
+
+    def test_warning_appears_in_to_dict(self):
+        """sp-g59o: warnings round-trip through to_dict() so MCP / file
+        persistence consumers see them."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_UNSTRUCTURED_SYNTHESIS_DATA)
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+        d = result.to_dict()
+
+        assert "warnings" in d
+        assert any("unstructured" in w for w in d["warnings"])
+
+    def test_no_warning_on_healthy_output(self):
+        """Healthy structured output produces no heuristic warning, and
+        to_dict() omits the warnings key entirely so the serialized shape
+        is unchanged for backwards-compat consumers."""
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_SYNTHESIS_DATA)
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+        d = result.to_dict()
+
+        assert result.warnings == []
+        assert "warnings" not in d
+
+    def test_no_warning_when_themes_present(self):
+        """If at least one structured list is populated, the recommendation
+        prose is permissible — no warning even when long."""
+        data = dict(_UNSTRUCTURED_SYNTHESIS_DATA)
+        data["themes"] = ["productivity"]
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(data)
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        assert result.warnings == []
+
+    def test_no_warning_when_recommendation_short(self):
+        """Empty lists are not enough on their own — only the
+        long-recommendation pattern signals the schema-adherence flake."""
+        data = dict(_UNSTRUCTURED_SYNTHESIS_DATA)
+        data["recommendation"] = "Short rec."
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(data)
+
+        result = synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        assert result.warnings == []
+
+    def test_unstructured_output_logs_warning(self, caplog):
+        """sp-g59o: detection emits a logger.warning so the signal is
+        visible in run logs even before structured consumption."""
+        import logging
+
+        mock_client = MagicMock()
+        mock_client.send.return_value = _make_synthesis_response(_UNSTRUCTURED_SYNTHESIS_DATA)
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.synthesis"):
+            synthesize_panel(mock_client, _PANELIST_RESULTS, _QUESTIONS)
+
+        assert any("unstructured" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary
Implements fix #1 from sp-g59o: detect-and-warn at consume time when synthesis output appears to have collapsed all structured fields into the unstructured `recommendation` field (gemini-flash-lite ~25% flake rate).

- `synthesis.py`: add post-parse degenerate-output detection; emit warning + append to `result.warnings[]` when all of {themes, agreements, disagreements, surprises} are empty AND `len(recommendation) > 600`.
- `sdk.py`: surface warnings in result envelope.
- Tests: 4 new cases covering empty-lists + long-recommendation, partial fields, normal output, threshold boundary.

Closes sp-g59o.

## Test plan
- [ ] `pytest tests/test_synthesis.py`
- [ ] CI: lint, typecheck, security, coverage, test 3.10-3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)