### PR TITLE
fix(ci): drop Docker Hub from docker workflow, ship GHCR-only (sp-s1mq)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,12 @@
 name: Build and Publish Docker Image
 
 # Builds the production runtime image (Dockerfile at repo root) and pushes
-# it to both GitHub Container Registry and Docker Hub. Tagged-release-only;
-# main pushes do not republish images (mirrors the publish.yml policy).
+# it to GitHub Container Registry. Tagged-release-only; main pushes do not
+# republish images (mirrors the publish.yml policy).
 #
 # Triggers:
 #   - tag push matching v*           (normal release path)
 #   - workflow_dispatch              (manual republish, takes a tag input)
-#
-# Required repo secrets:
-#   DOCKERHUB_USERNAME   Docker Hub user/org with push access to synthpanel/synthpanel
-#   DOCKERHUB_TOKEN      Docker Hub access token (NOT account password)
 #
 # GHCR uses GITHUB_TOKEN with packages:write — no extra secret needed.
 #
@@ -93,12 +89,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Compute image tag list
         id: tags
         env:
@@ -106,7 +96,7 @@ jobs:
           IS_STABLE: ${{ steps.ref.outputs.is_stable }}
         run: |
           set -euo pipefail
-          IMAGES=("ghcr.io/dataviking-tech/synthpanel" "synthpanel/synthpanel")
+          IMAGES=("ghcr.io/dataviking-tech/synthpanel")
           MAJOR="${VERSION%%.*}"
           REST="${VERSION#*.}"
           MINOR="${REST%%.*}"
@@ -162,6 +152,6 @@ jobs:
             echo "**Try it:**"
             echo '```bash'
             echo "docker pull ghcr.io/dataviking-tech/synthpanel:${VERSION}"
-            echo "docker run --rm -e ANTHROPIC_API_KEY=\$KEY synthpanel/synthpanel:${VERSION} prompt 'hello'"
+            echo "docker run --rm -e ANTHROPIC_API_KEY=\$KEY ghcr.io/dataviking-tech/synthpanel:${VERSION} prompt 'hello'"
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
Docker workflow has failed on every release tag since v0.9.2 because the Docker Hub login step has no credentials configured, aborting the job before GHCR push can run.

Per founder direction: drop Docker Hub, ship GHCR-only.

- `.github/workflows/docker.yml`: remove Docker Hub login step + image tags. Keeps GHCR login (uses `GITHUB_TOKEN`) and `ghcr.io/datavi king-tech/synthpanel` push.
- Net diff: -14 / +4 lines.

Closes sp-s1mq.

## Test plan
- [ ] CI: lint, typecheck, security, coverage, test 3.10-3.13
- [ ] Post-merge: next release tag should publish to GHCR successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)