### PR TITLE
fix: improve missing API key error message to point at `synthpanel login`

### DIFF
--- a/src/synth_panel/llm/providers/base.py
+++ b/src/synth_panel/llm/providers/base.py
@@ -26,7 +26,11 @@ class ProviderConfig:
         key = get_credential(self.api_key_env)
         if not key:
             raise LLMError(
-                f"Missing API key: set {self.api_key_env} or run `synthpanel login`",
+                (
+                f"Missing API key: set {self.api_key_env} or "
+                f"run `synthpanel login --provider {self.api_key_env.removesuffix('_API_KEY').lower()}` to store one persistently."
+                + (" Note: Claude Code OAuth tokens cannot be used as Anthropic API keys — generate a key at https://console.anthropic.com/settings/keys." if self.api_key_env == "ANTHROPIC_API_KEY" else "")
+            ),
                 LLMErrorCategory.MISSING_CREDENTIALS,
             )
         return key


### PR DESCRIPTION
## What

Improves the error message when a provider API key is missing to guide users toward the `synthpanel login` command.

## Changes

- **Provider-specific login command**: Error now suggests `synthpanel login --provider <name>` instead of just `synthpanel login`
- **Claude Code OAuth warning**: For Anthropic provider, explicitly warns that Claude Code OAuth tokens cannot be used as API keys (a common footgun)

### Before
```
Missing API key: set ANTHROPIC_API_KEY or run `synthpanel login`
```

### After
```
Missing API key: set ANTHROPIC_API_KEY or run `synthpanel login --provider anthropic` to store one persistently. Note: Claude Code OAuth tokens cannot be used as Anthropic API keys — generate a key at https://console.anthropic.com/settings/keys.
```

## Testing

- All 1692 existing tests pass
- Manual verification: `grep -rn "synthpanel login" src/` shows the updated message

Fixes #287