### PR TITLE
chore: fix CODEOWNERS and surface fork-PR flow in CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for everything in the repo
-* @DataViking-Tech/synthpanel
+* @the-data-viking @openclaw-dv
 
 # Renovate config — auto-assign dependency PRs
-renovate.json @DataViking-Tech/synthpanel
+renovate.json @the-data-viking @openclaw-dv

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,18 @@
 
 ## Development Setup
 
+External contributors: please **fork** the repository first, then clone your fork.
+The upstream repository is protected — direct branch pushes are not permitted.
+See [Submitting Changes](#submitting-changes) for the full PR flow.
+
 ```bash
-# Clone the repository
-git clone https://github.com/DataViking-Tech/synth-panel.git
-cd synth-panel
+# Fork via the GitHub UI or:
+gh repo fork DataViking-Tech/SynthPanel --clone
+cd SynthPanel
+
+# (Maintainers only — direct clone of upstream)
+# git clone https://github.com/DataViking-Tech/SynthPanel.git
+# cd SynthPanel
 
 # Create a virtual environment (using uv or standard venv)
 uv venv .venv && source .venv/bin/activate
@@ -97,11 +105,21 @@ Adapters are the highest-leverage contribution — one adapter brings every synt
 
 ## Submitting Changes
 
-1. Fork the repository and create a feature branch from `main`.
-2. Make your changes. Add tests for new functionality.
-3. Run the test suite: `pytest tests/`
-4. Run lint: `ruff check src/ tests/`
-5. Open a pull request against `main`.
+1. Fork the repository (`gh repo fork DataViking-Tech/SynthPanel --clone`).
+2. Create a feature branch from `main` on your fork: `git checkout -b feat/my-change`.
+3. Make your changes. Add tests for new functionality.
+4. Run the test suite: `pytest tests/`
+5. Run lint: `ruff check src/ tests/`
+6. Push to your fork and open a pull request against `DataViking-Tech/SynthPanel:main`.
+
+### What to expect on the PR
+
+`main` is protected. To merge, your PR must:
+
+- Pass all required CI: `test (3.10–3.13)`, `coverage`, `security`, `lint`, `typecheck`.
+- Receive at least one approval, including a CODEOWNERS review.
+- Have all review threads resolved.
+- Be DCO-signed (see [Sign-off](#sign-off) below).
 
 ### Commit Message Conventions
 


### PR DESCRIPTION
## Why

Two pieces of the contributor wall were broken:

1. **CODEOWNERS pointed to a nonexistent team.** `@DataViking-Tech/synthpanel` does not exist (the org has 0 teams). Combined with branch protection's `require_code_owner_review`, every PR to `main` was unmergeable except by admin bypass.
2. **External contributors hit "permission denied" before reading the fork instructions.** The "Development Setup" block at the top of `CONTRIBUTING.md` told them to `git clone` upstream directly (with a stale `synth-panel` URL — `SynthPanel` is the actual name; the old name still 301-redirects). The fork-and-PR flow was 90+ lines further down under "Submitting Changes," so contributors trying to follow the docs literally would `git push origin feature/x` against upstream and get rejected.

Reported by external devs as "I don't have permissions to create branches."

## Changes

- **`.github/CODEOWNERS`** — replace `@DataViking-Tech/synthpanel` (nonexistent team) with `@the-data-viking @openclaw-dv` so the CODEOWNERS rule actually has reviewers.
- **`CONTRIBUTING.md`**:
  - Add a fork-first note to "Development Setup" with the correct upstream name (`SynthPanel`, not `synth-panel`).
  - Use `gh repo fork --clone` as the canonical clone command.
  - Expand "Submitting Changes" with what the PR needs to merge: passing CI (test ×4, coverage, security, lint, typecheck), CODEOWNERS approval, resolved threads, DCO sign-off.

## Out-of-tree (already applied via API, not in this diff)

- **Tag protection ruleset** added (`refs/tags/*`, all create/update/delete blocked outside admin/maintain). Closes the gap where any future writer could push release tags.
- **Actions defaults tightened**: `default_workflow_permissions: write → read`, `can_approve_pull_request_reviews: true → false`. Reduces blast radius of any PR-triggered workflow.

## Note on merging this PR

Because the current `main` CODEOWNERS references a team that doesn't exist, no one can satisfy the code-owner-review rule on this PR via normal review. Admin bypass is required for this one merge — after which CODEOWNERS will be fixed and subsequent PRs can flow normally.