### PR TITLE
feat: auto-grant write access via issue template, drop fork requirement

### DIFF
--- a/.github/ISSUE_TEMPLATE/access_request.yml
+++ b/.github/ISSUE_TEMPLATE/access_request.yml
@@ -1,0 +1,39 @@
+name: Request contributor access
+description: Get write access so you can push branches directly to upstream and open PRs without forking.
+title: "[access] @<your-username>"
+labels: ["access-request"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Filing this issue auto-grants you `write` access to this repository, so you can `git push origin <branch>` directly to upstream instead of forking.
+
+        Your branches still cannot merge to `main` without:
+        - All required CI passing (test, coverage, security, lint, typecheck)
+        - CODEOWNERS approval
+        - DCO sign-off (`git commit -s`)
+
+        See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full flow.
+  - type: input
+    id: github_username
+    attributes:
+      label: GitHub username
+      description: The account that should receive write access. Must match the issue author.
+      placeholder: "octocat"
+    validations:
+      required: true
+  - type: textarea
+    id: intent
+    attributes:
+      label: What are you planning to work on?
+      description: Optional. A sentence or two helps maintainers route review when you open the PR.
+      placeholder: "Adding a new LLM provider adapter for ..."
+    validations:
+      required: false
+  - type: checkboxes
+    id: agreement
+    attributes:
+      label: Acknowledgement
+      options:
+        - label: I understand I will be added as an outside collaborator with write access. PRs to `main` still require review.
+          required: true

--- a/.github/workflows/auto-grant-access.yml
+++ b/.github/workflows/auto-grant-access.yml
@@ -1,0 +1,46 @@
+name: Auto-grant contributor access
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  grant:
+    if: contains(github.event.issue.labels.*.name, 'access-request')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invite issue author as outside collaborator
+        env:
+          GH_TOKEN: ${{ secrets.ACCESS_GRANT_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error::ACCESS_GRANT_TOKEN secret is not configured. See CONTRIBUTING.md."
+            exit 1
+          fi
+
+          # Idempotent: PUT collaborator returns 204 if already a collaborator,
+          # 201 if invitation created, 204 if no change.
+          gh api -X PUT "repos/${REPO}/collaborators/${AUTHOR}" \
+            -f permission=push \
+            --silent
+
+          gh issue comment "${ISSUE_NUMBER}" --repo "${REPO}" --body "@${AUTHOR} you've been granted **write** access to \`${REPO}\`.
+
+          You can now \`git clone\` upstream directly and \`git push origin <branch>\`. Merges to \`main\` still require:
+          - All required CI passing
+          - CODEOWNERS approval (@the-data-viking or @openclaw-dv)
+          - DCO sign-off on your commits (\`git commit -s\`)
+
+          See [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md) for the full flow.
+
+          Closing this issue. Open a fresh issue or PR for your actual work."
+
+          gh issue close "${ISSUE_NUMBER}" --repo "${REPO}" --reason completed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,16 @@
 
 ## Development Setup
 
-External contributors: please **fork** the repository first, then clone your fork.
-The upstream repository is protected — direct branch pushes are not permitted.
-See [Submitting Changes](#submitting-changes) for the full PR flow.
+This project does **not** require forking. To contribute:
+
+1. **[Request access](https://github.com/DataViking-Tech/SynthPanel/issues/new?template=access_request.yml)** — open the "Request contributor access" issue. You'll be auto-granted `write` access to the repository within seconds.
+2. Clone upstream directly and create a feature branch.
 
 ```bash
-# Fork via the GitHub UI or:
-gh repo fork DataViking-Tech/SynthPanel --clone
+# After your access request issue auto-closes:
+git clone https://github.com/DataViking-Tech/SynthPanel.git
 cd SynthPanel
-
-# (Maintainers only — direct clone of upstream)
-# git clone https://github.com/DataViking-Tech/SynthPanel.git
-# cd SynthPanel
+git checkout -b feat/my-change
 
 # Create a virtual environment (using uv or standard venv)
 uv venv .venv && source .venv/bin/activate
@@ -105,12 +103,12 @@ Adapters are the highest-leverage contribution — one adapter brings every synt
 
 ## Submitting Changes
 
-1. Fork the repository (`gh repo fork DataViking-Tech/SynthPanel --clone`).
-2. Create a feature branch from `main` on your fork: `git checkout -b feat/my-change`.
+1. [Request access](https://github.com/DataViking-Tech/SynthPanel/issues/new?template=access_request.yml) if you haven't already. Auto-granted in seconds.
+2. Clone upstream and create a feature branch: `git checkout -b feat/my-change`.
 3. Make your changes. Add tests for new functionality.
 4. Run the test suite: `pytest tests/`
 5. Run lint: `ruff check src/ tests/`
-6. Push to your fork and open a pull request against `DataViking-Tech/SynthPanel:main`.
+6. Push your branch (`git push -u origin feat/my-change`) and open a pull request against `main`.
 
 ### What to expect on the PR
 


### PR DESCRIPTION
## What

Replace the fork-and-PR contributor flow with self-service access request:

1. Contributor opens the new **Request contributor access** issue template.
2. Workflow auto-runs, invites them as an outside collaborator with `write`, comments next steps on the issue, and closes it.
3. They clone upstream directly, branch, push, open PR.

## Why

You wanted no forks and no per-user manual greenlighting. This is the closest GitHub-native pattern: you approve the *policy*, not the *people*.

## Wall on `main` is unchanged

Writers can push branches but not merge. Every PR still requires:
- All required CI passing (test ×4, coverage, security, lint, typecheck)
- CODEOWNERS approval (`@the-data-viking` or `@openclaw-dv`)
- Resolved review threads
- DCO sign-off
- Linear history, no force-push, no deletion

Tag protection ruleset (`refs/tags/*`) still blocks non-admin tag pushes. Actions `default_workflow_permissions` is `read`. CODEOWNERS file now points at real reviewers (merged in #320).

## Files

- `.github/ISSUE_TEMPLATE/access_request.yml` — issue template, auto-applies the `access-request` label.
- `.github/workflows/auto-grant-access.yml` — triggers on `issues.opened` and `issues.labeled`, gated by `contains(github.event.issue.labels.*.name, 'access-request')`. Calls `gh api -X PUT repos/{owner}/{repo}/collaborators/{user} -f permission=push`.
- `CONTRIBUTING.md` — replaces fork instructions with the access-request flow.

## ⚠️ Required setup before this works

The default `GITHUB_TOKEN` available to Actions **cannot create collaborator invites**. You need to create a PAT and store it as a repo secret:

1. Generate a fine-grained PAT scoped to `DataViking-Tech/SynthPanel` only, with **Administration: Read and write** permission. (Or a classic PAT with `repo` scope, but fine-grained is preferred.)
2. Add it as a repo secret: `gh secret set ACCESS_GRANT_TOKEN --repo DataViking-Tech/SynthPanel --body <token>`

Until that secret exists, the workflow will fail loudly with:
```
::error::ACCESS_GRANT_TOKEN secret is not configured.
```

## Residual risk to be aware of

Any GitHub user who opens the access-request issue gets immediate write. Spam bots could request access and burn CI minutes by pushing branches that trigger the 8-check matrix. If that happens:

- Add a blocklist conditional in the workflow (`if: !contains(BLOCKLIST, github.event.issue.user.login)`).
- Or gate on account age / public-commit count via `gh api users/$AUTHOR`.
- Or flip back to manual approval by removing the workflow.

The `main` wall is unaffected by any of this — at worst, junk branches accumulate and CI minutes get spent. Easy to revert if abuse appears.