### PR TITLE
feat: convergence diversity detector — warn on low-diversity panels (GH-291)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -2226,6 +2226,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # SynthBench submission block can reuse it.
         if convergence_report is not None:
             extra["convergence"] = convergence_report
+            dw = convergence_report.get("diversity_warnings") or []
+            if dw:
+                warnings_list = extra.setdefault("warnings", [])
+                warnings_list.extend(dw)
         # Include blend distributions when --blend is active
         if blend_result:
             extra["blend"] = {

--- a/src/synth_panel/convergence.py
+++ b/src/synth_panel/convergence.py
@@ -47,6 +47,8 @@ DEFAULT_EPSILON = 0.02
 DEFAULT_MIN_N = 50
 DEFAULT_M_CONSECUTIVE = 3
 DEFAULT_CURVE_POINTS = 20
+DEFAULT_DIVERSITY_ENTROPY_THRESHOLD = 0.35
+DEFAULT_DIVERSITY_MIN_N = 20
 
 # Structured-response key heuristics. The bundled schemas
 # (src/synth_panel/structured/schemas.py) each reserve exactly one field
@@ -338,6 +340,8 @@ class ConvergenceTracker:
         m_consecutive: int = DEFAULT_M_CONSECUTIVE,
         auto_stop: bool = False,
         log_path: str | None = None,
+        diversity_entropy_threshold: float = DEFAULT_DIVERSITY_ENTROPY_THRESHOLD,
+        diversity_min_n: int = DEFAULT_DIVERSITY_MIN_N,
     ) -> None:
         if check_every < 1:
             raise ValueError("check_every must be >= 1")
@@ -356,6 +360,8 @@ class ConvergenceTracker:
         self._m = m_consecutive
         self._auto_stop = auto_stop
         self._log_path = log_path
+        self._diversity_entropy_threshold = diversity_entropy_threshold
+        self._diversity_min_n = diversity_min_n
         self._states: dict[str, _QuestionState] = {k: _QuestionState(key=k) for k in self._keys}
         self._n = 0
         self._last_check_n = 0
@@ -524,12 +530,58 @@ class ConvergenceTracker:
                 "tracked_questions": list(self._keys),
                 "per_question": per_question,
                 "human_baseline": baseline,
+                "diversity_warnings": self._build_diversity_warnings_locked(),
             }
             return report
 
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalized_entropy(counts: Counter) -> float:
+        """Shannon entropy normalized to [0, 1] by the maximum possible entropy.
+
+        Returns 0.0 when all responses are identical, 1.0 when perfectly
+        uniform across all observed options. Returns 0.0 on empty counts.
+        """
+        total = sum(counts.values())
+        if total == 0:
+            return 0.0
+        n_options = len(counts)
+        if n_options <= 1:
+            return 0.0
+        h = -sum((c / total) * math.log2(c / total) for c in counts.values() if c > 0)
+        return h / math.log2(n_options)
+
+    def _build_diversity_warnings_locked(self) -> list[str]:
+        """Return informational warning strings for questions with low response diversity.
+
+        Called from within the build_report() lock. Skips questions that
+        haven't accumulated enough responses (diversity_min_n). Flags any
+        question whose normalized Shannon entropy falls below
+        diversity_entropy_threshold.
+        """
+        warnings: list[str] = []
+        for _i, key, _q in self._tracked:
+            state = self._states.get(key)
+            if state is None:
+                continue
+            counts = state.cumulative
+            n = sum(counts.values())
+            if n < self._diversity_min_n:
+                continue
+            entropy = self._normalized_entropy(counts)
+            if entropy >= self._diversity_entropy_threshold:
+                continue
+            dominant_choice, dominant_count = counts.most_common(1)[0]
+            dominant_pct = round(100 * dominant_count / n)
+            warnings.append(
+                f"low response diversity on '{key}' "
+                f"(entropy {entropy:.2f}/1.00; {dominant_pct}% chose '{dominant_choice}') "
+                f"— consider whether your persona spread is wide enough or your prompt is leading"
+            )
+        return warnings
 
     def _run_check_locked(self) -> ConvergenceCheck:
         per_q: dict[str, dict[str, float]] = {}

--- a/tests/test_convergence_metric.py
+++ b/tests/test_convergence_metric.py
@@ -16,6 +16,8 @@ from typing import Any
 import pytest
 
 from synth_panel.convergence import (
+    DEFAULT_DIVERSITY_ENTROPY_THRESHOLD,
+    DEFAULT_DIVERSITY_MIN_N,
     DEFAULT_EPSILON,
     ConvergenceTracker,
     SynthbenchUnavailableError,
@@ -503,3 +505,74 @@ def test_compute_calibration_jsd_wraps_local_implementation():
     assert compute_calibration_jsd({"a": 1.0}, {"b": 1.0}) == pytest.approx(1.0)
     # Empty model distribution → 0.0 (no panelist signal yet).
     assert compute_calibration_jsd({}, {"a": 1.0}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Diversity warning tests (GH-291)
+# ---------------------------------------------------------------------------
+
+
+def _make_tracker(key: str = "q1", **kwargs: Any) -> ConvergenceTracker:
+    questions = [_pick_one_question(key)]
+    tracked = identify_tracked_questions(questions)
+    return ConvergenceTracker(tracked, check_every=5, epsilon=0.02, min_n=0, m_consecutive=2, **kwargs)
+
+
+def _feed(tracker: ConvergenceTracker, key: str, distribution: dict[str, int]) -> None:
+    """Feed synthetic responses into the tracker according to distribution counts."""
+    for choice, count in distribution.items():
+        for _ in range(count):
+            tracker.record({key: choice})
+
+
+def test_diversity_warning_low_entropy():
+    """90% concentration on one choice should produce a diversity warning."""
+    tracker = _make_tracker(diversity_min_n=20)
+    _feed(tracker, "q1", {"Foo": 27, "Bar": 1, "Baz": 1, "Qux": 1})
+    report = tracker.build_report()
+    warnings = report["diversity_warnings"]
+    assert len(warnings) == 1
+    assert "q1" in warnings[0]
+    assert "90%" in warnings[0]
+    assert "Foo" in warnings[0]
+
+
+def test_diversity_no_warning_high_entropy():
+    """Near-uniform distribution across 4 options should not trigger a warning."""
+    tracker = _make_tracker(diversity_min_n=20)
+    _feed(tracker, "q1", {"A": 10, "B": 10, "C": 10, "D": 10})
+    report = tracker.build_report()
+    assert report["diversity_warnings"] == []
+
+
+def test_diversity_no_warning_below_min_n():
+    """Fewer responses than diversity_min_n should never produce a warning."""
+    tracker = _make_tracker(diversity_min_n=20)
+    # Feed only 10 responses, all identical — would warn if min_n weren't checked.
+    _feed(tracker, "q1", {"OnlyOne": 10})
+    report = tracker.build_report()
+    assert report["diversity_warnings"] == []
+
+
+def test_diversity_custom_threshold_fires_on_moderate_concentration():
+    """A raised threshold (0.8) should flag moderately-concentrated distributions."""
+    tracker = _make_tracker(diversity_min_n=10, diversity_entropy_threshold=0.8)
+    # 60/40 split — entropy ~0.97 bits / 1.0 = ~0.97 normalized. Still above 0.8.
+    # Use a more concentrated split: 80/20 across 4 options.
+    _feed(tracker, "q1", {"A": 16, "B": 2, "C": 1, "D": 1})
+    report = tracker.build_report()
+    assert len(report["diversity_warnings"]) == 1
+
+
+def test_diversity_warnings_key_always_present():
+    """build_report() always includes 'diversity_warnings', even when nothing fires."""
+    tracker = _make_tracker(diversity_min_n=20)
+    report = tracker.build_report()
+    assert "diversity_warnings" in report
+    assert isinstance(report["diversity_warnings"], list)
+
+
+def test_diversity_defaults_exported():
+    """The default constants must be importable and have sane values."""
+    assert 0 < DEFAULT_DIVERSITY_ENTROPY_THRESHOLD < 1
+    assert DEFAULT_DIVERSITY_MIN_N > 0


### PR DESCRIPTION
## Summary

- Adds `diversity_warnings` to `ConvergenceTracker.build_report()` — a list of informational strings flagging questions where responses cluster too tightly
- Computes normalized Shannon entropy per tracked (categorical/Likert) question; warns when entropy < 0.35 (configurable) after ≥ 20 responses (configurable)
- Surfaces warnings through `extra["warnings"]` in the run summary — same channel as existing missing-input and assignment warnings, **non-blocking**

## Approach

For each tracked question at report time, normalized entropy `H / log₂(n_options)` is computed from the cumulative response counter. A value near 0 means almost everyone picked the same answer; 1.0 is perfectly uniform. The default threshold (0.35) fires on a 5-option question where one choice gets ~90%+ of votes, and stays silent on anything reasonably spread.

Warning format matches the shape requested in the issue:
> `low response diversity on 'prefer_foo' (entropy 0.18/1.00; 95% chose 'Foo') — consider whether your persona spread is wide enough or your prompt is leading`

## What's deferred

Free-text cosine similarity (the third check in the issue) is out of scope here — `LLMClient` has no embeddings API and would require a new optional dep. Likert numeric variance is also deferred; entropy catches the same "everyone picks the same point" failure mode and keeps the implementation dep-free.

## Test plan

- [x] `test_diversity_warning_low_entropy` — 90% concentration triggers warning with correct content
- [x] `test_diversity_no_warning_high_entropy` — uniform distribution stays clean
- [x] `test_diversity_no_warning_below_min_n` — insufficient sample count suppresses warning
- [x] `test_diversity_custom_threshold_fires_on_moderate_concentration` — threshold override works
- [x] `test_diversity_warnings_key_always_present` — key always in report, empty list when clean
- [x] `test_diversity_defaults_exported` — constants importable with sane values

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)