### PR TITLE
fix(cost): accumulate provider_reported_cost with Decimal (#290)

### DIFF
--- a/src/synth_panel/checkpoint.py
+++ b/src/synth_panel/checkpoint.py
@@ -458,8 +458,8 @@ def _merge_usage(
         if prev is None and add is None:
             merged.pop("provider_reported_cost", None)
         else:
-            p = coerce_provider_reported_cost(prev) if prev is not None else Decimal(0)
-            a = coerce_provider_reported_cost(add) if add is not None else Decimal(0)
+            p = Decimal(0) if prev is None else (coerce_provider_reported_cost(prev) or Decimal(0))
+            a = Decimal(0) if add is None else (coerce_provider_reported_cost(add) or Decimal(0))
             merged["provider_reported_cost"] = float(p + a)
     return merged
 

--- a/src/synth_panel/checkpoint.py
+++ b/src/synth_panel/checkpoint.py
@@ -44,8 +44,11 @@ import threading
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
+
+from synth_panel.cost import coerce_provider_reported_cost
 
 logger = logging.getLogger(__name__)
 
@@ -455,7 +458,9 @@ def _merge_usage(
         if prev is None and add is None:
             merged.pop("provider_reported_cost", None)
         else:
-            merged["provider_reported_cost"] = float(prev or 0.0) + float(add or 0.0)
+            p = coerce_provider_reported_cost(prev) if prev is not None else Decimal(0)
+            a = coerce_provider_reported_cost(add) if add is not None else Decimal(0)
+            merged["provider_reported_cost"] = float(p + a)
     return merged
 
 

--- a/src/synth_panel/cost.py
+++ b/src/synth_panel/cost.py
@@ -11,18 +11,39 @@ import re
 import threading
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from decimal import Decimal
 
 logger = logging.getLogger(__name__)
+
+
+def coerce_provider_reported_cost(v: float | Decimal | str | int | None) -> Decimal | None:
+    """Normalize JSON/API cost values to ``Decimal`` for exact accumulation.
+
+    Floats round-trip via ``repr`` so single-turn ``from_dict(to_dict())`` stays
+    stable. ``None`` means absent cost (not zero).
+    """
+    if v is None:
+        return None
+    if isinstance(v, Decimal):
+        return v
+    if isinstance(v, bool):
+        raise TypeError("provider_reported_cost must not be a bool")
+    if isinstance(v, int):
+        return Decimal(v)
+    if isinstance(v, float):
+        return Decimal(repr(v))
+    if isinstance(v, str):
+        return Decimal(v)
+    raise TypeError(f"unsupported provider_reported_cost type: {type(v)!r}")
 
 
 @dataclass(frozen=True)
 class TokenUsage:
     """Immutable snapshot of token counts for a single LLM turn.
 
-    ``provider_reported_cost`` is the authoritative USD cost as billed by
-    the upstream provider (e.g. OpenRouter's ``usage.cost``). When present,
-    ``resolve_cost`` prefers it over the local pricing table; the local
-    table becomes a divergence sanity-check rather than a billing source.
+    ``provider_reported_cost`` is accumulated in :class:`decimal.Decimal`
+    internally so long runs reconcile with provider invoices; JSON and APIs
+    still use binary floats, normalized on ingest via :func:`coerce_provider_reported_cost`.
 
     ``reasoning_tokens`` / ``cached_tokens`` are informational sub-counts
     already included in ``output_tokens`` / ``input_tokens`` respectively.
@@ -32,7 +53,7 @@ class TokenUsage:
     output_tokens: int = 0
     cache_creation_input_tokens: int = 0
     cache_read_input_tokens: int = 0
-    provider_reported_cost: float | None = None
+    provider_reported_cost: Decimal | None = None
     reasoning_tokens: int = 0
     cached_tokens: int = 0
 
@@ -40,11 +61,18 @@ class TokenUsage:
     def total_tokens(self) -> int:
         return self.input_tokens + self.output_tokens + self.cache_creation_input_tokens + self.cache_read_input_tokens
 
+    def __post_init__(self) -> None:
+        coerced = coerce_provider_reported_cost(self.provider_reported_cost)
+        if coerced is not self.provider_reported_cost:
+            object.__setattr__(self, "provider_reported_cost", coerced)
+
     def __add__(self, other: TokenUsage) -> TokenUsage:
         if self.provider_reported_cost is None and other.provider_reported_cost is None:
-            summed_cost: float | None = None
+            summed_cost: Decimal | None = None
         else:
-            summed_cost = (self.provider_reported_cost or 0.0) + (other.provider_reported_cost or 0.0)
+            a = self.provider_reported_cost or Decimal(0)
+            b = other.provider_reported_cost or Decimal(0)
+            summed_cost = a + b
         return TokenUsage(
             input_tokens=self.input_tokens + other.input_tokens,
             output_tokens=self.output_tokens + other.output_tokens,
@@ -63,7 +91,7 @@ class TokenUsage:
             "cache_read_input_tokens": self.cache_read_input_tokens,
         }
         if self.provider_reported_cost is not None:
-            d["provider_reported_cost"] = self.provider_reported_cost
+            d["provider_reported_cost"] = float(self.provider_reported_cost)
         if self.reasoning_tokens:
             d["reasoning_tokens"] = self.reasoning_tokens
         if self.cached_tokens:

--- a/src/synth_panel/llm/models.py
+++ b/src/synth_panel/llm/models.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from decimal import Decimal
 from enum import Enum
 from typing import Any, Literal
+
+from synth_panel.cost import coerce_provider_reported_cost
 
 # ---------------------------------------------------------------------------
 # Content blocks
@@ -73,9 +76,9 @@ class InputMessage:
 class TokenUsage:
     """Token consumption counters for a single LLM call.
 
-    ``provider_reported_cost`` is the authoritative USD cost as billed by
-    the upstream provider (e.g. OpenRouter's ``usage.cost``). When present,
-    downstream cost resolution prefers it over the local pricing table.
+    ``provider_reported_cost`` is stored as :class:`decimal.Decimal` after
+    ingest so multi-turn accumulation matches billing; API inputs may still
+    be floats.
 
     ``reasoning_tokens`` / ``cached_tokens`` are informational sub-counts
     already included in ``output_tokens`` / ``input_tokens`` respectively.
@@ -87,7 +90,7 @@ class TokenUsage:
     output_tokens: int = 0
     cache_write_tokens: int = 0
     cache_read_tokens: int = 0
-    provider_reported_cost: float | None = None
+    provider_reported_cost: Decimal | None = None
     reasoning_tokens: int = 0
     cached_tokens: int = 0
 
@@ -95,11 +98,18 @@ class TokenUsage:
     def total_tokens(self) -> int:
         return self.input_tokens + self.output_tokens + self.cache_write_tokens + self.cache_read_tokens
 
+    def __post_init__(self) -> None:
+        coerced = coerce_provider_reported_cost(self.provider_reported_cost)
+        if coerced is not self.provider_reported_cost:
+            object.__setattr__(self, "provider_reported_cost", coerced)
+
     def __add__(self, other: TokenUsage) -> TokenUsage:
         if self.provider_reported_cost is None and other.provider_reported_cost is None:
-            summed_cost: float | None = None
+            summed_cost: Decimal | None = None
         else:
-            summed_cost = (self.provider_reported_cost or 0.0) + (other.provider_reported_cost or 0.0)
+            a = self.provider_reported_cost or Decimal(0)
+            b = other.provider_reported_cost or Decimal(0)
+            summed_cost = a + b
         return TokenUsage(
             input_tokens=self.input_tokens + other.input_tokens,
             output_tokens=self.output_tokens + other.output_tokens,

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -445,7 +445,7 @@ class TestTokenUsageProviderCost:
         a = TokenUsage(provider_reported_cost=0.1, reasoning_tokens=5, cached_tokens=3)
         b = TokenUsage(provider_reported_cost=0.2, reasoning_tokens=7, cached_tokens=4)
         c = a + b
-        assert c.provider_reported_cost == pytest.approx(0.3)
+        assert float(c.provider_reported_cost) == pytest.approx(0.3)
         assert c.reasoning_tokens == 12
         assert c.cached_tokens == 7
 
@@ -458,8 +458,8 @@ class TestTokenUsageProviderCost:
     def test_addition_treats_missing_as_zero_when_one_present(self):
         a = TokenUsage(provider_reported_cost=0.5)
         b = TokenUsage()
-        assert (a + b).provider_reported_cost == pytest.approx(0.5)
-        assert (b + a).provider_reported_cost == pytest.approx(0.5)
+        assert float((a + b).provider_reported_cost) == pytest.approx(0.5)
+        assert float((b + a).provider_reported_cost) == pytest.approx(0.5)
 
     def test_roundtrip_dict_preserves_provider_cost(self):
         u = TokenUsage(
@@ -471,8 +471,19 @@ class TestTokenUsageProviderCost:
         )
         assert TokenUsage.from_dict(u.to_dict()) == u
 
+    def test_provider_reported_cost_many_adds_matches_decimal_sum(self):
+        """GH #290: long chains of __add__ must not drift vs exact Decimal sum."""
+        from decimal import Decimal
 
-# --- aggregate_per_model --------------------------------------------------
+        costs = [round(0.0002 + (i % 97) * 1e-6, 6) for i in range(5000)]
+        expected = sum(Decimal(repr(c)) for c in costs)
+
+        total = TokenUsage()
+        for c in costs:
+            total = total + TokenUsage(provider_reported_cost=c)
+
+        assert total.provider_reported_cost is not None
+        assert abs(float(expected) - float(total.provider_reported_cost)) < 0.0001
 
 
 class _FakePanelist:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -329,7 +329,7 @@ class TestParseOpenaiResponse:
             },
         }
         resp = parse_openai_response(data, "openai/gpt-4o-mini")
-        assert resp.usage.provider_reported_cost == pytest.approx(0.000123)
+        assert float(resp.usage.provider_reported_cost) == pytest.approx(0.000123)
 
     def test_openrouter_cost_details_upstream_inference_cost(self):
         """Prefer cost_details.upstream_inference_cost over absent top-level cost."""
@@ -346,7 +346,7 @@ class TestParseOpenaiResponse:
             },
         }
         resp = parse_openai_response(data, "m")
-        assert resp.usage.provider_reported_cost == pytest.approx(0.000456)
+        assert float(resp.usage.provider_reported_cost) == pytest.approx(0.000456)
 
     def test_openrouter_cost_details_prompt_plus_completion(self):
         """Fall back to prompt+completion cost sum if upstream total is missing."""
@@ -366,7 +366,7 @@ class TestParseOpenaiResponse:
             },
         }
         resp = parse_openai_response(data, "m")
-        assert resp.usage.provider_reported_cost == pytest.approx(0.0007)
+        assert float(resp.usage.provider_reported_cost) == pytest.approx(0.0007)
 
     def test_reasoning_and_cached_tokens_captured(self):
         """sp-loil: reasoning_tokens and cached_tokens subcounts land in TokenUsage."""


### PR DESCRIPTION
Store USD provider cost as Decimal in TokenUsage (cost + LLM layers), coerce floats on ingest via repr for stable round-trips, emit floats in to_dict for JSON. Merge checkpoint usage increments the same way.

Adds regression test for 5000 sequential adds vs exact Decimal sum.

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
