### PR TITLE
fix(pack): graceful errors on empty / malformed pack files in 'pack calibrate' (sy-anu)

### DIFF
--- a/src/synth_panel/calibration.py
+++ b/src/synth_panel/calibration.py
@@ -84,9 +84,7 @@ def load_pack_yaml(path: str, *, min_personas: int = 1) -> tuple[str, dict[str, 
         raise ValueError(f"pack YAML at {path} must be a mapping at top level")
     personas = data.get("personas")
     if not isinstance(personas, list) or len(personas) < min_personas:
-        raise ValueError(
-            f"no personas found in {path}; calibration requires at least {min_personas} persona(s)"
-        )
+        raise ValueError(f"no personas found in {path}; calibration requires at least {min_personas} persona(s)")
     return raw, data
 
 

--- a/src/synth_panel/calibration.py
+++ b/src/synth_panel/calibration.py
@@ -68,10 +68,11 @@ def now_iso_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def load_pack_yaml(path: str) -> tuple[str, dict[str, Any]]:
+def load_pack_yaml(path: str, *, min_personas: int = 1) -> tuple[str, dict[str, Any]]:
     """Read a pack YAML and return ``(raw_text, parsed_dict)``.
 
-    Raises ``ValueError`` on parse failure or non-mapping top level.
+    Raises ``ValueError`` on parse failure, non-mapping top level, or when
+    the pack contains fewer than ``min_personas`` persona entries.
     """
     with open(path, encoding="utf-8") as f:
         raw = f.read()
@@ -81,6 +82,11 @@ def load_pack_yaml(path: str) -> tuple[str, dict[str, Any]]:
         raise ValueError(f"failed to parse {path}: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"pack YAML at {path} must be a mapping at top level")
+    personas = data.get("personas")
+    if not isinstance(personas, list) or len(personas) < min_personas:
+        raise ValueError(
+            f"no personas found in {path}; calibration requires at least {min_personas} persona(s)"
+        )
     return raw, data
 
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3409,7 +3409,7 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 f"For gated datasets use post-hoc calibration.",
                 file=sys.stderr,
             )
-            return 1
+            return 2
 
         # ── Load + validate the pack YAML ────────────────────────────────
         if not Path(pack_yaml_path).exists():
@@ -3501,7 +3501,7 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 },
             )
         return 0
-    except Exception as exc:  # noqa: BLE001 - intentional catch-all safety net
+    except Exception as exc:
         if debug:
             raise
         print(

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3391,114 +3391,124 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
     output_path = args.output or pack_yaml_path
     dry_run = bool(args.dry_run)
     yes = bool(args.yes)
+    debug = bool(getattr(args, "debug", False))
 
-    # ── Validate --against spec + allowlist before any work ───────────
-    dataset, sep, question = against.partition(":")
-    if not sep or not dataset or not question:
-        print(
-            "Error: --against requires DATASET:QUESTION (colon-separated, both non-empty).",
-            file=sys.stderr,
-        )
-        return 2
-    if dataset not in _INLINE_CALIBRATION_ALLOWED and os.environ.get("SYNTHBENCH_ALLOW_GATED") != "1":
-        allowed = ", ".join(sorted(_INLINE_CALIBRATION_ALLOWED))
-        print(
-            f"Error: --against only supports inline-publishable datasets ({allowed}). "
-            f"For gated datasets use post-hoc calibration.",
-            file=sys.stderr,
-        )
-        return 1
-
-    # ── Load + validate the pack YAML ────────────────────────────────
-    if not Path(pack_yaml_path).exists():
-        print(f"Error: pack YAML not found: {pack_yaml_path}", file=sys.stderr)
-        return 1
     try:
-        raw_text, parsed = calib_mod.load_pack_yaml(pack_yaml_path)
-    except (OSError, ValueError) as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
+        # ── Validate --against spec + allowlist before any work ───────────
+        dataset, sep, question = against.partition(":")
+        if not sep or not dataset or not question:
+            print(
+                "Error: --against requires DATASET:QUESTION (colon-separated, both non-empty).",
+                file=sys.stderr,
+            )
+            return 2
+        if dataset not in _INLINE_CALIBRATION_ALLOWED and os.environ.get("SYNTHBENCH_ALLOW_GATED") != "1":
+            allowed = ", ".join(sorted(_INLINE_CALIBRATION_ALLOWED))
+            print(
+                f"Error: --against only supports inline-publishable datasets ({allowed}). "
+                f"For gated datasets use post-hoc calibration.",
+                file=sys.stderr,
+            )
+            return 1
 
-    # ── Run the calibration panel ────────────────────────────────────
-    try:
-        run_result = _run_calibration_panel(
-            pack_yaml_path=pack_yaml_path,
-            against=against,
+        # ── Load + validate the pack YAML ────────────────────────────────
+        if not Path(pack_yaml_path).exists():
+            print(f"Error: file not found: {pack_yaml_path}", file=sys.stderr)
+            return 2
+        try:
+            raw_text, parsed = calib_mod.load_pack_yaml(pack_yaml_path)
+        except (OSError, ValueError) as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 2
+
+        # ── Run the calibration panel ────────────────────────────────────
+        try:
+            run_result = _run_calibration_panel(
+                pack_yaml_path=pack_yaml_path,
+                against=against,
+                n=int(args.n),
+                samples_per_question=int(args.samples_per_question),
+                models=args.models,
+            )
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
+        # ── Build the calibration entry ──────────────────────────────────
+        entry = calib_mod.CalibrationEntry(
+            dataset=dataset,
+            question=question,
+            jsd=round(float(run_result["jsd"]), 6),
             n=int(args.n),
             samples_per_question=int(args.samples_per_question),
-            models=args.models,
+            models=list(run_result.get("models") or []),
+            extractor=str(run_result.get("extractor") or "pick_one:auto-derived"),
+            panelist_cost_usd=round(float(run_result.get("panelist_cost_usd") or 0.0), 4),
+            calibrated_at=calib_mod.now_iso_utc(),
+            synthpanel_version=str(__version__),
+            alignment_error=run_result.get("alignment_error"),
         )
-    except RuntimeError as exc:
-        print(f"Error: {exc}", file=sys.stderr)
-        return 1
+        new_dict = entry.to_yaml_dict()
+        new_yaml = calib_mod.update_pack_calibration_text(raw_text, parsed, new_dict)
 
-    # ── Build the calibration entry ──────────────────────────────────
-    entry = calib_mod.CalibrationEntry(
-        dataset=dataset,
-        question=question,
-        jsd=round(float(run_result["jsd"]), 6),
-        n=int(args.n),
-        samples_per_question=int(args.samples_per_question),
-        models=list(run_result.get("models") or []),
-        extractor=str(run_result.get("extractor") or "pick_one:auto-derived"),
-        panelist_cost_usd=round(float(run_result.get("panelist_cost_usd") or 0.0), 4),
-        calibrated_at=calib_mod.now_iso_utc(),
-        synthpanel_version=str(__version__),
-        alignment_error=run_result.get("alignment_error"),
-    )
-    new_dict = entry.to_yaml_dict()
-    new_yaml = calib_mod.update_pack_calibration_text(raw_text, parsed, new_dict)
+        # ── Dry-run: print, don't write ──────────────────────────────────
+        if dry_run:
+            if fmt is OutputFormat.TEXT:
+                print(f"# DRY RUN — would write to {output_path}")
+                print(new_yaml, end="")
+            else:
+                emit(
+                    fmt,
+                    message="Dry-run preview",
+                    extra={
+                        "pack_yaml": pack_yaml_path,
+                        "output": output_path,
+                        "calibration_entry": new_dict,
+                        "rendered_yaml": new_yaml,
+                    },
+                )
+            return 0
 
-    # ── Dry-run: print, don't write ──────────────────────────────────
-    if dry_run:
+        # ── Confirm overwrite when output path already exists ────────────
+        out_exists = Path(output_path).exists()
+        if out_exists and not yes and sys.stdin.isatty():
+            prompt = f"Overwrite {output_path}? [y/N]: "
+            try:
+                answer = input(prompt).strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print("\nAborted.", file=sys.stderr)
+                return 1
+            if answer not in {"y", "yes"}:
+                print("Aborted.", file=sys.stderr)
+                return 1
+
+        try:
+            Path(output_path).write_text(new_yaml, encoding="utf-8")
+        except OSError as exc:
+            print(f"Error: failed to write {output_path}: {exc}", file=sys.stderr)
+            return 1
+
         if fmt is OutputFormat.TEXT:
-            print(f"# DRY RUN — would write to {output_path}")
-            print(new_yaml, end="")
+            print(f"Wrote calibration entry ({dataset}:{question}, JSD {entry.jsd}) → {output_path}")
         else:
             emit(
                 fmt,
-                message="Dry-run preview",
+                message="Pack calibrated",
                 extra={
                     "pack_yaml": pack_yaml_path,
                     "output": output_path,
                     "calibration_entry": new_dict,
-                    "rendered_yaml": new_yaml,
                 },
             )
         return 0
-
-    # ── Confirm overwrite when output path already exists ────────────
-    out_exists = Path(output_path).exists()
-    if out_exists and not yes and sys.stdin.isatty():
-        prompt = f"Overwrite {output_path}? [y/N]: "
-        try:
-            answer = input(prompt).strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            print("\nAborted.", file=sys.stderr)
-            return 1
-        if answer not in {"y", "yes"}:
-            print("Aborted.", file=sys.stderr)
-            return 1
-
-    try:
-        Path(output_path).write_text(new_yaml, encoding="utf-8")
-    except OSError as exc:
-        print(f"Error: failed to write {output_path}: {exc}", file=sys.stderr)
-        return 1
-
-    if fmt is OutputFormat.TEXT:
-        print(f"Wrote calibration entry ({dataset}:{question}, JSD {entry.jsd}) → {output_path}")
-    else:
-        emit(
-            fmt,
-            message="Pack calibrated",
-            extra={
-                "pack_yaml": pack_yaml_path,
-                "output": output_path,
-                "calibration_entry": new_dict,
-            },
+    except Exception as exc:  # noqa: BLE001 - intentional catch-all safety net
+        if debug:
+            raise
+        print(
+            f"Error: unexpected failure: {type(exc).__name__}: {exc}",
+            file=sys.stderr,
         )
-    return 0
+        return 1
 
 
 def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -819,6 +819,12 @@ def build_parser() -> argparse.ArgumentParser:
         dest="yes",
         help="Non-interactive overwrite confirm (skip the y/N prompt).",
     )
+    pack_calibrate_parser.add_argument(
+        "--debug",
+        action="store_true",
+        dest="debug",
+        help="Re-raise unexpected errors with full traceback (default: print a clean message).",
+    )
 
     # instruments
     instruments_parser = subparsers.add_parser(

--- a/tests/test_pack_calibrate.py
+++ b/tests/test_pack_calibrate.py
@@ -389,8 +389,109 @@ def test_cli_pack_calibrate_missing_pack_yaml(tmp_path, capsys):
             "gss:HAPPY",
         ]
     )
+    assert rc == 2
+    assert "file not found" in capsys.readouterr().err
+
+
+def test_cli_pack_calibrate_rejects_empty_yaml(tmp_path, capsys):
+    pack = tmp_path / "empty.yaml"
+    pack.write_text("", encoding="utf-8")
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(pack),
+            "--against",
+            "gss:HAPPY",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "mapping" in err or "personas" in err
+
+
+def test_cli_pack_calibrate_rejects_zero_personas(tmp_path, capsys):
+    pack = tmp_path / "no_personas.yaml"
+    pack.write_text("name: empty pack\npersonas: []\n", encoding="utf-8")
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(pack),
+            "--against",
+            "gss:HAPPY",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no personas" in err
+
+
+def test_cli_pack_calibrate_rejects_malformed_yaml(tmp_path, capsys):
+    pack = tmp_path / "bad.yaml"
+    pack.write_text("personas: [\n  - name: alice\n  - missing closing", encoding="utf-8")
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(pack),
+            "--against",
+            "gss:HAPPY",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "failed to parse" in err.lower() or "parse" in err.lower()
+
+
+def test_cli_pack_calibrate_unexpected_error_clean_message(tmp_path, capsys):
+    pack = _write_pack(tmp_path)
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        side_effect=KeyError("missing-field"),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--yes",
+            ]
+        )
     assert rc == 1
-    assert "not found" in capsys.readouterr().err
+    err = capsys.readouterr().err
+    assert "unexpected failure" in err
+    assert "KeyError" in err
+
+
+def test_cli_pack_calibrate_debug_reraises_unexpected(tmp_path):
+    pack = _write_pack(tmp_path)
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        side_effect=KeyError("missing-field"),
+    ):
+        with pytest.raises(KeyError):
+            main(
+                [
+                    "pack",
+                    "calibrate",
+                    str(pack),
+                    "--against",
+                    "gss:HAPPY",
+                    "--n",
+                    "20",
+                    "--samples-per-question",
+                    "5",
+                    "--yes",
+                    "--debug",
+                ]
+            )
 
 
 def test_cli_pack_calibrate_propagates_panel_failure(tmp_path, capsys):

--- a/tests/test_pack_calibrate.py
+++ b/tests/test_pack_calibrate.py
@@ -374,7 +374,7 @@ def test_cli_pack_calibrate_rejects_gated_dataset(tmp_path, capsys, monkeypatch)
             "wvs:Q1",
         ]
     )
-    assert rc == 1
+    assert rc == 2
     err = capsys.readouterr().err
     assert "inline-publishable" in err
 
@@ -413,6 +413,32 @@ def test_cli_pack_calibrate_rejects_empty_yaml(tmp_path, capsys):
 def test_cli_pack_calibrate_rejects_zero_personas(tmp_path, capsys):
     pack = tmp_path / "no_personas.yaml"
     pack.write_text("name: empty pack\npersonas: []\n", encoding="utf-8")
+    rc = main(
+        [
+            "pack",
+            "calibrate",
+            str(pack),
+            "--against",
+            "gss:HAPPY",
+        ]
+    )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "no personas" in err
+
+
+@pytest.mark.parametrize(
+    "personas_yaml",
+    [
+        "name: missing key pack\n",
+        "name: null personas pack\npersonas: null\n",
+        "name: scalar personas pack\npersonas: not-a-list\n",
+    ],
+    ids=["missing-key", "null-value", "scalar-value"],
+)
+def test_cli_pack_calibrate_rejects_personas_not_a_nonempty_list(tmp_path, capsys, personas_yaml):
+    pack = tmp_path / "bad_personas.yaml"
+    pack.write_text(personas_yaml, encoding="utf-8")
     rc = main(
         [
             "pack",
@@ -472,26 +498,28 @@ def test_cli_pack_calibrate_unexpected_error_clean_message(tmp_path, capsys):
 
 def test_cli_pack_calibrate_debug_reraises_unexpected(tmp_path):
     pack = _write_pack(tmp_path)
-    with patch(
-        "synth_panel.cli.commands._run_calibration_panel",
-        side_effect=KeyError("missing-field"),
+    with (
+        patch(
+            "synth_panel.cli.commands._run_calibration_panel",
+            side_effect=KeyError("missing-field"),
+        ),
+        pytest.raises(KeyError),
     ):
-        with pytest.raises(KeyError):
-            main(
-                [
-                    "pack",
-                    "calibrate",
-                    str(pack),
-                    "--against",
-                    "gss:HAPPY",
-                    "--n",
-                    "20",
-                    "--samples-per-question",
-                    "5",
-                    "--yes",
-                    "--debug",
-                ]
-            )
+        main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--yes",
+                "--debug",
+            ]
+        )
 
 
 def test_cli_pack_calibrate_propagates_panel_failure(tmp_path, capsys):


### PR DESCRIPTION
## Summary

- Tightens the user-input/file error surface for `synthpanel pack calibrate` (added in #282) so empty files, zero-persona packs, malformed YAML, and gated datasets produce clean exit-2 errors instead of raw tracebacks.
- Standardizes exit codes: **2** for *all* user-input/file/policy rejections, **1** for runtime errors (panel run, write failures, abort).
- Adds a `--debug` flag plus a top-level catch-all so unexpected exceptions print `Error: unexpected failure: <type>: <msg>`; tracebacks only re-raise when `--debug` is set.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| File missing | exit 1 — `Error: pack YAML not found: <path>` | exit **2** — `Error: file not found: <path>` |
| Malformed YAML | exit 1 — `Error: failed to parse <path>: ...` | exit **2** — same message |
| Pack has 0 personas (or `personas:` missing/null/non-list) | (silent — exploded later in panel-run subprocess) | exit **2** — `Error: no personas found in <path>; calibration requires at least 1 persona(s)` |
| Empty file | exit 1 — `Error: pack YAML at <path> must be a mapping at top level` | exit **2** — same message |
| Gated dataset (no `SYNTHBENCH_ALLOW_GATED=1`) | exit 1 | exit **2** — same message |
| Unexpected `KeyError` / `AttributeError` | raw traceback | exit 1 — clean `unexpected failure` message; pass `--debug` to see the traceback |

The panel-run `RuntimeError` path stays on exit 1 (it's a runtime failure, not user input).

## Implementation

- `src/synth_panel/calibration.py` — `load_pack_yaml` now takes `min_personas: int = 1` and raises `ValueError` when the parsed dict's `personas:` key is missing or has fewer entries than the threshold (covers absent key, null value, non-list value, and empty list).
- `src/synth_panel/cli/parser.py` — added `--debug` to the `pack calibrate` subparser.
- `src/synth_panel/cli/commands.py` — `handle_pack_calibrate`: bumped exit codes for user-input errors (missing file, parse, allowlist) to 2; wrapped the entire handler body in `try/except Exception` that prints a clean message and re-raises only when `args.debug` is set.

## Test plan

- [x] `test_cli_pack_calibrate_missing_pack_yaml` — rc 2, "file not found" wording.
- [x] `test_cli_pack_calibrate_rejects_empty_yaml` — rc 2.
- [x] `test_cli_pack_calibrate_rejects_zero_personas` — `personas: []` → rc 2.
- [x] `test_cli_pack_calibrate_rejects_personas_not_a_nonempty_list` — parametrized over missing-key / null / scalar → rc 2.
- [x] `test_cli_pack_calibrate_rejects_malformed_yaml` — rc 2.
- [x] `test_cli_pack_calibrate_rejects_gated_dataset` — rc 2 (was 1; bumped for consistency).
- [x] `test_cli_pack_calibrate_unexpected_error_clean_message` — KeyError side-effect → rc 1, `"unexpected failure"` + `"KeyError"` in stderr.
- [x] `test_cli_pack_calibrate_debug_reraises_unexpected` — `--debug` re-raises via `pytest.raises`.
- [x] `test_cli_pack_calibrate_propagates_panel_failure` — RuntimeError path stays rc 1.
- [x] `pytest tests/test_pack_calibrate.py` — 27/27 pass.
- [x] `pytest tests/test_pack_calibrate.py tests/test_calibration.py tests/test_cli.py tests/test_cli_auth.py tests/test_cli_report.py` — 207/207 + 3 new pass.
- [x] `ruff check src/ tests/` — clean.
- [x] CLI smoke-tested all error paths against real fixtures; output and exit codes match the table above.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)