### PR TITLE
feat(security): add sha256 integrity sidecar for credentials.json (GH-319)

### DIFF
--- a/src/synth_panel/credentials.py
+++ b/src/synth_panel/credentials.py
@@ -16,9 +16,15 @@ offer a dedicated ``synthpanel login`` instead of auto-bridging.
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import json
 import os
 from pathlib import Path
+
+
+class CredentialIntegrityError(Exception):
+    """Raised when credentials.json sha256 sidecar does not match the file content."""
+
 
 # Recognised provider env var names. ``synthpanel login`` validates
 # against this list so a typo doesn't silently persist a key nothing
@@ -84,6 +90,14 @@ def detect_provider_from_key(value: str) -> str | None:
     return None
 
 
+def _sidecar_path(path: Path) -> Path:
+    return path.with_name(path.name + ".sha256")
+
+
+def _compute_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
 def credentials_path() -> Path:
     """Return the path to the credential store.
 
@@ -103,14 +117,45 @@ def load_credentials() -> dict[str, str]:
 
     Returns an empty dict if the file is missing or unreadable. Only
     string values are kept so malformed entries can't crash the caller.
+
+    Raises ``CredentialIntegrityError`` if a sha256 sidecar exists and does
+    not match the file content. When no sidecar exists the sidecar is
+    generated (migration) and the credentials are returned normally.
     """
     path = credentials_path()
     if not path.exists():
         return {}
     try:
         raw = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    sidecar = _sidecar_path(path)
+    actual_hash = _compute_hash(raw)
+    if sidecar.exists():
+        try:
+            stored_hash = sidecar.read_text(encoding="utf-8").strip()
+        except OSError:
+            stored_hash = ""
+        if stored_hash != actual_hash:
+            raise CredentialIntegrityError(
+                f"Credential file {path} failed integrity check — "
+                "re-run `synthpanel login` to restore your credentials."
+            )
+    else:
+        # Migration: generate sidecar on first successful read
+        try:
+            sidecar_tmp = path.with_name(path.name + ".sha256.tmp")
+            sidecar_tmp.write_text(actual_hash + "\n", encoding="utf-8")
+            with contextlib.suppress(OSError):
+                os.chmod(sidecar_tmp, 0o600)
+            os.replace(sidecar_tmp, sidecar)
+        except OSError:
+            pass
+
+    try:
         data = json.loads(raw) if raw.strip() else {}
-    except (OSError, json.JSONDecodeError):
+    except json.JSONDecodeError:
         return {}
     if not isinstance(data, dict):
         return {}
@@ -133,8 +178,14 @@ def save_credential(env_var: str, value: str) -> Path:
     if not value:
         raise ValueError("value must be non-empty")
 
-    existing = load_credentials()
+    try:
+        existing = load_credentials()
+    except CredentialIntegrityError:
+        existing = {}  # login supersedes tampered credentials
     existing[env_var] = value
+
+    content = json.dumps(existing, indent=2, sort_keys=True) + "\n"
+    new_hash = _compute_hash(content)
 
     path = credentials_path()
     parent = path.parent
@@ -142,10 +193,18 @@ def save_credential(env_var: str, value: str) -> Path:
     with contextlib.suppress(OSError):
         os.chmod(parent, 0o700)
 
+    sidecar = _sidecar_path(path)
+    sidecar_tmp = path.with_name(path.name + ".sha256.tmp")
+    sidecar_tmp.write_text(new_hash + "\n", encoding="utf-8")
+    with contextlib.suppress(OSError):
+        os.chmod(sidecar_tmp, 0o600)
+
     tmp = path.with_suffix(path.suffix + ".tmp")
-    tmp.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp.write_text(content, encoding="utf-8")
     with contextlib.suppress(OSError):
         os.chmod(tmp, 0o600)
+
+    os.replace(sidecar_tmp, sidecar)
     os.replace(tmp, path)
     return path
 
@@ -161,15 +220,25 @@ def delete_credential(env_var: str) -> bool:
         return False
     del existing[env_var]
     path = credentials_path()
+    sidecar = _sidecar_path(path)
     if existing:
+        content = json.dumps(existing, indent=2, sort_keys=True) + "\n"
+        new_hash = _compute_hash(content)
+        sidecar_tmp = path.with_name(path.name + ".sha256.tmp")
+        sidecar_tmp.write_text(new_hash + "\n", encoding="utf-8")
+        with contextlib.suppress(OSError):
+            os.chmod(sidecar_tmp, 0o600)
         tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(json.dumps(existing, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        tmp.write_text(content, encoding="utf-8")
         with contextlib.suppress(OSError):
             os.chmod(tmp, 0o600)
+        os.replace(sidecar_tmp, sidecar)
         os.replace(tmp, path)
     else:
         with contextlib.suppress(FileNotFoundError):
             path.unlink()
+        with contextlib.suppress(FileNotFoundError):
+            sidecar.unlink()
     return True
 
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -10,8 +10,8 @@ from pathlib import Path
 import pytest
 
 from synth_panel.credentials import (
-    CredentialIntegrityError,
     PROVIDER_KEY_PREFIXES,
+    CredentialIntegrityError,
     credentials_path,
     delete_credential,
     detect_provider_from_key,

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from synth_panel.credentials import (
+    CredentialIntegrityError,
     PROVIDER_KEY_PREFIXES,
     credentials_path,
     delete_credential,
@@ -143,6 +144,79 @@ class TestGetCredential:
         assert has_credential("ANTHROPIC_API_KEY") is False
         save_credential("ANTHROPIC_API_KEY", "sk-x")
         assert has_credential("ANTHROPIC_API_KEY") is True
+
+
+class TestSha256Sidecar:
+    def test_save_writes_sidecar(self):
+        path = save_credential("ANTHROPIC_API_KEY", "sk-x")
+        sidecar = path.parent / (path.name + ".sha256")
+        assert sidecar.exists()
+        assert len(sidecar.read_text().strip()) == 64  # hex sha256
+
+    def test_load_passes_when_sidecar_matches(self):
+        save_credential("ANTHROPIC_API_KEY", "sk-x")
+        assert load_credentials() == {"ANTHROPIC_API_KEY": "sk-x"}
+
+    def test_load_raises_on_sidecar_mismatch(self):
+        path = save_credential("ANTHROPIC_API_KEY", "sk-x")
+        path.write_text('{"ANTHROPIC_API_KEY": "tampered"}\n', encoding="utf-8")
+        with pytest.raises(CredentialIntegrityError, match="synthpanel login"):
+            load_credentials()
+
+    def test_migration_generates_sidecar_on_first_read(self, monkeypatch, tmp_path):
+        creds = tmp_path / "credentials.json"
+        creds.write_text('{"ANTHROPIC_API_KEY": "sk-legacy"}\n', encoding="utf-8")
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(creds))
+        result = load_credentials()
+        assert result == {"ANTHROPIC_API_KEY": "sk-legacy"}
+        sidecar = tmp_path / "credentials.json.sha256"
+        assert sidecar.exists()
+
+    def test_migration_sidecar_matches_content(self, monkeypatch, tmp_path):
+        import hashlib
+
+        content = '{"ANTHROPIC_API_KEY": "sk-legacy"}\n'
+        creds = tmp_path / "credentials.json"
+        creds.write_text(content, encoding="utf-8")
+        monkeypatch.setenv("SYNTHPANEL_CREDENTIALS_PATH", str(creds))
+        load_credentials()
+        sidecar = tmp_path / "credentials.json.sha256"
+        expected = hashlib.sha256(content.encode()).hexdigest()
+        assert sidecar.read_text().strip() == expected
+
+    def test_save_login_recovers_from_tampered_file(self):
+        path = save_credential("ANTHROPIC_API_KEY", "sk-original")
+        path.write_text('{"ANTHROPIC_API_KEY": "tampered"}\n', encoding="utf-8")
+        # login should succeed despite mismatch (starts fresh)
+        new_path = save_credential("ANTHROPIC_API_KEY", "sk-new")
+        assert load_credentials() == {"ANTHROPIC_API_KEY": "sk-new"}
+        assert new_path == path
+
+    def test_delete_updates_sidecar_when_entries_remain(self):
+        import hashlib
+
+        save_credential("ANTHROPIC_API_KEY", "sk-a")
+        save_credential("OPENAI_API_KEY", "sk-b")
+        delete_credential("ANTHROPIC_API_KEY")
+        path = credentials_path()
+        sidecar = path.parent / (path.name + ".sha256")
+        content = path.read_text(encoding="utf-8")
+        expected = hashlib.sha256(content.encode()).hexdigest()
+        assert sidecar.read_text().strip() == expected
+
+    def test_delete_removes_sidecar_when_file_deleted(self):
+        save_credential("ANTHROPIC_API_KEY", "sk-only")
+        path = credentials_path()
+        sidecar = path.parent / (path.name + ".sha256")
+        delete_credential("ANTHROPIC_API_KEY")
+        assert not path.exists()
+        assert not sidecar.exists()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permissions")
+    def test_sidecar_file_is_mode_0600(self):
+        path = save_credential("ANTHROPIC_API_KEY", "sk-x")
+        sidecar = path.parent / (path.name + ".sha256")
+        assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
 
 
 class TestProviderIntegration:


### PR DESCRIPTION
## Summary

- Adds a sha256 integrity sidecar (`.sha256`) for `credentials.json` to detect tampering
- `load_credentials()` raises `CredentialIntegrityError` when the sidecar exists and doesn't match
- Auto-generates the sidecar on first read (migration path for existing users)
- `save_credential()` atomically writes both the credentials file and its sidecar

## Test plan

- [x] 1775 unit tests pass
- [x] Coverage at 87.32% (above 80% threshold)
- [x] Rebased cleanly on top of current main (trivial import conflict resolved: both `PROVIDER_KEY_PREFIXES` and `CredentialIntegrityError` kept in test imports)

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)