### PR TITLE
feat(cli): add 'runs prune' and 'runs list' commands (GH-314)

### DIFF
--- a/src/synth_panel/checkpoint.py
+++ b/src/synth_panel/checkpoint.py
@@ -43,7 +43,7 @@ import tempfile
 import threading
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
@@ -489,3 +489,161 @@ def ensure_config_matches(
             f"fingerprint {current_fp[:12]}... — rerun without --resume or "
             f"restore the original config to continue"
         )
+
+
+# ---------------------------------------------------------------------------
+# Run listing and pruning
+# ---------------------------------------------------------------------------
+
+_DURATION_RE = re.compile(r"^(\d+(?:\.\d+)?)(w|d|h|m)$")
+
+
+def parse_duration(value: str) -> timedelta:
+    """Parse a human duration string into a :class:`~datetime.timedelta`.
+
+    Supported units: ``w`` (weeks), ``d`` (days), ``h`` (hours), ``m`` (minutes).
+    Examples: ``7d``, ``2w``, ``24h``, ``90m``.
+    """
+    m = _DURATION_RE.match(value.strip())
+    if not m:
+        raise ValueError(f"invalid duration {value!r}: expected NNd, NNh, NNw, or NNm (e.g. '7d', '2w', '24h')")
+    n = float(m.group(1))
+    unit = m.group(2)
+    if unit == "w":
+        return timedelta(weeks=n)
+    if unit == "d":
+        return timedelta(days=n)
+    if unit == "h":
+        return timedelta(hours=n)
+    return timedelta(minutes=n)
+
+
+def _is_in_progress(checkpoint: PanelCheckpoint) -> bool:
+    """Return True if the checkpoint appears to be from an actively-running session.
+
+    A run with remaining personas and no abort reason was either still running
+    or crashed without signal handling. We treat both as in-progress to avoid
+    destroying resumable checkpoints.
+    """
+    return bool(checkpoint.remaining) and checkpoint.abort_reason is None
+
+
+def list_runs(root: Path | None = None) -> list[dict[str, Any]]:
+    """Return metadata for all checkpoint runs found under *root*.
+
+    Each entry is a dict with keys: ``run_id``, ``created_at``, ``updated_at``,
+    ``completed``, ``remaining``, ``in_progress``, ``abort_reason``, ``directory``.
+    Malformed entries include a ``malformed: True`` key instead of checkpoint fields.
+    """
+    r = Path(root) if root is not None else default_checkpoint_root()
+    if not r.exists():
+        return []
+    runs: list[dict[str, Any]] = []
+    for entry in sorted(r.iterdir()):
+        if not entry.is_dir():
+            continue
+        state = _state_path(entry)
+        if not state.exists():
+            continue
+        try:
+            data = json.loads(state.read_text(encoding="utf-8"))
+            ckpt = PanelCheckpoint.from_dict(data)
+            runs.append(
+                {
+                    "run_id": ckpt.run_id,
+                    "created_at": ckpt.created_at,
+                    "updated_at": ckpt.updated_at,
+                    "completed": len(ckpt.completed),
+                    "remaining": len(ckpt.remaining),
+                    "in_progress": _is_in_progress(ckpt),
+                    "abort_reason": ckpt.abort_reason,
+                    "directory": str(entry),
+                }
+            )
+        except (CheckpointFormatError, json.JSONDecodeError, KeyError, ValueError):
+            runs.append(
+                {
+                    "run_id": entry.name,
+                    "directory": str(entry),
+                    "malformed": True,
+                }
+            )
+    return runs
+
+
+def prune_runs(
+    root: Path | None = None,
+    older_than: timedelta | None = None,
+    keep: int | None = None,
+    dry_run: bool = False,
+) -> list[str]:
+    """Delete stale checkpoint run directories; return list of pruned run IDs.
+
+    Rules applied in order:
+    - In-progress runs (remaining personas, no abort reason) are *never* pruned.
+    - ``older_than``: prune runs whose ``updated_at`` is older than this duration.
+    - ``keep``: prune runs beyond the *keep* most-recently-updated non-in-progress runs.
+    - When both flags are given, a run is pruned if it matches *either* condition.
+    - At least one of ``older_than`` or ``keep`` must be provided.
+
+    With ``dry_run=True`` the returned list shows what *would* be pruned without
+    touching the filesystem.
+    """
+    if older_than is None and keep is None:
+        raise ValueError("at least one of older_than or keep must be specified")
+
+    r = Path(root) if root is not None else default_checkpoint_root()
+    if not r.exists():
+        return []
+
+    now = datetime.now(timezone.utc)
+
+    # Build list of (updated_at_dt | None, directory, run_id, in_progress)
+    candidates: list[tuple[datetime | None, Path, str, bool]] = []
+    for entry in r.iterdir():
+        if not entry.is_dir():
+            continue
+        state = _state_path(entry)
+        if not state.exists():
+            continue
+        try:
+            data = json.loads(state.read_text(encoding="utf-8"))
+            ckpt = PanelCheckpoint.from_dict(data)
+            in_progress = _is_in_progress(ckpt)
+            try:
+                updated_dt: datetime | None = datetime.fromisoformat(ckpt.updated_at)
+                if updated_dt.tzinfo is None:
+                    updated_dt = updated_dt.replace(tzinfo=timezone.utc)
+            except (ValueError, TypeError):
+                updated_dt = None
+            candidates.append((updated_dt, entry, ckpt.run_id, in_progress))
+        except (CheckpointFormatError, json.JSONDecodeError, KeyError, ValueError):
+            # Malformed directory — treat as prunable (no in-progress risk)
+            candidates.append((None, entry, entry.name, False))
+
+    # Sort newest-first (runs without a timestamp sort after all dated runs)
+    candidates.sort(key=lambda x: (x[0] is None, x[0] or datetime.min.replace(tzinfo=timezone.utc)), reverse=True)
+
+    pruned: list[str] = []
+    non_inprogress_seen = 0
+
+    for updated_dt, entry, run_id, in_progress in candidates:
+        if in_progress:
+            continue
+
+        should_prune = False
+
+        if keep is not None and non_inprogress_seen >= keep:
+            should_prune = True
+
+        if older_than is not None and updated_dt is not None and (now - updated_dt) > older_than:
+            should_prune = True
+
+        non_inprogress_seen += 1
+
+        if should_prune:
+            pruned.append(run_id)
+            if not dry_run:
+                shutil.rmtree(str(entry), ignore_errors=True)
+
+    return pruned

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -33,8 +33,11 @@ from synth_panel.checkpoint import (
     checkpoint_dir_for,
     default_checkpoint_root,
     ensure_config_matches,
+    list_runs,
     load_checkpoint,
     new_run_id,
+    parse_duration,
+    prune_runs,
 )
 from synth_panel.cli.output import (
     OutputFormat,
@@ -4746,3 +4749,80 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
         extra=extra,
     )
     return rc
+
+
+def handle_runs_prune(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Prune stale checkpoint run directories from the checkpoint root."""
+    from pathlib import Path
+
+    root = Path(args.root) if getattr(args, "root", None) else None
+
+    older_than = None
+    if getattr(args, "older_than", None):
+        try:
+            older_than = parse_duration(args.older_than)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 1
+
+    keep = getattr(args, "keep", None)
+    dry_run: bool = getattr(args, "dry_run", False)
+
+    if older_than is None and keep is None:
+        print("error: specify at least one of --older-than or --keep", file=sys.stderr)
+        return 1
+
+    try:
+        pruned = prune_runs(root=root, older_than=older_than, keep=keep, dry_run=dry_run)
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.TEXT:
+        checkpoint_root = root or default_checkpoint_root()
+        prefix = "[dry-run] would prune" if dry_run else "pruned"
+        if not pruned:
+            print(f"Nothing to prune under {checkpoint_root}")
+        else:
+            for run_id in pruned:
+                print(f"{prefix}: {run_id}")
+            noun = "run" if len(pruned) == 1 else "runs"
+            suffix = " (no files deleted)" if dry_run else ""
+            print(f"\n{len(pruned)} {noun}{suffix}")
+        return 0
+
+    emit(
+        fmt,
+        message="runs_pruned",
+        extra={
+            "dry_run": dry_run,
+            "pruned": pruned,
+            "count": len(pruned),
+        },
+    )
+    return 0
+
+
+def handle_runs_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """List checkpoint run directories and their status."""
+    from pathlib import Path
+
+    root = Path(args.root) if getattr(args, "root", None) else None
+
+    runs = list_runs(root=root)
+
+    if fmt is OutputFormat.TEXT:
+        checkpoint_root = root or default_checkpoint_root()
+        if not runs:
+            print(f"No runs found under {checkpoint_root}")
+            return 0
+        for run in runs:
+            if run.get("malformed"):
+                print(f"  {run['run_id']}  [malformed]")
+            else:
+                status = "in-progress" if run["in_progress"] else ("aborted" if run["abort_reason"] else "complete")
+                print(f"  {run['run_id']}  [{status}]  updated={run['updated_at']}")
+        return 0
+
+    emit(fmt, message="runs_list", extra={"runs": runs, "count": len(runs)})
+    return 0

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1063,4 +1063,56 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # runs — manage checkpoint run directories
+    runs_parser = subparsers.add_parser(
+        "runs",
+        help="Manage checkpoint run directories (~/.synthpanel/checkpoints).",
+    )
+    runs_subparsers = runs_parser.add_subparsers(dest="runs_command")
+
+    # runs list
+    runs_list_parser = runs_subparsers.add_parser(
+        "list",
+        help="List checkpoint runs and their status.",
+    )
+    runs_list_parser.add_argument(
+        "--root",
+        default=None,
+        metavar="DIR",
+        help="Checkpoint root directory (default: $SYNTHPANEL_CHECKPOINT_ROOT or ~/.synthpanel/checkpoints).",
+    )
+
+    # runs prune
+    runs_prune_parser = runs_subparsers.add_parser(
+        "prune",
+        help="Delete stale checkpoint runs. At least one of --older-than or --keep is required.",
+    )
+    runs_prune_parser.add_argument(
+        "--older-than",
+        default=None,
+        metavar="DURATION",
+        dest="older_than",
+        help="Prune runs last updated more than DURATION ago. Format: Nd, Nh, Nw, Nm (e.g. 7d, 24h, 2w).",
+    )
+    runs_prune_parser.add_argument(
+        "--keep",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Keep the N most-recently-updated non-in-progress runs; prune the rest.",
+    )
+    runs_prune_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        dest="dry_run",
+        help="Show what would be pruned without deleting anything.",
+    )
+    runs_prune_parser.add_argument(
+        "--root",
+        default=None,
+        metavar="DIR",
+        help="Checkpoint root directory (default: $SYNTHPANEL_CHECKPOINT_ROOT or ~/.synthpanel/checkpoints).",
+    )
+
     return parser

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -32,6 +32,8 @@ from synth_panel.cli.commands import (
     handle_panel_synthesize,
     handle_prompt,
     handle_report,
+    handle_runs_list,
+    handle_runs_prune,
     handle_whoami,
 )
 from synth_panel.cli.output import OutputFormat
@@ -124,6 +126,15 @@ def main(argv: list[str] | None = None) -> int:
         return handle_whoami(args, output_format)
     elif args.command == "doctor":
         return handle_doctor(args, output_format)
+    elif args.command == "runs":
+        sub = getattr(args, "runs_command", None)
+        if sub == "prune":
+            return handle_runs_prune(args, output_format)
+        elif sub == "list":
+            return handle_runs_list(args, output_format)
+        else:
+            parser.parse_args(["runs", "--help"])
+            return 1
     else:
         # No subcommand → interactive REPL
         return run_repl(args, output_format)

--- a/tests/test_runs_prune.py
+++ b/tests/test_runs_prune.py
@@ -1,0 +1,314 @@
+"""Tests for checkpoint run listing and pruning (sy-67b / GH-314).
+
+Covers:
+- parse_duration: valid and invalid formats
+- list_runs: empty root, normal runs, malformed entries
+- prune_runs: --older-than, --keep, --dry-run, in-progress protection
+- CLI wiring: synthpanel runs prune / list
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from synth_panel.checkpoint import (
+    PanelCheckpoint,
+    _is_in_progress,
+    checkpoint_dir_for,
+    list_runs,
+    parse_duration,
+    prune_runs,
+)
+from synth_panel.main import main
+
+# ---------------------------------------------------------------------------
+# parse_duration
+# ---------------------------------------------------------------------------
+
+
+class TestParseDuration:
+    def test_days(self) -> None:
+        assert parse_duration("7d") == timedelta(days=7)
+
+    def test_hours(self) -> None:
+        assert parse_duration("24h") == timedelta(hours=24)
+
+    def test_weeks(self) -> None:
+        assert parse_duration("2w") == timedelta(weeks=2)
+
+    def test_minutes(self) -> None:
+        assert parse_duration("90m") == timedelta(minutes=90)
+
+    def test_fractional(self) -> None:
+        assert parse_duration("1.5d") == timedelta(days=1.5)
+
+    def test_invalid_unit(self) -> None:
+        with pytest.raises(ValueError, match="invalid duration"):
+            parse_duration("7x")
+
+    def test_invalid_no_unit(self) -> None:
+        with pytest.raises(ValueError, match="invalid duration"):
+            parse_duration("7")
+
+    def test_invalid_empty(self) -> None:
+        with pytest.raises(ValueError, match="invalid duration"):
+            parse_duration("")
+
+
+# ---------------------------------------------------------------------------
+# _is_in_progress
+# ---------------------------------------------------------------------------
+
+
+class TestIsInProgress:
+    def _make(self, remaining: list[str], abort_reason: str | None) -> PanelCheckpoint:
+        now = datetime.now(timezone.utc).isoformat()
+        return PanelCheckpoint(
+            run_id="run-test",
+            created_at=now,
+            updated_at=now,
+            config_fingerprint="abc",
+            config={},
+            remaining=remaining,
+            abort_reason=abort_reason,
+        )
+
+    def test_completed_run_not_in_progress(self) -> None:
+        ckpt = self._make(remaining=[], abort_reason=None)
+        assert not _is_in_progress(ckpt)
+
+    def test_aborted_run_not_in_progress(self) -> None:
+        ckpt = self._make(remaining=["alice"], abort_reason="signal:SIGINT")
+        assert not _is_in_progress(ckpt)
+
+    def test_running_or_crashed_is_in_progress(self) -> None:
+        ckpt = self._make(remaining=["alice"], abort_reason=None)
+        assert _is_in_progress(ckpt)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_run(
+    root: Path,
+    run_id: str,
+    *,
+    remaining: list[str] | None = None,
+    abort_reason: str | None = None,
+    updated_at: datetime | None = None,
+) -> None:
+    """Write a checkpoint run directly (bypasses save_checkpoint's now() stamp)."""
+    now = datetime.now(timezone.utc)
+    if updated_at is None:
+        updated_at = now
+    directory = checkpoint_dir_for(run_id, root)
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "run_id": run_id,
+        "created_at": now.isoformat(),
+        "updated_at": updated_at.isoformat(),
+        "config_fingerprint": "deadbeef",
+        "config": {},
+        "completed": [],
+        "remaining": remaining or [],
+        "usage": {},
+        "abort_reason": abort_reason,
+    }
+    (directory / "state.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# list_runs
+# ---------------------------------------------------------------------------
+
+
+class TestListRuns:
+    def test_empty_root_returns_empty(self, tmp_path: Path) -> None:
+        assert list_runs(tmp_path) == []
+
+    def test_missing_root_returns_empty(self, tmp_path: Path) -> None:
+        missing = tmp_path / "no-such-dir"
+        assert list_runs(missing) == []
+
+    def test_single_completed_run(self, tmp_path: Path) -> None:
+        _write_run(tmp_path, "run-20240101T000000Z-abc123")
+        runs = list_runs(tmp_path)
+        assert len(runs) == 1
+        assert runs[0]["run_id"] == "run-20240101T000000Z-abc123"
+        assert not runs[0]["in_progress"]
+        assert runs[0]["remaining"] == 0
+
+    def test_in_progress_run_flagged(self, tmp_path: Path) -> None:
+        _write_run(tmp_path, "run-a", remaining=["alice", "bob"])
+        runs = list_runs(tmp_path)
+        assert len(runs) == 1
+        assert runs[0]["in_progress"] is True
+        assert runs[0]["remaining"] == 2
+
+    def test_malformed_entry_reported(self, tmp_path: Path) -> None:
+        bad_dir = tmp_path / "bad-run"
+        bad_dir.mkdir()
+        (bad_dir / "state.json").write_text("{not valid json", encoding="utf-8")
+        runs = list_runs(tmp_path)
+        assert len(runs) == 1
+        assert runs[0].get("malformed") is True
+
+    def test_directories_without_state_json_ignored(self, tmp_path: Path) -> None:
+        (tmp_path / "some-dir").mkdir()
+        assert list_runs(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# prune_runs
+# ---------------------------------------------------------------------------
+
+
+class TestPruneRuns:
+    def test_requires_at_least_one_flag(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="at least one"):
+            prune_runs(root=tmp_path)
+
+    def test_empty_root_returns_empty(self, tmp_path: Path) -> None:
+        assert prune_runs(root=tmp_path, keep=5) == []
+
+    def test_keep_n_prunes_oldest(self, tmp_path: Path) -> None:
+        now = datetime.now(timezone.utc)
+        for i, age_days in enumerate([10, 5, 1]):
+            _write_run(tmp_path, f"run-{i:03d}", updated_at=now - timedelta(days=age_days))
+
+        pruned = prune_runs(root=tmp_path, keep=2)
+        assert len(pruned) == 1
+        assert "run-000" in pruned  # oldest (10 days ago)
+
+    def test_older_than_prunes_by_age(self, tmp_path: Path) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(tmp_path, "run-old", updated_at=now - timedelta(days=10))
+        _write_run(tmp_path, "run-new", updated_at=now - timedelta(days=1))
+
+        pruned = prune_runs(root=tmp_path, older_than=timedelta(days=7))
+        assert pruned == ["run-old"]
+        assert not (tmp_path / "run-old").exists()
+        assert (tmp_path / "run-new").exists()
+
+    def test_dry_run_does_not_delete(self, tmp_path: Path) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(tmp_path, "run-old", updated_at=now - timedelta(days=10))
+
+        pruned = prune_runs(root=tmp_path, older_than=timedelta(days=7), dry_run=True)
+        assert pruned == ["run-old"]
+        assert (tmp_path / "run-old").exists()
+
+    def test_in_progress_never_pruned(self, tmp_path: Path) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(tmp_path, "run-active", remaining=["alice"], updated_at=now - timedelta(days=30))
+        _write_run(tmp_path, "run-old", updated_at=now - timedelta(days=30))
+
+        pruned = prune_runs(root=tmp_path, older_than=timedelta(days=7))
+        assert "run-old" in pruned
+        assert "run-active" not in pruned
+        assert (tmp_path / "run-active").exists()
+
+    def test_aborted_run_is_prunable(self, tmp_path: Path) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(
+            tmp_path,
+            "run-aborted",
+            remaining=["bob"],
+            abort_reason="signal:SIGINT",
+            updated_at=now - timedelta(days=10),
+        )
+
+        pruned = prune_runs(root=tmp_path, older_than=timedelta(days=7))
+        assert "run-aborted" in pruned
+
+    def test_both_flags_are_union(self, tmp_path: Path) -> None:
+        """--older-than OR --keep: prune if either condition is met."""
+        now = datetime.now(timezone.utc)
+        # 5 fresh runs and 1 old run
+        for i in range(5):
+            _write_run(tmp_path, f"run-new-{i}", updated_at=now - timedelta(hours=1))
+        _write_run(tmp_path, "run-old", updated_at=now - timedelta(days=30))
+
+        # --keep=5 keeps newest 5, --older-than=7d prunes old one too
+        pruned = prune_runs(root=tmp_path, keep=5, older_than=timedelta(days=7))
+        assert "run-old" in pruned
+
+    def test_keep_n_no_delete_when_fewer(self, tmp_path: Path) -> None:
+        _write_run(tmp_path, "run-a")
+        _write_run(tmp_path, "run-b")
+        pruned = prune_runs(root=tmp_path, keep=10)
+        assert pruned == []
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCliRunsPrune:
+    def test_prune_requires_flag(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["--output-format", "text", "runs", "prune", "--root", str(tmp_path)])
+        assert rc != 0
+        captured = capsys.readouterr()
+        assert "older-than" in captured.err or "keep" in captured.err
+
+    def test_prune_dry_run_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(tmp_path, "run-stale", updated_at=now - timedelta(days=10))
+
+        rc = main(["runs", "prune", "--older-than", "7d", "--dry-run", "--root", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "run-stale" in out
+        assert "dry-run" in out.lower() or "would prune" in out.lower()
+
+    def test_prune_deletes_run(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(tmp_path, "run-old", updated_at=now - timedelta(days=30))
+
+        rc = main(["runs", "prune", "--older-than", "7d", "--root", str(tmp_path)])
+        assert rc == 0
+        assert not (tmp_path / "run-old").exists()
+
+    def test_prune_nothing_to_prune(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["runs", "prune", "--keep", "10", "--root", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Nothing to prune" in out
+
+    def test_prune_json_output(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        now = datetime.now(timezone.utc)
+        _write_run(tmp_path, "run-old", updated_at=now - timedelta(days=10))
+
+        rc = main(["--output-format", "json", "runs", "prune", "--older-than", "7d", "--root", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["count"] == 1
+        assert "run-old" in data["pruned"]
+
+    def test_list_shows_runs(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        _write_run(tmp_path, "run-abc")
+        rc = main(["runs", "list", "--root", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "run-abc" in out
+
+    def test_list_empty(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["runs", "list", "--root", str(tmp_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No runs" in out
+
+    def test_invalid_duration_returns_error(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = main(["runs", "prune", "--older-than", "badval", "--root", str(tmp_path)])
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "invalid duration" in err


### PR DESCRIPTION
## Summary

- Adds `synthpanel runs list` to display saved panel run history
- Adds `synthpanel runs prune` to remove old checkpoint files and prevent unbounded growth
- Fixes unbounded accumulation of checkpoint files in the default data directory

## Test plan

- [x] 1802 unit tests pass
- [x] Coverage at 87.32% (above 80% threshold)
- [x] Rebased cleanly on top of current main

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)