### PR TITLE
fix(aggregation): propagate conditional skip-logic to aggregation stats (GH-316)

### DIFF
--- a/src/synth_panel/aggregation.py
+++ b/src/synth_panel/aggregation.py
@@ -189,16 +189,24 @@ def robustness_report(
         for group in scorable:
             if qi >= len(group.original.responses):
                 continue
+            orig_resp = group.original.responses[qi]
+            # No reference answer when the original itself was conditionally skipped.
+            if isinstance(orig_resp, dict) and orig_resp.get("skipped_by_condition"):
+                continue
 
-            ref = extract(group.original.responses[qi])
+            ref = extract(orig_resp)
 
             k = 0
             agreements = 0
             for v in group.variants:
                 if qi >= len(v.responses):
                     continue
+                v_resp = v.responses[qi]
+                # Don't count a variant that skipped this question by condition.
+                if isinstance(v_resp, dict) and v_resp.get("skipped_by_condition"):
+                    continue
                 k += 1
-                if extract(v.responses[qi]) == ref:
+                if extract(v_resp) == ref:
                     agreements += 1
 
             score = agreements / k if k > 0 else 0.0

--- a/src/synth_panel/analysis/inspect.py
+++ b/src/synth_panel/analysis/inspect.py
@@ -35,6 +35,7 @@ class PersonaSummary:
     response_count: int
     error_count: int
     panelist_error: str | None
+    skip_count: int = 0
 
 
 @dataclass
@@ -71,6 +72,7 @@ class FailureStats:
     failure_rate: float
     failed_panelists: int
     errored_personas: list[str]
+    skipped_follow_ups: int = 0
 
 
 @dataclass
@@ -207,6 +209,7 @@ def _collect_persona_summaries(panelists: list[dict[str, Any]]) -> list[PersonaS
         responses = p.get("responses") or []
         resp_count = sum(1 for r in responses if isinstance(r, dict))
         err_count = sum(1 for r in responses if isinstance(r, dict) and r.get("error") and not r.get("follow_up"))
+        skip_count = sum(1 for r in responses if isinstance(r, dict) and r.get("skipped_by_condition"))
         panelist_error = p.get("error")
         out.append(
             PersonaSummary(
@@ -215,6 +218,7 @@ def _collect_persona_summaries(panelists: list[dict[str, Any]]) -> list[PersonaS
                 response_count=resp_count,
                 error_count=err_count,
                 panelist_error=panelist_error if panelist_error else None,
+                skip_count=skip_count,
             )
         )
     return out
@@ -338,11 +342,13 @@ def _collect_failure_stats(
             failure_rate=float(fs.get("failure_rate", 0.0) or 0.0),
             failed_panelists=int(fs.get("failed_panelists", 0) or 0),
             errored_personas=list(fs.get("errored_personas") or []),
+            skipped_follow_ups=int(fs.get("skipped_follow_ups", 0) or 0),
         )
 
     total = 0
     errored = 0
     failed_panelists = 0
+    skipped_follow_ups = 0
     bad_personas: set[str] = set()
     for p in panelists:
         name = str(p.get("persona", "unknown"))
@@ -356,6 +362,8 @@ def _collect_failure_stats(
         bad = 0
         for resp in p.get("responses") or []:
             if not isinstance(resp, dict) or resp.get("follow_up"):
+                if isinstance(resp, dict) and resp.get("skipped_by_condition"):
+                    skipped_follow_ups += 1
                 continue
             seen += 1
             if resp.get("error"):
@@ -375,6 +383,7 @@ def _collect_failure_stats(
         failure_rate=rate,
         failed_panelists=failed_panelists,
         errored_personas=sorted(bad_personas),
+        skipped_follow_ups=skipped_follow_ups,
     )
 
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -2096,6 +2096,11 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             if r.get("error"):
                 print(f"  ERROR: {r['error']}")
             for resp in r["responses"]:
+                if resp.get("skipped_by_condition"):
+                    print(f"  [follow-up] Q: {resp['question']}")
+                    print("  [follow-up] A: (skipped — condition not met)")
+                    print()
+                    continue
                 prefix = "  [follow-up] " if resp.get("follow_up") else "  "
                 print(f"{prefix}Q: {resp['question']}")
                 print(f"{prefix}A: {resp['response']}")
@@ -2165,6 +2170,9 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 "cost line reflects that no tokens were billed)",
                 file=sys.stderr,
             )
+        skipped_fu = failure_stats.get("skipped_follow_ups", 0)
+        if skipped_fu:
+            print(f"  ({skipped_fu} follow-up(s) skipped by condition)")
         if banner:
             # Repeat the banner at the bottom so a scrolled terminal still
             # surfaces it — this is the critical fix for sp-2hg.
@@ -2495,15 +2503,21 @@ def _analyze_failures(
       - an individual response dict was flagged ``error: True`` (the
         orchestrator sets this when a per-question call raises).
 
+    Follow-ups skipped by condition (``skipped_by_condition: True``) are
+    excluded from both the numerator and denominator — they are intentional
+    non-answers, not failures.
+
     Returns a dict with ``total_pairs``, ``errored_pairs``,
     ``failure_rate`` (0-1), ``failed_panelists`` (panelist-level
-    failures) and ``errored_personas`` (names of affected personas).
+    failures), ``errored_personas`` (names of affected personas), and
+    ``skipped_follow_ups`` (total follow-ups skipped by condition).
     """
     total_questions = len(questions) if questions else 0
     total_pairs = 0
     errored_pairs = 0
     failed_panelists = 0
     errored_personas: set[str] = set()
+    skipped_follow_ups = 0
 
     for pr in panelist_results:
         if getattr(pr, "error", None):
@@ -2521,6 +2535,8 @@ def _analyze_failures(
             if isinstance(resp, dict) and resp.get("follow_up"):
                 # Follow-ups are not counted as primary QA pairs — they
                 # are second-order and would double-count toward the rate.
+                if resp.get("skipped_by_condition"):
+                    skipped_follow_ups += 1
                 continue
             pair_count += 1
             if isinstance(resp, dict) and resp.get("error"):
@@ -2544,6 +2560,7 @@ def _analyze_failures(
         "failure_rate": failure_rate,
         "failed_panelists": failed_panelists,
         "errored_personas": sorted(errored_personas),
+        "skipped_follow_ups": skipped_follow_ups,
     }
 
 

--- a/src/synth_panel/convergence.py
+++ b/src/synth_panel/convergence.py
@@ -132,10 +132,7 @@ def _lead_interpretation_for_uniform_skew(
     signal for panel operators.
     """
     if chi2_warning:
-        reliability = (
-            f"p={p_value:.4g} (approximate - {chi2_warning.rstrip('.')}); "
-            "treat effect size as directional."
-        )
+        reliability = f"p={p_value:.4g} (approximate - {chi2_warning.rstrip('.')}); treat effect size as directional."
     else:
         reliability = f"p={p_value:.4g} vs discrete uniform over {n_categories} categories (n={total_n})."
 

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -476,6 +476,15 @@ def _run_panelist(
                     sentiment_cache=sentiment_cache,
                     sentiment_cache_lock=sentiment_cache_lock,
                 ):
+                    responses.append(
+                        {
+                            "question": fu["text"],
+                            "response": None,
+                            "follow_up": True,
+                            "skipped_by_condition": True,
+                            "condition": condition,
+                        }
+                    )
                     continue
                 try:
                     fu_summary = runtime.run_turn(fu["text"])

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -208,6 +208,8 @@ def _format_panelist_data(
         name = result.persona_name
         parts.append(f"\n### {name}")
         for resp in result.responses:
+            if resp.get("skipped_by_condition"):
+                continue
             q_text = resp.get("question", "")
             answer = resp.get("response", "")
             is_follow_up = resp.get("follow_up", False)
@@ -562,6 +564,8 @@ def _filter_panelist_to_question(
 
     kept: list[dict[str, Any]] = []
     for resp in pr.responses:
+        if resp.get("skipped_by_condition"):
+            continue
         q = resp.get("question", "")
         if q == question_text:
             kept.append(resp)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1065,7 +1065,11 @@ class TestConditionalFollowUps:
             question_prompt_fn=_simple_question_prompt,
         )
 
-        assert len(results[0].responses) == 1
+        assert len(results[0].responses) == 2
+        stub = results[0].responses[1]
+        assert stub.get("skipped_by_condition") is True
+        assert stub.get("follow_up") is True
+        assert stub["response"] is None
 
     def test_response_contains_fires_on_match(self):
         """Follow-up fires when response contains the keyword."""
@@ -1119,7 +1123,11 @@ class TestConditionalFollowUps:
             question_prompt_fn=_simple_question_prompt,
         )
 
-        assert len(results[0].responses) == 1
+        assert len(results[0].responses) == 2
+        stub = results[0].responses[1]
+        assert stub.get("skipped_by_condition") is True
+        assert stub.get("follow_up") is True
+        assert stub["response"] is None
 
     def test_dict_follow_up_without_condition_defaults_always(self):
         """Dict follow-up missing condition key defaults to always."""
@@ -1189,14 +1197,17 @@ class TestConditionalFollowUps:
         )
 
         resp = results[0].responses
-        # Q1 main + 2 follow-ups (always + tools match) + Q2 main = 4
-        assert len(resp) == 4
+        # Q1 main + 2 answered follow-ups + 2 skipped stubs + Q2 main + 1 skipped stub = 7
+        assert len(resp) == 7
         assert resp[0]["question"] == "What's your testing workflow?"
         assert resp[1]["question"] == "What frameworks?"
         assert resp[1].get("follow_up") is True
         assert resp[2]["question"] == "Which tools?"
         assert resp[2].get("follow_up") is True
-        assert resp[3]["question"] == "Is there waste in your process?"
+        assert resp[3].get("skipped_by_condition") is True
+        assert resp[4].get("skipped_by_condition") is True
+        assert resp[5]["question"] == "Is there waste in your process?"
+        assert resp[6].get("skipped_by_condition") is True
 
     def test_structured_mode_with_conditional_follow_ups(self):
         """Follow-ups use text mode and evaluate conditions against serialized structured response."""
@@ -1234,7 +1245,9 @@ class TestConditionalFollowUps:
         responses = results[0].responses
         assert responses[0].get("structured") is True
         # Structured response serialized contains "positive" → first follow-up fires
-        # "terrible" is not in the serialized response → second follow-up skipped
-        assert len(responses) == 2
+        # "terrible" is not in the serialized response → second follow-up skipped (stub)
+        assert len(responses) == 3
         assert responses[1].get("follow_up") is True
         assert responses[1]["question"] == "Why positive?"
+        assert responses[2].get("skipped_by_condition") is True
+        assert responses[2]["question"] == "Why negative?"


### PR DESCRIPTION
## Summary

- Fixes conditional question skip-logic not being propagated to aggregation stats (GH-316)
- `conditions.py` correctly skips conditional questions per-persona; this PR fixes `aggregation.py` to distinguish answered, skipped-by-condition (excluded from denominator), and failed (included) states
- Summary surfaces skip rates separately

## Test plan

- [x] All existing tests pass (1779 passed)
- [x] Coverage above required 80% (87.50%)
- [x] Rebased on current main

🤖 Merged via [Claude Code](https://claude.com/claude-code) / GasTown refinery