### PR TITLE
feat(cli): cap third-party logs at WARNING; add --debug-all (GH #309)…

### DIFF
--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -63,7 +63,7 @@ def build_parser() -> argparse.ArgumentParser:
         "-v",
         action="store_true",
         default=False,
-        help="Enable verbose (DEBUG) logging.",
+        help="Enable DEBUG logs for synthpanel only (third-party SDK logs stay at WARNING).",
     )
     parser.add_argument(
         "--quiet",
@@ -71,6 +71,15 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Suppress most output; only show warnings and errors.",
+    )
+    parser.add_argument(
+        "--debug-all",
+        action="store_true",
+        default=False,
+        help=(
+            "Enable DEBUG for synthpanel and common third-party loggers (httpx, "
+            "httpcore, urllib3, MCP/websocket libs). Overrides --quiet / verbosity caps."
+        ),
     )
 
     # Subcommands

--- a/src/synth_panel/logging_config.py
+++ b/src/synth_panel/logging_config.py
@@ -1,12 +1,18 @@
 """Structured logging configuration for synthpanel.
 
 Provides a single ``setup_logging`` entry point that configures the
-Python logging hierarchy for the ``synth_panel`` namespace.  Verbosity
+Python logging hierarchy for the ``synth_panel`` namespace. Verbosity
 is resolved from (in priority order):
 
-1. Explicit *verbosity* argument (``"debug"`` / ``"warning"``).
-2. ``SYNTHPANEL_LOG_LEVEL`` environment variable.
-3. Default: ``INFO``.
+1. ``debug_all=True`` (CLI ``--debug-all``): synthpanel and known
+   third-party loggers at DEBUG.
+2. Explicit *verbosity* argument (``"debug"`` / ``"warning"``).
+3. ``SYNTHPANEL_LOG_LEVEL`` environment variable.
+4. Default: ``INFO``.
+
+Unless ``debug_all=True``, known chatty libraries (HTTP clients,
+MCP/websocket stacks) stay capped at WARNING so ``--verbose`` debugs
+``synth_panel`` only without drowning traces in SDK noise.
 """
 
 from __future__ import annotations
@@ -23,28 +29,50 @@ _VERBOSITY_MAP: dict[str, int] = {
 }
 
 
-def setup_logging(verbosity: str | None = None) -> None:
+# Roots for ecosystems that spam at INFO/DEBUG when left unchecked.
+_NOISY_LOGGERS: tuple[str, ...] = (
+    "httpcore",
+    "httpx",
+    "hpack",
+    "mcp",
+    "multipart",
+    "urllib3",
+    "websockets",
+)
+
+
+def setup_logging(verbosity: str | None = None, *, debug_all: bool = False) -> None:
     """Configure logging for the ``synth_panel`` package.
 
     Args:
         verbosity: One of ``"debug"``, ``"info"``, ``"warning"``.
-            When *None*, falls back to the ``SYNTHPANEL_LOG_LEVEL``
-            environment variable (case-insensitive), then to ``INFO``.
+            When *None*, falls back to ``SYNTHPANEL_LOG_LEVEL`` (case-insensitive),
+            then ``INFO``. Ignored for level picking when ``debug_all`` is True
+            (synthpanel always DEBUG in that mode).
+        debug_all: When True, elevate ``_NOISY_LOGGERS`` to DEBUG as well.
     """
-    if verbosity is not None:
-        level = _VERBOSITY_MAP.get(verbosity.lower(), logging.INFO)
+    if debug_all:
+        synth_level = logging.DEBUG
+        noisy_level = logging.DEBUG
+    elif verbosity is not None:
+        synth_level = _VERBOSITY_MAP.get(verbosity.lower(), logging.INFO)
+        noisy_level = logging.WARNING
     else:
         env = os.environ.get("SYNTHPANEL_LOG_LEVEL", "").strip().lower()
-        level = _VERBOSITY_MAP.get(env, logging.INFO)
+        synth_level = _VERBOSITY_MAP.get(env, logging.INFO)
+        noisy_level = logging.WARNING
 
     handler = logging.StreamHandler()
     handler.setFormatter(logging.Formatter(_LOG_FORMAT))
 
     logger = logging.getLogger("synth_panel")
-    logger.setLevel(level)
+    logger.setLevel(synth_level)
     # Avoid duplicate handlers if called more than once.
     if not logger.handlers:
         logger.addHandler(handler)
     else:
         logger.handlers[0].setFormatter(logging.Formatter(_LOG_FORMAT))
-        logger.setLevel(level)
+        logger.setLevel(synth_level)
+
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(noisy_level)

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -44,11 +44,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 
-    # Configure logging from --verbose / --quiet / env var.
-    if args.verbose:
-        setup_logging("debug")
+    # Configure logging from --debug-all / --quiet / --verbose / env var.
+    if getattr(args, "debug_all", False):
+        setup_logging(debug_all=True)
     elif args.quiet:
         setup_logging("warning")
+    elif args.verbose:
+        setup_logging("debug")
     else:
         setup_logging()
 

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,53 @@
+"""Tests for synth_panel.logging_config (CLI logging behavior)."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from synth_panel.logging_config import _NOISY_LOGGERS, setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_loggers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate tests from each other without changing package logger wiring."""
+    del logging.root.handlers[:]
+
+    monkeypatch.delenv("SYNTHPANEL_LOG_LEVEL", raising=False)
+
+    synth = logging.getLogger("synth_panel")
+    # Clear handlers synth_panel attaches in setup_logging between tests.
+    while synth.handlers:
+        synth.removeHandler(synth.handlers[-1])
+
+    for name in _NOISY_LOGGERS:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
+
+def test_default_info_synth_and_noisy_warning() -> None:
+    setup_logging()
+    assert logging.getLogger("synth_panel").getEffectiveLevel() == logging.INFO
+    for name in _NOISY_LOGGERS:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.WARNING
+
+
+def test_verbose_debug_synth_only_noisy_stays_warning() -> None:
+    setup_logging("debug")
+    assert logging.getLogger("synth_panel").getEffectiveLevel() == logging.DEBUG
+    for name in _NOISY_LOGGERS:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.WARNING
+
+
+def test_debug_all_elevates_noisy_libraries() -> None:
+    setup_logging(debug_all=True)
+    assert logging.getLogger("synth_panel").getEffectiveLevel() == logging.DEBUG
+    for name in _NOISY_LOGGERS:
+        assert logging.getLogger(name).getEffectiveLevel() == logging.DEBUG
+
+
+def test_env_syn_log_level_debug_does_not_flood_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SYNTHPANEL_LOG_LEVEL", "debug")
+    setup_logging()
+    assert logging.getLogger("synth_panel").getEffectiveLevel() == logging.DEBUG
+    assert logging.getLogger("httpx").getEffectiveLevel() == logging.WARNING


### PR DESCRIPTION
… (#332)

- synth_panel.DEBUG via -v/env leaves httpx/httpcore/MCP libs at WARNING
- Global --debug-all elevates noisy loggers to DEBUG for SDK tracing
- Tests cover defaults, verbose, debug-all, and SYNTHPANEL_LOG_LEVEL=debug

Made-with: Cursor

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
