### PR TITLE
feat(cli): add synthpanel doctor preflight without secret output (GH …

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -4615,3 +4615,99 @@ def handle_whoami(args: argparse.Namespace, fmt: OutputFormat) -> int:
         extra={"credentials_path": str(credentials_path()), "providers": rows},
     )
     return 0
+
+
+def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Preflight check for CI/scripts: sane runtime and credentials, no secret material in output."""
+    import os
+    import sys
+
+    from synth_panel import __version__
+    from synth_panel.credentials import (
+        KNOWN_CREDENTIAL_ENV_VARS,
+        PROVIDER_LABELS,
+        credentials_path,
+        has_credential,
+        load_credentials,
+    )
+
+    def _credential_row(env_var: str) -> dict[str, Any]:
+        env_set = bool(os.environ.get(env_var, "").strip())
+        disk = load_credentials()
+        stored_set = env_var in disk
+        source: str | None = None
+        if env_set:
+            source = "env"
+        elif stored_set:
+            source = "stored"
+        return {
+            "provider": PROVIDER_LABELS.get(env_var, env_var),
+            "env_var": env_var,
+            "available": has_credential(env_var),
+            "source": source,
+        }
+
+    dep_errors: list[str] = []
+    optional_notes: list[str] = []
+
+    try:
+        import httpx  # noqa: F401
+    except ImportError:
+        dep_errors.append("missing dependency: httpx")
+
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        dep_errors.append("missing dependency: pyyaml")
+
+    try:
+        import mcp  # noqa: F401
+    except ImportError:
+        optional_notes.append("optional: mcp not installed (`pip install synthpanel[mcp]`).")
+
+    provider_rows = [_credential_row(ev) for ev in KNOWN_CREDENTIAL_ENV_VARS]
+    any_provider = any(r["available"] for r in provider_rows)
+    checks_ok = not dep_errors and any_provider
+
+    extra: dict[str, Any] = {
+        "synthpanel_version": __version__,
+        "python_version": sys.version.split()[0],
+        "credentials_path": str(credentials_path()),
+        "providers": provider_rows,
+        "dependencies_ok": not dep_errors,
+        "dependency_errors": dep_errors,
+        "optional_notes": optional_notes,
+        "credential_configured": any_provider,
+        "checks_ok": checks_ok,
+    }
+
+    rc = 0 if checks_ok else 1
+
+    if fmt is OutputFormat.TEXT:
+        print(f"synthpanel {__version__} (Python {sys.version.split()[0]})")
+        if dep_errors:
+            print("Issues:", file=sys.stderr)
+            for msg in dep_errors:
+                print(f"  - {msg}", file=sys.stderr)
+        if optional_notes:
+            for msg in optional_notes:
+                print(f"Note: {msg}")
+        print(f"Credential store: {credentials_path()}")
+        if any_provider:
+            print("Configured providers:")
+            for row in provider_rows:
+                if not row["available"]:
+                    continue
+                print(f"  [{row['source']}] {row['env_var']} — {row['provider']}")
+        else:
+            print("No LLM credentials found (env or stored). Run `synthpanel login`.", file=sys.stderr)
+        if rc != 0:
+            print("doctor: preflight failed", file=sys.stderr)
+        return rc
+
+    emit(
+        fmt,
+        message="doctor_report",
+        extra=extra,
+    )
+    return rc

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1055,4 +1055,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show which providers have credentials available (env or stored).",
     )
 
+    subparsers.add_parser(
+        "doctor",
+        help=(
+            "Preflight diagnostics: runtime, deps, and provider credentials "
+            "(never prints secrets; exits 1 if no provider credential is configured)."
+        ),
+    )
+
     return parser

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -11,6 +11,7 @@ import sys
 from synth_panel.cli.commands import (
     handle_analyze,
     handle_cost_summary,
+    handle_doctor,
     handle_instruments_graph,
     handle_instruments_install,
     handle_instruments_list,
@@ -121,6 +122,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_logout(args, output_format)
     elif args.command == "whoami":
         return handle_whoami(args, output_format)
+    elif args.command == "doctor":
+        return handle_doctor(args, output_format)
     else:
         # No subcommand → interactive REPL
         return run_repl(args, output_format)

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -167,6 +167,90 @@ class TestLogout:
         assert "No stored credential" in capsys.readouterr().out
 
 
+class TestDoctor:
+    """synthpanel doctor preflight — must never leak credentials (GH #310)."""
+
+    def test_doctor_is_registered(self):
+        parser = build_parser()
+        args = parser.parse_args(["doctor"])
+        assert args.command == "doctor"
+
+    def test_doctor_fails_when_no_credentials(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        rc = main(["doctor"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "No LLM credentials found" in err
+
+    def test_doctor_passes_when_env_credentials_set(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-do-not-leak-this-value")
+        rc = main(["doctor"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "sk-ant-do-not-leak-this-value" not in combined
+        assert "do-not-leak" not in combined
+
+    def test_doctor_never_echoes_stored_credentials(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        save_credential("OPENAI_API_KEY", "sk-stored-ultra-secret-999")
+        rc = main(["doctor"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert "sk-stored-ultra-secret-999" not in combined
+        assert "ultra-secret" not in combined
+
+    def test_doctor_json_has_no_secret_values(self, capsys, monkeypatch):
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setenv("XAI_API_KEY", "xai-json-secret-banned")
+        rc = main(["--output-format", "json", "doctor"])
+        assert rc == 0
+        raw = capsys.readouterr().out
+        assert "xai-json-secret-banned" not in raw
+        payload = json.loads(raw)
+        assert payload["message"] == "doctor_report"
+        assert payload["credential_configured"] is True
+        assert payload["checks_ok"] is True
+        dumped = json.dumps(payload)
+        assert "xai-json-secret-banned" not in dumped
+
+
 class TestWhoami:
     def test_whoami_reports_no_credentials(self, capsys, monkeypatch):
         for env in (


### PR DESCRIPTION
…#310, sp-4y5.3) (#333)

- New doctor command: runtime/deps snapshot, provider credential presence
- Text/json/ndjson emit only env var names and sources, never key material
- Exit 1 when no LLM credential is configured (CI-friendly)
- Tests assert stdout/stderr/json never contain known secret substrings

Made-with: Cursor

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
