### PR TITLE
feat(cli): add runs diff subcommand for statistical panel comparison …

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -69,6 +69,7 @@ from synth_panel.cost import (
     lookup_pricing,
 )
 from synth_panel.credentials import has_credential
+from synth_panel.diff import CategoricalQuestionDiff, RunDiff, TextQuestionDiff
 from synth_panel.instrument import Instrument, InstrumentError, parse_instrument
 from synth_panel.llm.client import LLMClient
 from synth_panel.metadata import PanelTimer, build_metadata
@@ -1725,9 +1726,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     else:
         # Show a live progress bar when the user is watching a TTY in text mode.
         _show_progress = fmt is OutputFormat.TEXT and sys.stdout.isatty() and bool(active_personas)
-        progress: PanelProgressBar | None = (
-            PanelProgressBar(len(active_personas), model) if _show_progress else None
-        )
+        progress: PanelProgressBar | None = PanelProgressBar(len(active_personas), model) if _show_progress else None
 
         def _on_complete(pr: PanelistResult) -> None:
             if checkpoint_writer is not None:
@@ -4835,3 +4834,160 @@ def handle_runs_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     emit(fmt, message="runs_list", extra={"runs": runs, "count": len(runs)})
     return 0
+
+
+def handle_runs_diff(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Compare two saved panel results statistically."""
+    from synth_panel.diff import (
+        compute_diff,
+        load_result,
+    )
+
+    try:
+        result_a = load_result(args.result_a)
+    except FileNotFoundError:
+        print(f"error: result not found: {args.result_a}", file=sys.stderr)
+        return 1
+
+    try:
+        result_b = load_result(args.result_b)
+    except FileNotFoundError:
+        print(f"error: result not found: {args.result_b}", file=sys.stderr)
+        return 1
+
+    diff = compute_diff(result_a, result_b)
+    m = diff.metadata
+
+    if fmt is OutputFormat.TEXT:
+        _print_runs_diff_text(diff)
+        return 0
+
+    # JSON / NDJSON output
+    cat_out = [
+        {
+            "question_key": q.question_key,
+            "question_text": q.question_text,
+            "type": "categorical",
+            "jsd": round(q.jsd, 4),
+            "cramers_v_a": round(q.cramers_v_a, 4) if q.cramers_v_a is not None else None,
+            "cramers_v_b": round(q.cramers_v_b, 4) if q.cramers_v_b is not None else None,
+            "distribution_a": q.distribution_a,
+            "distribution_b": q.distribution_b,
+        }
+        for q in diff.categorical_questions
+    ]
+    text_out = [
+        {
+            "question_key": q.question_key,
+            "question_text": q.question_text,
+            "type": "text",
+            "top_themes_a": q.top_themes_a,
+            "top_themes_b": q.top_themes_b,
+            "new_themes": q.new_themes,
+            "dropped_themes": q.dropped_themes,
+        }
+        for q in diff.text_questions
+    ]
+    emit(
+        fmt,
+        message="runs_diff",
+        extra={
+            "result_a": m.result_a_id,
+            "result_b": m.result_b_id,
+            "metadata": {
+                "created_at_a": m.created_at_a,
+                "created_at_b": m.created_at_b,
+                "model_a": m.model_a,
+                "model_b": m.model_b,
+                "persona_count_a": m.persona_count_a,
+                "persona_count_b": m.persona_count_b,
+                "question_count_a": m.question_count_a,
+                "question_count_b": m.question_count_b,
+                "cost_a": m.cost_a,
+                "cost_b": m.cost_b,
+                "usage_a": m.usage_a,
+                "usage_b": m.usage_b,
+            },
+            "categorical_questions": cat_out,
+            "text_questions": text_out,
+        },
+    )
+    return 0
+
+
+def _print_runs_diff_text(diff: RunDiff) -> None:
+    """Print a human-readable diff to stdout."""
+    m = diff.metadata
+
+    def _field(label: str, a: object, b: object) -> str:
+        eq = "=" if str(a) == str(b) else "→"
+        return f"  {label:<16} {a!s:<18} {eq}  {b}"
+
+    print(f"Run A: {m.result_a_id}  ({m.created_at_a})")
+    print(f"Run B: {m.result_b_id}  ({m.created_at_b})")
+    print()
+    print("── Metadata " + "─" * 40)
+    print(_field("Model", m.model_a, m.model_b))
+    print(_field("Personas", m.persona_count_a, m.persona_count_b))
+    print(_field("Questions", m.question_count_a, m.question_count_b))
+    print(_field("Cost", m.cost_a or "—", m.cost_b or "—"))
+
+    if not diff.categorical_questions and not diff.text_questions:
+        print()
+        print("(No question-level data available for comparison.)")
+        return
+
+    if diff.categorical_questions:
+        print()
+        print("── Categorical questions " + "─" * 27)
+        for q in diff.categorical_questions:
+            _print_categorical_diff(q)
+
+    if diff.text_questions:
+        print()
+        print("── Text questions " + "─" * 34)
+        for q in diff.text_questions:
+            _print_text_diff(q)
+
+
+def _pct_bar(dist: dict[str, int]) -> str:
+    total = sum(dist.values()) or 1
+    parts = [f"{k}={round(100 * v / total)}%" for k, v in sorted(dist.items())]
+    return "  ".join(parts)
+
+
+def _print_categorical_diff(q: CategoricalQuestionDiff) -> None:
+    text = q.question_text[:72] + ("…" if len(q.question_text) > 72 else "")
+    print(f"\n  [{q.question_key}] {text}")
+
+    if q.jsd < 0.05:
+        shift = "stable"
+    elif q.jsd < 0.15:
+        shift = "small shift"
+    elif q.jsd < 0.30:
+        shift = "moderate shift"
+    else:
+        shift = "large shift"
+    print(f"    JSD: {q.jsd:.3f}  ({shift})")
+
+    if q.distribution_a:
+        print(f"    Run A: {_pct_bar(q.distribution_a)}")
+    else:
+        print("    Run A: (no data)")
+    if q.distribution_b:
+        print(f"    Run B: {_pct_bar(q.distribution_b)}")
+    else:
+        print("    Run B: (no data)")
+
+
+def _print_text_diff(q: TextQuestionDiff) -> None:
+    text = q.question_text[:72] + ("…" if len(q.question_text) > 72 else "")
+    print(f"\n  [{q.question_key}] {text}")
+    if q.top_themes_a:
+        print(f"    Themes A: {', '.join(q.top_themes_a[:8])}")
+    if q.top_themes_b:
+        print(f"    Themes B: {', '.join(q.top_themes_b[:8])}")
+    if q.new_themes:
+        print(f"    New in B: {', '.join(q.new_themes)}")
+    if q.dropped_themes:
+        print(f"    Gone in B: {', '.join(q.dropped_themes)}")

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1115,4 +1115,20 @@ def build_parser() -> argparse.ArgumentParser:
         help="Checkpoint root directory (default: $SYNTHPANEL_CHECKPOINT_ROOT or ~/.synthpanel/checkpoints).",
     )
 
+    # runs diff
+    runs_diff_parser = runs_subparsers.add_parser(
+        "diff",
+        help="Compare two saved panel results statistically.",
+    )
+    runs_diff_parser.add_argument(
+        "result_a",
+        metavar="RESULT_A",
+        help="First result ID or path to result JSON file.",
+    )
+    runs_diff_parser.add_argument(
+        "result_b",
+        metavar="RESULT_B",
+        help="Second result ID or path to result JSON file.",
+    )
+
     return parser

--- a/src/synth_panel/diff.py
+++ b/src/synth_panel/diff.py
@@ -1,0 +1,331 @@
+"""Diff two saved panel results (sy-1b3n / GH-349)."""
+
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from synth_panel.convergence import (
+    extract_category,
+    identify_tracked_questions,
+    jensen_shannon_divergence,
+)
+from synth_panel.stats import chi_squared_test
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MetadataDiff:
+    result_a_id: str
+    result_b_id: str
+    created_at_a: str
+    created_at_b: str
+    model_a: str
+    model_b: str
+    persona_count_a: int
+    persona_count_b: int
+    question_count_a: int
+    question_count_b: int
+    cost_a: str
+    cost_b: str
+    usage_a: dict[str, Any]
+    usage_b: dict[str, Any]
+
+
+@dataclass
+class CategoricalQuestionDiff:
+    question_text: str
+    question_key: str
+    distribution_a: dict[str, int]
+    distribution_b: dict[str, int]
+    jsd: float
+    cramers_v_a: float | None
+    cramers_v_b: float | None
+
+
+@dataclass
+class TextQuestionDiff:
+    question_text: str
+    question_key: str
+    top_themes_a: list[str]
+    top_themes_b: list[str]
+    new_themes: list[str]
+    dropped_themes: list[str]
+
+
+@dataclass
+class RunDiff:
+    metadata: MetadataDiff
+    categorical_questions: list[CategoricalQuestionDiff] = field(default_factory=list)
+    text_questions: list[TextQuestionDiff] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def load_result(id_or_path: str) -> dict[str, Any]:
+    """Load a panel result by ID or file path.
+
+    Raises FileNotFoundError if neither path nor ID resolves.
+    """
+    p = Path(id_or_path)
+    if p.exists():
+        data = json.loads(p.read_text(encoding="utf-8"))
+        if "id" not in data:
+            data["id"] = p.stem
+        return data
+    # Path-like strings (contain separator or extension) that don't exist as files
+    # should raise FileNotFoundError rather than fall through to the ID lookup,
+    # which would raise a misleading ValueError on path-traversal validation.
+    if "/" in id_or_path or p.suffix:
+        raise FileNotFoundError(f"Result file not found: {id_or_path!r}")
+    from synth_panel.mcp.data import get_panel_result
+
+    return get_panel_result(id_or_path)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+_STOP_WORDS: frozenset[str] = frozenset(
+    {
+        "the",
+        "a",
+        "an",
+        "and",
+        "or",
+        "but",
+        "in",
+        "on",
+        "at",
+        "to",
+        "for",
+        "of",
+        "with",
+        "by",
+        "from",
+        "as",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "have",
+        "has",
+        "had",
+        "do",
+        "does",
+        "did",
+        "will",
+        "would",
+        "could",
+        "should",
+        "may",
+        "might",
+        "can",
+        "i",
+        "my",
+        "me",
+        "we",
+        "our",
+        "you",
+        "your",
+        "it",
+        "its",
+        "this",
+        "that",
+        "these",
+        "those",
+        "not",
+        "no",
+        "so",
+        "if",
+        "when",
+        "what",
+        "how",
+        "why",
+        "which",
+        "who",
+        "just",
+        "also",
+        "more",
+        "very",
+        "much",
+        "like",
+        "really",
+        "about",
+        "there",
+        "their",
+        "they",
+        "them",
+        "then",
+        "than",
+    }
+)
+
+
+def _question_key(question: Any, index: int) -> str:
+    if not isinstance(question, dict):
+        return f"q{index}"
+    for candidate in ("key", "id", "name"):
+        val = question.get(candidate)
+        if isinstance(val, str) and val:
+            return val
+    text = question.get("text")
+    if isinstance(text, str) and text:
+        return text.strip()[:40] or f"q{index}"
+    return f"q{index}"
+
+
+def _main_responses(panelist: dict[str, Any]) -> list[dict[str, Any]]:
+    return [r for r in panelist.get("responses", []) if isinstance(r, dict) and not r.get("follow_up")]
+
+
+def _build_categorical_dist(
+    panelists: list[dict[str, Any]],
+    q_idx: int,
+) -> dict[str, int]:
+    dist: dict[str, int] = {}
+    for p in panelists:
+        responses = _main_responses(p)
+        if q_idx < len(responses):
+            cat = extract_category(responses[q_idx])
+            if cat is not None:
+                dist[cat] = dist.get(cat, 0) + 1
+    return dist
+
+
+def _extract_text_responses(
+    panelists: list[dict[str, Any]],
+    q_idx: int,
+) -> list[str]:
+    texts: list[str] = []
+    for p in panelists:
+        responses = _main_responses(p)
+        if q_idx < len(responses):
+            resp = responses[q_idx].get("response", "")
+            if isinstance(resp, str) and resp.strip():
+                texts.append(resp.strip())
+    return texts
+
+
+def _top_words(texts: list[str], n: int = 10) -> list[str]:
+    words: list[str] = []
+    for text in texts:
+        for raw in text.lower().split():
+            word = raw.strip(".,!?;:\"'()-[]")
+            if len(word) >= 4 and word not in _STOP_WORDS:
+                words.append(word)
+    return [w for w, _ in Counter(words).most_common(n)]
+
+
+def _cramers_v(dist: dict[str, int]) -> float | None:
+    if not dist or sum(dist.values()) == 0:
+        return None
+    try:
+        return chi_squared_test(dist).cramers_v
+    except ValueError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Core diff computation
+# ---------------------------------------------------------------------------
+
+
+def compute_diff(
+    result_a: dict[str, Any],
+    result_b: dict[str, Any],
+) -> RunDiff:
+    """Compute a diff between two saved panel results."""
+    metadata = MetadataDiff(
+        result_a_id=result_a.get("id", ""),
+        result_b_id=result_b.get("id", ""),
+        created_at_a=result_a.get("created_at", ""),
+        created_at_b=result_b.get("created_at", ""),
+        model_a=result_a.get("model", ""),
+        model_b=result_b.get("model", ""),
+        persona_count_a=result_a.get("persona_count", 0),
+        persona_count_b=result_b.get("persona_count", 0),
+        question_count_a=result_a.get("question_count", 0),
+        question_count_b=result_b.get("question_count", 0),
+        cost_a=result_a.get("total_cost", ""),
+        cost_b=result_b.get("total_cost", ""),
+        usage_a=result_a.get("total_usage", {}),
+        usage_b=result_b.get("total_usage", {}),
+    )
+
+    questions_a = result_a.get("questions") or []
+    questions_b = result_b.get("questions") or []
+    panelists_a = result_a.get("results") or []
+    panelists_b = result_b.get("results") or []
+
+    # Use longer question list as reference; fall back to question count
+    questions = questions_a if len(questions_a) >= len(questions_b) else questions_b
+    if not questions:
+        # No question metadata saved — nothing to diff per-question
+        return RunDiff(metadata=metadata)
+
+    tracked = identify_tracked_questions(questions)
+    tracked_indices = {idx for idx, _, _ in tracked}
+
+    categorical: list[CategoricalQuestionDiff] = []
+    text_qs: list[TextQuestionDiff] = []
+
+    for i, q in enumerate(questions):
+        q_text = q.get("text", f"Question {i + 1}") if isinstance(q, dict) else f"Question {i + 1}"
+        q_key = _question_key(q, i)
+
+        if i in tracked_indices:
+            dist_a = _build_categorical_dist(panelists_a, i)
+            dist_b = _build_categorical_dist(panelists_b, i)
+            jsd = jensen_shannon_divergence(
+                {k: float(v) for k, v in dist_a.items()},
+                {k: float(v) for k, v in dist_b.items()},
+            )
+            categorical.append(
+                CategoricalQuestionDiff(
+                    question_text=q_text,
+                    question_key=q_key,
+                    distribution_a=dist_a,
+                    distribution_b=dist_b,
+                    jsd=jsd,
+                    cramers_v_a=_cramers_v(dist_a),
+                    cramers_v_b=_cramers_v(dist_b),
+                )
+            )
+        else:
+            texts_a = _extract_text_responses(panelists_a, i)
+            texts_b = _extract_text_responses(panelists_b, i)
+            top_a = _top_words(texts_a)
+            top_b = _top_words(texts_b)
+            set_a = set(top_a)
+            set_b = set(top_b)
+            text_qs.append(
+                TextQuestionDiff(
+                    question_text=q_text,
+                    question_key=q_key,
+                    top_themes_a=top_a,
+                    top_themes_b=top_b,
+                    new_themes=[w for w in top_b if w not in set_a][:5],
+                    dropped_themes=[w for w in top_a if w not in set_b][:5],
+                )
+            )
+
+    return RunDiff(
+        metadata=metadata,
+        categorical_questions=categorical,
+        text_questions=text_qs,
+    )

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -32,6 +32,7 @@ from synth_panel.cli.commands import (
     handle_panel_synthesize,
     handle_prompt,
     handle_report,
+    handle_runs_diff,
     handle_runs_list,
     handle_runs_prune,
     handle_whoami,
@@ -132,6 +133,8 @@ def main(argv: list[str] | None = None) -> int:
             return handle_runs_prune(args, output_format)
         elif sub == "list":
             return handle_runs_list(args, output_format)
+        elif sub == "diff":
+            return handle_runs_diff(args, output_format)
         else:
             parser.parse_args(["runs", "--help"])
             return 1

--- a/tests/test_runs_diff.py
+++ b/tests/test_runs_diff.py
@@ -1,0 +1,233 @@
+"""Tests for runs diff subcommand (sy-1b3n / GH-349)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from synth_panel.diff import compute_diff, load_result
+from synth_panel.main import main
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _panelist(name: str, responses: list[dict]) -> dict:
+    return {"name": name, "responses": responses}
+
+
+def _text_resp(question: str, text: str) -> dict:
+    return {"question": question, "response": text, "follow_up": False}
+
+
+def _structured_resp(question: str, value: object) -> dict:
+    """Structured categorical response (a dict body extract_category can read).
+
+    Uses "rating" as the key — a member of _BOUNDED_KEYS — so extract_category
+    returns the raw string value rather than JSON-serializing the whole dict.
+    """
+    return {"question": question, "response": {"rating": str(value)}, "follow_up": False}
+
+
+def _make_result(
+    rid: str,
+    model: str,
+    questions: list[dict],
+    panelists: list[dict],
+    **extra,
+) -> dict:
+    return {
+        "id": rid,
+        "model": model,
+        "persona_count": len(panelists),
+        "question_count": len(questions),
+        "created_at": "2026-04-30T00:00:00Z",
+        "total_cost": "$0.01",
+        "total_usage": {"input": 100, "output": 50},
+        "questions": questions,
+        "results": panelists,
+        **extra,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Synthetic fixtures
+# ---------------------------------------------------------------------------
+
+Q_TEXT = "What frustrates you most about the product?"
+Q_ENUM = "How satisfied are you with the product?"
+
+_QUESTIONS_TEXT = [{"text": Q_TEXT, "response_schema": {"type": "text"}}]
+_QUESTIONS_ENUM = [
+    {
+        "text": Q_ENUM,
+        "response_schema": {"type": "enum", "options": ["satisfied", "neutral", "dissatisfied"]},
+    }
+]
+
+# Run A: workflow/interface frustrations
+RESULT_A_TEXT = _make_result(
+    rid="run_a",
+    model="claude-sonnet-4-6",
+    questions=_QUESTIONS_TEXT,
+    panelists=[
+        _panelist("Alice", [_text_resp(Q_TEXT, "The workflow interface feels clunky and confusing")]),
+        _panelist("Bob", [_text_resp(Q_TEXT, "Interface navigation takes too many clicks to complete tasks")]),
+        _panelist("Carol", [_text_resp(Q_TEXT, "Workflow steps are not intuitive or clear enough")]),
+    ],
+)
+
+# Run B: pricing frustrations (different themes)
+RESULT_B_TEXT = _make_result(
+    rid="run_b",
+    model="claude-haiku-4-5",
+    questions=_QUESTIONS_TEXT,
+    panelists=[
+        _panelist("Dave", [_text_resp(Q_TEXT, "The pricing model feels expensive and unclear")]),
+        _panelist("Eve", [_text_resp(Q_TEXT, "Cost structure makes budgeting difficult for teams")]),
+        _panelist("Frank", [_text_resp(Q_TEXT, "Pricing tiers are confusing and expensive compared to alternatives")]),
+    ],
+)
+
+# Run A: mostly satisfied
+RESULT_A_ENUM = _make_result(
+    rid="run_a_enum",
+    model="claude-sonnet-4-6",
+    questions=_QUESTIONS_ENUM,
+    panelists=[
+        _panelist("Alice", [_structured_resp(Q_ENUM, "satisfied")]),
+        _panelist("Bob", [_structured_resp(Q_ENUM, "satisfied")]),
+        _panelist("Carol", [_structured_resp(Q_ENUM, "neutral")]),
+    ],
+)
+
+# Run B: shift toward dissatisfied
+RESULT_B_ENUM = _make_result(
+    rid="run_b_enum",
+    model="claude-haiku-4-5",
+    questions=_QUESTIONS_ENUM,
+    panelists=[
+        _panelist("Dave", [_structured_resp(Q_ENUM, "dissatisfied")]),
+        _panelist("Eve", [_structured_resp(Q_ENUM, "dissatisfied")]),
+        _panelist("Frank", [_structured_resp(Q_ENUM, "neutral")]),
+    ],
+)
+
+RESULT_EMPTY = _make_result(
+    rid="run_empty",
+    model="claude-sonnet-4-6",
+    questions=[],
+    panelists=[],
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_diff unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiff:
+    def test_metadata_fields(self) -> None:
+        diff = compute_diff(RESULT_A_TEXT, RESULT_B_TEXT)
+        m = diff.metadata
+        assert m.result_a_id == "run_a"
+        assert m.result_b_id == "run_b"
+        assert m.model_a == "claude-sonnet-4-6"
+        assert m.model_b == "claude-haiku-4-5"
+        assert m.persona_count_a == 3
+        assert m.persona_count_b == 3
+
+    def test_text_question_diff(self) -> None:
+        diff = compute_diff(RESULT_A_TEXT, RESULT_B_TEXT)
+        assert len(diff.text_questions) == 1
+        assert len(diff.categorical_questions) == 0
+        q = diff.text_questions[0]
+        assert q.question_key  # non-empty
+        # Run A themes should mention interface/workflow; B should mention pricing
+        assert q.top_themes_a  # has themes
+        assert q.top_themes_b  # has themes
+        # New themes in B should include pricing-related words not in A
+        assert any("pric" in t for t in q.new_themes + q.top_themes_b)
+
+    def test_categorical_question_diff(self) -> None:
+        diff = compute_diff(RESULT_A_ENUM, RESULT_B_ENUM)
+        assert len(diff.categorical_questions) == 1
+        assert len(diff.text_questions) == 0
+        q = diff.categorical_questions[0]
+        assert 0.0 <= q.jsd <= 1.0
+        assert "satisfied" in q.distribution_a or "neutral" in q.distribution_a
+        assert "dissatisfied" in q.distribution_b or "neutral" in q.distribution_b
+        # Distribution shifted — JSD should be non-zero
+        assert q.jsd > 0
+
+    def test_no_question_data(self) -> None:
+        diff = compute_diff(RESULT_EMPTY, RESULT_EMPTY)
+        assert diff.categorical_questions == []
+        assert diff.text_questions == []
+
+
+class TestLoadResult:
+    def test_load_from_path(self, tmp_path: Path) -> None:
+        result_file = tmp_path / "run_x.json"
+        result_file.write_text(json.dumps(RESULT_A_TEXT), encoding="utf-8")
+        loaded = load_result(str(result_file))
+        assert loaded["id"] == "run_a"
+
+    def test_load_injects_stem_as_id(self, tmp_path: Path) -> None:
+        data = {k: v for k, v in RESULT_A_TEXT.items() if k != "id"}
+        f = tmp_path / "my_run.json"
+        f.write_text(json.dumps(data), encoding="utf-8")
+        loaded = load_result(str(f))
+        assert loaded["id"] == "my_run"
+
+    def test_load_missing_path_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_result("/nonexistent/path/result.json")
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunsDiffCLI:
+    def test_text_mode(self, tmp_path: Path) -> None:
+        a_path = tmp_path / "run_a.json"
+        b_path = tmp_path / "run_b.json"
+        a_path.write_text(json.dumps(RESULT_A_TEXT), encoding="utf-8")
+        b_path.write_text(json.dumps(RESULT_B_TEXT), encoding="utf-8")
+        rc = main(["runs", "diff", str(a_path), str(b_path)])
+        assert rc == 0
+
+    def test_json_mode(self, tmp_path: Path, capsys) -> None:
+        a_path = tmp_path / "run_a_enum.json"
+        b_path = tmp_path / "run_b_enum.json"
+        a_path.write_text(json.dumps(RESULT_A_ENUM), encoding="utf-8")
+        b_path.write_text(json.dumps(RESULT_B_ENUM), encoding="utf-8")
+        rc = main(["--output-format", "json", "runs", "diff", str(a_path), str(b_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        # emit() merges the extra dict directly into the top-level payload.
+        assert payload["message"] == "runs_diff"
+        assert payload["result_a"] == "run_a_enum"
+        assert payload["result_b"] == "run_b_enum"
+        cat_qs = payload["categorical_questions"]
+        assert len(cat_qs) == 1
+        assert "jsd" in cat_qs[0]
+        assert 0.0 <= cat_qs[0]["jsd"] <= 1.0
+
+    def test_missing_result_a(self, tmp_path: Path) -> None:
+        b_path = tmp_path / "run_b.json"
+        b_path.write_text(json.dumps(RESULT_B_TEXT), encoding="utf-8")
+        rc = main(["runs", "diff", "/no/such/file.json", str(b_path)])
+        assert rc == 1
+
+    def test_missing_result_b(self, tmp_path: Path) -> None:
+        a_path = tmp_path / "run_a.json"
+        a_path.write_text(json.dumps(RESULT_A_TEXT), encoding="utf-8")
+        rc = main(["runs", "diff", str(a_path), "/no/such/file.json"])
+        assert rc == 1


### PR DESCRIPTION
…(GH-349) [retroactive] (#363)

* feat(cli): add runs diff subcommand for statistical panel comparison (GH-349)

Adds `synthpanel runs diff <run-a> <run-b>` to compare two saved panel results. Categorical (enum/scaled/pick-one) questions get JSD + Cramer's V; text questions get top-word theme diff with new/dropped highlights. Both text and JSON output modes are supported.

- src/synth_panel/diff.py: core diff logic (load, compute, data models)
- src/synth_panel/cli/parser.py: `runs diff` subparser
- src/synth_panel/cli/commands.py: handle_runs_diff + text/json formatters
- src/synth_panel/main.py: wire dispatch for `runs diff`
- tests/test_runs_diff.py: 11 tests covering compute_diff, load_result, CLI

* style: fix missing diff imports + ruff formatting

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
