### PR TITLE
feat(checkpoint): add schema_version field + migration registry (GH-3…

### DIFF
--- a/src/synth_panel/checkpoint.py
+++ b/src/synth_panel/checkpoint.py
@@ -49,6 +49,7 @@ from pathlib import Path
 from typing import Any
 
 from synth_panel.cost import coerce_provider_reported_cost
+from synth_panel.metadata_migrations import CURRENT_SCHEMA_VERSION, migrate_to_current
 
 logger = logging.getLogger(__name__)
 
@@ -80,6 +81,14 @@ class CheckpointDriftError(CheckpointError):
     Resuming under a changed instrument/persona/model mix would silently
     produce a mixed-config dataset — not what "resume" promises. Refuse
     rather than paper over it.
+    """
+
+
+class CheckpointSchemaTooNewError(CheckpointError):
+    """Raised when a checkpoint was written by a newer synthpanel version.
+
+    The on-disk schema_version exceeds what this installation understands.
+    The caller should tell the user to upgrade synthpanel.
     """
 
 
@@ -163,7 +172,7 @@ class PanelCheckpoint:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "version": 1,
+            "schema_version": CURRENT_SCHEMA_VERSION,
             "run_id": self.run_id,
             "created_at": self.created_at,
             "updated_at": self.updated_at,
@@ -240,6 +249,10 @@ def load_checkpoint(run_id: str, root: Path | None = None) -> PanelCheckpoint:
         raise CheckpointFormatError(f"checkpoint at {path} is not valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise CheckpointFormatError(f"checkpoint at {path} is not a JSON object")
+    try:
+        data = migrate_to_current(data)
+    except ValueError as exc:
+        raise CheckpointSchemaTooNewError(str(exc)) from exc
     return PanelCheckpoint.from_dict(data)
 
 

--- a/src/synth_panel/metadata_migrations.py
+++ b/src/synth_panel/metadata_migrations.py
@@ -1,0 +1,70 @@
+"""On-disk schema-version migrations for PanelCheckpoint records.
+
+When a checkpoint was written by an older synthpanel, this module
+brings it up to CURRENT_SCHEMA_VERSION so the rest of the codebase
+can assume the latest shape.
+
+Version history
+---------------
+v1 — synthpanel 0.11.x initial checkpointing (sp-hsk3); no cli_args field.
+v2 — synthpanel 0.12.x; cli_args added (sy-ws76); best_model_for flag added.
+     Absent or legacy ``version: 1`` key → treated as v1.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+CURRENT_SCHEMA_VERSION: int = 2
+
+
+def migrate_v1_to_v2(old: dict[str, Any]) -> dict[str, Any]:
+    """Migrate a v1 checkpoint (synthpanel 0.11.x) to v2 schema.
+
+    v1 checkpoints predate the cli_args field (added in sy-ws76 for bare
+    ``--resume <id>`` support). Missing optional fields receive safe defaults
+    so ``PanelCheckpoint.from_dict`` always gets a complete record.
+    """
+    result = dict(old)
+    result.setdefault("cli_args", None)
+    result.setdefault("completed", [])
+    result.setdefault("remaining", [])
+    result.setdefault("usage", {})
+    result.setdefault("abort_reason", None)
+    result["schema_version"] = 2
+    return result
+
+
+# Each entry: (from_version, migration_fn).  Apply all entries where
+# from_version >= the checkpoint's current version.
+_CHAIN: list[tuple[int, Any]] = [
+    (1, migrate_v1_to_v2),
+]
+
+
+def migrate_to_current(data: dict[str, Any]) -> dict[str, Any]:
+    """Return *data* migrated to :data:`CURRENT_SCHEMA_VERSION`.
+
+    Reads ``schema_version`` (absent, or legacy ``version`` key) — treats
+    missing / zero as v1.  Applies all pending migrations in order and
+    returns the updated dict.  Returns *data* unchanged when already at
+    the current version.
+
+    Raises ``ValueError`` if ``schema_version`` exceeds
+    :data:`CURRENT_SCHEMA_VERSION` — caller should convert to an
+    appropriate domain error.
+    """
+    version = int(data.get("schema_version") or data.get("version") or 1)
+    if version > CURRENT_SCHEMA_VERSION:
+        raise ValueError(
+            f"checkpoint schema_version {version} is newer than this synthpanel "
+            f"installation (max supported: v{CURRENT_SCHEMA_VERSION}). "
+            f"Upgrade synthpanel to resume this run."
+        )
+    if version == CURRENT_SCHEMA_VERSION:
+        return data
+    result = dict(data)
+    for from_ver, migration_fn in _CHAIN:
+        if version <= from_ver:
+            result = migration_fn(result)
+    return result

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -26,6 +26,7 @@ from synth_panel.checkpoint import (
     CheckpointDriftError,
     CheckpointFormatError,
     CheckpointNotFoundError,
+    CheckpointSchemaTooNewError,
     CheckpointWriter,
     PanelCheckpoint,
     _merge_usage,
@@ -43,6 +44,11 @@ from synth_panel.llm.models import (
 )
 from synth_panel.llm.models import (
     TokenUsage as LLMTokenUsage,
+)
+from synth_panel.metadata_migrations import (
+    CURRENT_SCHEMA_VERSION,
+    migrate_to_current,
+    migrate_v1_to_v2,
 )
 from synth_panel.orchestrator import PanelistResult, run_panel_parallel
 
@@ -1041,3 +1047,140 @@ class TestResumeFromCheckpointCli:
         err = capsys.readouterr().err
         assert "drift" in err.lower()
         assert "statistically inconsistent" in err.lower()
+
+
+# ---------------------------------------------------------------------------
+# sy-z8p6: schema_version field + migration registry
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaMigration:
+    """schema_version field and migrate_to_current() migration chain."""
+
+    def test_current_version_written_on_save(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice"])
+        ckpt = PanelCheckpoint(
+            run_id="run-ver",
+            created_at="now",
+            updated_at="now",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+        )
+        d = ckpt.to_dict()
+        assert d["schema_version"] == CURRENT_SCHEMA_VERSION
+        assert "version" not in d
+
+    def test_current_version_persisted_to_disk(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice"])
+        ckpt = PanelCheckpoint(
+            run_id="run-ver-disk",
+            created_at="now",
+            updated_at="now",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+        )
+        directory = checkpoint_dir_for("run-ver-disk", tmp_path)
+        save_checkpoint(ckpt, directory)
+        raw = json.loads((directory / "state.json").read_text())
+        assert raw["schema_version"] == CURRENT_SCHEMA_VERSION
+
+    def test_v1_checkpoint_migrates_on_load(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice", "Bob"])
+        directory = checkpoint_dir_for("run-v1", tmp_path)
+        directory.mkdir(parents=True)
+        v1_data = {
+            "version": 1,
+            "run_id": "run-v1",
+            "created_at": "2026-04-24T00:00:00Z",
+            "updated_at": "2026-04-24T00:00:00Z",
+            "config_fingerprint": fingerprint_config(cfg),
+            "config": cfg,
+            "completed": [{"persona": "Alice", "responses": [], "usage": {}, "error": None}],
+            "remaining": ["Bob"],
+            "usage": {"input_tokens": 5},
+            "abort_reason": None,
+            # No cli_args, no schema_version
+        }
+        (directory / "state.json").write_text(json.dumps(v1_data))
+        loaded = load_checkpoint("run-v1", tmp_path)
+        assert loaded.run_id == "run-v1"
+        assert loaded.cli_args is None
+        assert loaded.completed[0]["persona"] == "Alice"
+        assert loaded.remaining == ["Bob"]
+
+    def test_schema_too_new_raises(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice"])
+        directory = checkpoint_dir_for("run-future", tmp_path)
+        directory.mkdir(parents=True)
+        future_data = {
+            "schema_version": CURRENT_SCHEMA_VERSION + 1,
+            "run_id": "run-future",
+            "created_at": "now",
+            "updated_at": "now",
+            "config_fingerprint": fingerprint_config(cfg),
+            "config": cfg,
+        }
+        (directory / "state.json").write_text(json.dumps(future_data))
+        with pytest.raises(CheckpointSchemaTooNewError, match="newer than this synthpanel"):
+            load_checkpoint("run-future", tmp_path)
+
+    def test_migrate_v1_to_v2_adds_defaults(self) -> None:
+        v1 = {
+            "version": 1,
+            "run_id": "x",
+            "created_at": "now",
+            "updated_at": "now",
+            "config_fingerprint": "abc",
+            "config": {},
+        }
+        result = migrate_v1_to_v2(v1)
+        assert result["schema_version"] == 2
+        assert result["cli_args"] is None
+        assert result["completed"] == []
+        assert result["remaining"] == []
+        assert result["usage"] == {}
+        assert result["abort_reason"] is None
+
+    def test_migrate_v1_to_v2_preserves_existing_fields(self) -> None:
+        v1 = {
+            "version": 1,
+            "run_id": "x",
+            "created_at": "now",
+            "updated_at": "now",
+            "config_fingerprint": "abc",
+            "config": {},
+            "completed": [{"persona": "Alice"}],
+            "remaining": ["Bob"],
+            "usage": {"input_tokens": 7},
+            "abort_reason": "signal:SIGINT",
+        }
+        result = migrate_v1_to_v2(v1)
+        assert result["completed"] == [{"persona": "Alice"}]
+        assert result["remaining"] == ["Bob"]
+        assert result["usage"] == {"input_tokens": 7}
+        assert result["abort_reason"] == "signal:SIGINT"
+
+    def test_migrate_to_current_noop_at_current_version(self) -> None:
+        data = {"schema_version": CURRENT_SCHEMA_VERSION, "run_id": "x"}
+        assert migrate_to_current(data) is data
+
+    def test_migrate_to_current_raises_on_future_version(self) -> None:
+        data = {"schema_version": CURRENT_SCHEMA_VERSION + 1}
+        with pytest.raises(ValueError, match="newer than this synthpanel"):
+            migrate_to_current(data)
+
+    def test_round_trip_preserves_schema_version(self, tmp_path: Path) -> None:
+        cfg = _make_config(["Alice"])
+        ckpt = PanelCheckpoint(
+            run_id="run-rt-ver",
+            created_at="now",
+            updated_at="now",
+            config_fingerprint=fingerprint_config(cfg),
+            config=cfg,
+        )
+        directory = checkpoint_dir_for("run-rt-ver", tmp_path)
+        save_checkpoint(ckpt, directory)
+        loaded = load_checkpoint("run-rt-ver", tmp_path)
+        # Re-saving the loaded checkpoint still writes the current version.
+        d = loaded.to_dict()
+        assert d["schema_version"] == CURRENT_SCHEMA_VERSION


### PR DESCRIPTION
…48) [retroactive] (#361)

* feat(checkpoint): add schema_version field + migration registry (sy-z8p6 / GH-348)

- New metadata_migrations.py: CURRENT_SCHEMA_VERSION=2, migrate_v1_to_v2(), migrate_to_current() chain — v1 = 0.11.x (no cli_args), v2 = 0.12+
- checkpoint.py: to_dict() writes schema_version instead of hardcoded version:1; load_checkpoint() runs migrate_to_current() before from_dict(), raising CheckpointSchemaTooNewError for unrecognized future versions
- 9 new tests covering migration happy path, too-new error, round-trip, and unit coverage of migrate_v1_to_v2 and migrate_to_current



* style: fix ruff import sort in test_checkpoint.py

---------

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
