### PR TITLE
feat(cli): add live progress bar during panel run (GH-351) [retroacti…

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -45,6 +45,7 @@ from synth_panel.cli.output import (
     format_prose_for_inspect,
     terminal_columns,
 )
+from synth_panel.cli.progress import PanelProgressBar
 from synth_panel.convergence import (
     DEFAULT_CHECK_EVERY,
     DEFAULT_EPSILON,
@@ -1722,12 +1723,16 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         # Flatten all panelist results across models for output + synthesis
         panelist_results = [pr for mr in ensemble.model_results for pr in mr.panelist_results]
     else:
+        # Show a live progress bar when the user is watching a TTY in text mode.
+        _show_progress = fmt is OutputFormat.TEXT and sys.stdout.isatty() and bool(active_personas)
+        progress: PanelProgressBar | None = PanelProgressBar(len(active_personas), model) if _show_progress else None
 
         def _on_complete(pr: PanelistResult) -> None:
-            if checkpoint_writer is None:
-                return
-            record = _panelist_result_to_ckpt_dict(pr, model)
-            checkpoint_writer.record_completed(record, pr.usage.to_dict())
+            if checkpoint_writer is not None:
+                record = _panelist_result_to_ckpt_dict(pr, model)
+                checkpoint_writer.record_completed(record, pr.usage.to_dict())
+            if progress is not None:
+                progress.update(pr.usage)
 
         # sp-utnk: instantiate the gate against the panelists actually being
         # dispatched in this invocation. On a fresh run this is all personas;
@@ -1751,7 +1756,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 persona_models=persona_models,
                 max_workers=max_concurrent,
                 convergence_tracker=convergence_tracker,
-                on_panelist_complete=_on_complete if checkpoint_writer else None,
+                on_panelist_complete=_on_complete if (checkpoint_writer is not None or progress is not None) else None,
                 cost_gate=cost_gate,
             )
         except RunAbortedError as abort_exc:
@@ -1769,6 +1774,8 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 file=sys.stderr,
             )
         finally:
+            if progress is not None:
+                progress.close()
             if checkpoint_writer is not None:
                 try:
                     checkpoint_writer.flush(force=True)

--- a/src/synth_panel/cli/progress.py
+++ b/src/synth_panel/cli/progress.py
@@ -1,0 +1,93 @@
+"""Live terminal progress bar for panel runs (CLI text mode only).
+
+Renders to stderr via carriage-return overwrites; never touches stdout.
+Caller is responsible for the guard: only instantiate when
+sys.stdout.isatty() is True and output format is TEXT.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import threading
+import time
+from typing import Any
+
+from synth_panel.cost import resolve_cost
+
+
+class PanelProgressBar:
+    """Thread-safe in-place progress display written to stderr.
+
+    Instantiate before run_panel_parallel, call update() from the
+    on_panelist_complete callback, and call close() when the run ends.
+    """
+
+    def __init__(self, total: int, model: str, *, file: Any = None) -> None:
+        self._total = total
+        self._model = model
+        self._completed = 0
+        self._cost = 0.0
+        self._start = time.monotonic()
+        self._lock = threading.Lock()
+        self._out = file if file is not None else sys.stderr
+        self._bar_width = 20
+        self._rendered = False
+
+    def update(self, usage: Any) -> None:
+        """Record one completed panelist and redraw."""
+        try:
+            priced = resolve_cost(usage, self._model)
+            cost_delta = priced.total_cost
+        except Exception:
+            cost_delta = 0.0
+
+        with self._lock:
+            self._completed += 1
+            self._cost += cost_delta
+            self._render()
+
+    def close(self) -> None:
+        """Emit a trailing newline so the next stdout line is not overwritten."""
+        with self._lock:
+            if self._rendered:
+                print("", file=self._out, flush=True)
+
+    def _render(self) -> None:
+        """Redraw the bar (caller must hold self._lock)."""
+        self._rendered = True
+        pct = self._completed / self._total if self._total else 1.0
+        filled = int(self._bar_width * pct)
+        if filled >= self._bar_width:
+            bar = "=" * self._bar_width
+        else:
+            bar = "=" * filled + ">" + " " * (self._bar_width - filled - 1)
+
+        elapsed = time.monotonic() - self._start
+        elapsed_str = _fmt_secs(elapsed)
+
+        if 0 < self._completed < self._total:
+            eta_secs = elapsed / self._completed * (self._total - self._completed)
+            eta_str = f"ETA {_fmt_secs(eta_secs)}"
+        elif self._completed >= self._total:
+            eta_str = "done"
+        else:
+            eta_str = "ETA ..."
+
+        line = f"\r  [{bar}] {self._completed}/{self._total}  {elapsed_str} elapsed  {eta_str}  ${self._cost:.4f}"
+
+        cols = shutil.get_terminal_size(fallback=(80, 24)).columns
+        if len(line) > cols:
+            line = line[:cols]
+        else:
+            # Pad with spaces to erase any characters left from a longer prior render.
+            line = line.ljust(cols)
+
+        print(line, end="", file=self._out, flush=True)
+
+
+def _fmt_secs(s: float) -> str:
+    s = int(s)
+    if s >= 60:
+        return f"{s // 60}m{s % 60:02d}s"
+    return f"{s}s"

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,145 @@
+"""Tests for PanelProgressBar — progress suppression and basic rendering."""
+
+from __future__ import annotations
+
+import io
+import sys
+from unittest.mock import MagicMock, patch
+
+from synth_panel.cli.output import OutputFormat
+from synth_panel.cli.progress import PanelProgressBar, _fmt_secs
+from synth_panel.cost import TokenUsage
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_usage(input_tokens: int = 100, output_tokens: int = 50) -> TokenUsage:
+    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
+# ---------------------------------------------------------------------------
+# Progress suppression guard
+# ---------------------------------------------------------------------------
+
+
+class TestProgressGuard:
+    """The guard in commands.py: only show progress when TTY + TEXT mode."""
+
+    def test_no_progress_when_stdout_not_tty(self):
+        """When stdout is not a TTY, _show_progress must be False."""
+        with patch.object(sys.stdout, "isatty", return_value=False):
+            show = OutputFormat.TEXT is OutputFormat.TEXT and sys.stdout.isatty()
+        assert show is False
+
+    def test_no_progress_when_json_format(self):
+        """JSON output mode must suppress progress regardless of TTY state."""
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            show = OutputFormat.JSON is OutputFormat.TEXT and sys.stdout.isatty()
+        assert show is False
+
+    def test_no_progress_when_ndjson_format(self):
+        """NDJSON output mode must suppress progress regardless of TTY state."""
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            show = OutputFormat.NDJSON is OutputFormat.TEXT and sys.stdout.isatty()
+        assert show is False
+
+    def test_progress_enabled_when_tty_and_text(self):
+        """TEXT mode + TTY must allow progress display."""
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            show = OutputFormat.TEXT is OutputFormat.TEXT and sys.stdout.isatty()
+        assert show is True
+
+
+# ---------------------------------------------------------------------------
+# PanelProgressBar behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPanelProgressBar:
+    def _bar(self, total: int = 5, model: str = "claude-sonnet-4-6") -> tuple[PanelProgressBar, io.StringIO]:
+        buf = io.StringIO()
+        bar = PanelProgressBar(total=total, model=model, file=buf)
+        return bar, buf
+
+    def test_update_writes_to_file(self):
+        bar, buf = self._bar(total=3)
+        with patch("synth_panel.cli.progress.resolve_cost") as mock_rc:
+            mock_rc.return_value = MagicMock(total_cost=0.001)
+            bar.update(_make_usage())
+        output = buf.getvalue()
+        assert output != ""
+        assert "1/3" in output
+
+    def test_update_increments_completed_count(self):
+        bar, buf = self._bar(total=4)
+        with patch("synth_panel.cli.progress.resolve_cost") as mock_rc:
+            mock_rc.return_value = MagicMock(total_cost=0.0)
+            bar.update(_make_usage())
+            bar.update(_make_usage())
+        output = buf.getvalue()
+        assert "2/4" in output
+
+    def test_cost_accumulates(self):
+        bar, buf = self._bar(total=2)
+        with patch("synth_panel.cli.progress.resolve_cost") as mock_rc:
+            mock_rc.return_value = MagicMock(total_cost=0.0050)
+            bar.update(_make_usage())
+            bar.update(_make_usage())
+        output = buf.getvalue()
+        assert "$0.0100" in output
+
+    def test_close_emits_newline_after_render(self):
+        bar, buf = self._bar(total=1)
+        with patch("synth_panel.cli.progress.resolve_cost") as mock_rc:
+            mock_rc.return_value = MagicMock(total_cost=0.0)
+            bar.update(_make_usage())
+        bar.close()
+        # After close() the buffer should end with a newline
+        assert buf.getvalue().endswith("\n")
+
+    def test_close_without_update_emits_nothing(self):
+        bar, buf = self._bar(total=2)
+        bar.close()
+        assert buf.getvalue() == ""
+
+    def test_resolve_cost_exception_does_not_crash(self):
+        bar, buf = self._bar(total=2)
+        with patch("synth_panel.cli.progress.resolve_cost", side_effect=ValueError("no pricing")):
+            bar.update(_make_usage())  # must not raise
+        assert "1/2" in buf.getvalue()
+
+    def test_renders_carriage_return(self):
+        bar, buf = self._bar(total=2)
+        with patch("synth_panel.cli.progress.resolve_cost") as mock_rc:
+            mock_rc.return_value = MagicMock(total_cost=0.0)
+            bar.update(_make_usage())
+        assert buf.getvalue().startswith("\r")
+
+    def test_done_label_at_completion(self):
+        bar, buf = self._bar(total=2)
+        with patch("synth_panel.cli.progress.resolve_cost") as mock_rc:
+            mock_rc.return_value = MagicMock(total_cost=0.0)
+            bar.update(_make_usage())
+            bar.update(_make_usage())
+        assert "done" in buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# _fmt_secs helper
+# ---------------------------------------------------------------------------
+
+
+class TestFmtSecs:
+    def test_under_60_seconds(self):
+        assert _fmt_secs(42.9) == "42s"
+
+    def test_exactly_60_seconds(self):
+        assert _fmt_secs(60.0) == "1m00s"
+
+    def test_90_seconds(self):
+        assert _fmt_secs(90.0) == "1m30s"
+
+    def test_zero(self):
+        assert _fmt_secs(0.0) == "0s"


### PR DESCRIPTION
…ve] (#362)

* feat(cli): add live progress bar during panel run (GH-351)

Display an in-place progress bar to stderr during panel runs when stdout is a TTY and output format is TEXT. Shows completed/total panelists, elapsed time, ETA, and cumulative cost. Suppressed in JSON/NDJSON modes and non-TTY environments. Wired via the existing on_panelist_complete callback so it composes cleanly with checkpoint writing.



* style: fix ruff formatting in commands.py

---------

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
