### PR TITLE
feat(llm): add cache_control breakpoints for Anthropic prompt caching…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, "pr/gh-*"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/src/synth_panel/llm/providers/anthropic.py
+++ b/src/synth_panel/llm/providers/anthropic.py
@@ -75,14 +75,20 @@ def _build_content_blocks(blocks: list[ContentBlock]) -> list[dict[str, Any]]:
 
 def _build_messages(request: CompletionRequest) -> list[dict[str, Any]]:
     """Convert InputMessages to Anthropic API format."""
+    last_user_idx = -1
+    for i, msg in enumerate(request.messages):
+        if msg.role == "user":
+            last_user_idx = i
+
     result = []
-    for msg in request.messages:
-        result.append(
-            {
-                "role": msg.role,
-                "content": _build_content_blocks(msg.content),
-            }
-        )
+    for i, msg in enumerate(request.messages):
+        content = _build_content_blocks(msg.content)
+        if i == last_user_idx and content:
+            for j in range(len(content) - 1, -1, -1):
+                if content[j].get("type") == "text":
+                    content[j] = {**content[j], "cache_control": {"type": "ephemeral"}}
+                    break
+        result.append({"role": msg.role, "content": content})
     return result
 
 
@@ -158,7 +164,7 @@ class AnthropicProvider(LLMProvider):
             "messages": _build_messages(request),
         }
         if request.system:
-            body["system"] = request.system
+            body["system"] = [{"type": "text", "text": request.system, "cache_control": {"type": "ephemeral"}}]
         tools = _build_tools(request)
         if tools is not None:
             body["tools"] = tools

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -631,9 +631,88 @@ class TestAnthropicProvider:
         with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
             provider = AnthropicProvider()
         body = provider._build_body(req)
-        assert body["system"] == "Be helpful."
+        assert body["system"] == [{"type": "text", "text": "Be helpful.", "cache_control": {"type": "ephemeral"}}]
         assert len(body["tools"]) == 1
         assert body["tool_choice"] == {"type": "any"}
+
+    def test_cache_control_on_system_prompt(self):
+        from synth_panel.llm.providers.anthropic import AnthropicProvider
+
+        req = CompletionRequest(
+            model="claude-sonnet-4-6-20250414",
+            max_tokens=100,
+            messages=[InputMessage(role="user", content=[TextBlock(text="Hello")])],
+            system="You are a helpful assistant.",
+        )
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            provider = AnthropicProvider()
+        body = provider._build_body(req)
+        system = body["system"]
+        assert isinstance(system, list)
+        assert len(system) == 1
+        assert system[0]["type"] == "text"
+        assert system[0]["text"] == "You are a helpful assistant."
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_no_system_omits_system_key(self):
+        from synth_panel.llm.providers.anthropic import AnthropicProvider
+
+        req = CompletionRequest(
+            model="claude-sonnet-4-6-20250414",
+            max_tokens=100,
+            messages=[InputMessage(role="user", content=[TextBlock(text="Hello")])],
+        )
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}):
+            provider = AnthropicProvider()
+        body = provider._build_body(req)
+        assert "system" not in body
+
+    def test_cache_control_on_last_user_message_last_text_block(self):
+        from synth_panel.llm.providers.anthropic import _build_messages
+
+        req = CompletionRequest(
+            model="claude-sonnet-4-6-20250414",
+            max_tokens=100,
+            messages=[
+                InputMessage(role="user", content=[TextBlock(text="First question")]),
+                InputMessage(role="assistant", content=[TextBlock(text="First answer")]),
+                InputMessage(role="user", content=[TextBlock(text="Second question")]),
+            ],
+        )
+        messages = _build_messages(req)
+        last_user_content = messages[2]["content"]
+        assert last_user_content[-1]["cache_control"] == {"type": "ephemeral"}
+        # Earlier user message must NOT have cache_control
+        first_user_content = messages[0]["content"]
+        assert "cache_control" not in first_user_content[0]
+
+    def test_cache_control_only_on_last_user_message(self):
+        from synth_panel.llm.providers.anthropic import _build_messages
+
+        req = CompletionRequest(
+            model="claude-sonnet-4-6-20250414",
+            max_tokens=100,
+            messages=[
+                InputMessage(role="user", content=[TextBlock(text="Q1")]),
+            ],
+        )
+        messages = _build_messages(req)
+        assert messages[0]["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_cache_control_not_on_assistant_messages(self):
+        from synth_panel.llm.providers.anthropic import _build_messages
+
+        req = CompletionRequest(
+            model="claude-sonnet-4-6-20250414",
+            max_tokens=100,
+            messages=[
+                InputMessage(role="user", content=[TextBlock(text="Q1")]),
+                InputMessage(role="assistant", content=[TextBlock(text="A1")]),
+            ],
+        )
+        messages = _build_messages(req)
+        assistant_content = messages[1]["content"]
+        assert "cache_control" not in assistant_content[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
… (GH-350) (#368)

* feat(llm): add cache_control breakpoints for Anthropic prompt caching (GH-350)

Adds cache_control: {type: ephemeral} to the system prompt block and the last text block of the final user turn so Anthropic's prompt caching activates automatically on every API request. Verifies _parse_usage already maps cache_creation_input_tokens / cache_read_input_tokens correctly.



* ci: trigger on PRs targeting pr/gh-* base branches + add workflow_dispatch

---------

## What changed

<!-- Brief summary of what this PR does. -->

## Why

<!-- The motivation. Link any related issues (Fixes #..., Refs #...). -->

## Type of change

- [ ] Bug fix
- [ ] New adapter
- [ ] New instrument pack
- [ ] New persona pack
- [ ] Feature
- [ ] Docs
- [ ] Refactor

## Test plan

<!-- How did you verify this works? Commands run, cases covered, manual checks. -->

## Semver impact

Choose one (matches the auto-tag labels):

- [ ] `semver:skip` — no release needed (docs, CI, internal refactor)
- [ ] `semver:patch` — bug fix or small internal change
- [ ] `semver:minor` — new feature, backwards compatible
- [ ] `semver:major` — breaking change

## Checklist

- [ ] Tests added or updated
- [ ] `ruff check src/ tests/` passes
- [ ] `mypy src/synth_panel/` passes
- [ ] CHANGELOG.md updated (if user-visible change)
- [ ] Commits signed off with `git commit -s` (see CONTRIBUTING.md)

## For adapter PRs

<!-- Delete this section if not an adapter PR. -->

Benchmarked on SynthBench? Link results here: ___
