### PR TITLE
feat(calibration): surface Cramer's V effect size (GH-313)

### DIFF
--- a/src/synth_panel/calibration.py
+++ b/src/synth_panel/calibration.py
@@ -38,6 +38,14 @@ class CalibrationEntry:
     A pack's ``calibration:`` field is a list of these. Re-running
     calibration against the same ``(dataset, question)`` pair replaces
     the prior entry rather than appending a duplicate (newest wins).
+
+    GH-313: ``cramers_v`` surfaces the categorical effect size for the
+    panel-vs-baseline comparison. Effect size leads p-values for
+    interpretation: it answers "how different are these distributions?"
+    in standard Cohen-style buckets (negligible <0.1, small 0.1-0.3,
+    medium 0.3-0.5, large >=0.5). See ``docs/calibration.md`` for the
+    full readout. The field is optional for backward compatibility with
+    pre-GH-313 pack YAMLs that have only ``jsd``.
     """
 
     dataset: str
@@ -52,6 +60,7 @@ class CalibrationEntry:
     synthpanel_version: str
     methodology_url: str = "https://synthpanel.dev/docs/calibration"
     alignment_error: str | None = field(default=None)
+    cramers_v: float | None = field(default=None)
 
     def to_yaml_dict(self) -> dict[str, Any]:
         """Render as an ordered plain dict suitable for YAML emission."""
@@ -60,6 +69,10 @@ class CalibrationEntry:
         # example for the happy path.
         if d.get("alignment_error") is None:
             d.pop("alignment_error", None)
+        # Drop None cramers_v so older pack YAMLs without an effect size
+        # don't grow a noisy null when re-emitted.
+        if d.get("cramers_v") is None:
+            d.pop("cramers_v", None)
         return d
 
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3636,12 +3636,24 @@ def _run_calibration_panel(
             cost_section.get("usd") or cost_section.get("total_usd") or cost_section.get("cost_usd") or 0.0
         )
 
+    cramers_v_raw = calib.get("cramers_v")
+    cramers_v: float | None
+    if cramers_v_raw is None:
+        cramers_v = None
+    else:
+        try:
+            cramers_v = float(cramers_v_raw)
+        except (TypeError, ValueError):
+            cramers_v = None
+
     return {
         "jsd": float(calib["jsd"]),
+        "cramers_v": cramers_v,
         "extractor": calib.get("extractor") or "pick_one:auto-derived",
         "models": _split_models_arg(models) if models else _default_models_list(payload),
         "panelist_cost_usd": panelist_cost_usd,
         "alignment_error": calib.get("alignment_error"),
+        "lead_interpretation": calib.get("lead_interpretation"),
     }
 
 
@@ -3650,6 +3662,17 @@ def _split_models_arg(models: str | None) -> list[str]:
     if not models:
         return []
     return [m.strip() for m in models.split(",") if m.strip()]
+
+
+def _calibration_effect_bucket(v: float) -> str:
+    """Cohen-style label for a Cramer's V effect size (GH-313)."""
+    if v < 0.1:
+        return "negligible"
+    if v < 0.3:
+        return "small"
+    if v < 0.5:
+        return "medium"
+    return "large"
 
 
 def _default_models_list(payload: dict[str, Any]) -> list[str]:
@@ -3723,6 +3746,7 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
             return 1
 
         # ── Build the calibration entry ──────────────────────────────────
+        run_cramers_v = run_result.get("cramers_v")
         entry = calib_mod.CalibrationEntry(
             dataset=dataset,
             question=question,
@@ -3735,6 +3759,7 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
             calibrated_at=calib_mod.now_iso_utc(),
             synthpanel_version=str(__version__),
             alignment_error=run_result.get("alignment_error"),
+            cramers_v=round(float(run_cramers_v), 6) if run_cramers_v is not None else None,
         )
         new_dict = entry.to_yaml_dict()
         new_yaml = calib_mod.update_pack_calibration_text(raw_text, parsed, new_dict)
@@ -3777,7 +3802,23 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
             return 1
 
         if fmt is OutputFormat.TEXT:
-            print(f"Wrote calibration entry ({dataset}:{question}, JSD {entry.jsd}) → {output_path}")
+            # GH-313: lead with effect size (Cramer's V) so the reader's first
+            # impression is "how different are these distributions?" rather
+            # than "what's the JSD scalar?". JSD is retained as the secondary
+            # check on distributional shape.
+            lead = run_result.get("lead_interpretation")
+            if entry.cramers_v is not None:
+                effect_label = _calibration_effect_bucket(entry.cramers_v)
+                summary = (
+                    f"Wrote calibration entry ({dataset}:{question}): "
+                    f"Cramer's V={entry.cramers_v:.3f} ({effect_label}); "
+                    f"JSD={entry.jsd} → {output_path}"
+                )
+            else:
+                summary = f"Wrote calibration entry ({dataset}:{question}, JSD {entry.jsd}) → {output_path}"
+            print(summary)
+            if isinstance(lead, str) and lead:
+                print(f"  {lead}")
         else:
             emit(
                 fmt,

--- a/src/synth_panel/convergence.py
+++ b/src/synth_panel/convergence.py
@@ -114,6 +114,99 @@ def compute_calibration_jsd(
     return jensen_shannon_divergence(model_dist, human_dist)
 
 
+# Smoothing constant for chi-squared expected counts on categories the baseline
+# does not cover. Avoids divide-by-zero while keeping the contribution small
+# enough that "model invented a brand-new category" still surfaces as deviation.
+_CALIBRATION_EXPECTED_FLOOR = 0.5
+
+
+def compute_calibration_cramers_v(
+    model_counts: dict[str, int],
+    human_dist: dict[str, float],
+) -> tuple[float, int, float, str | None]:
+    """Cramer's V for a model panel distribution vs a human baseline (GH-313).
+
+    Treats ``human_dist`` as expected proportions, scales by the model's total
+    n, and returns ``(cramers_v, df, p_value, warning)`` from a chi-squared
+    goodness-of-fit test over the UNION of supports. A small smoothing constant
+    (:data:`_CALIBRATION_EXPECTED_FLOOR`) is applied where the baseline has no
+    mass for an observed category, so categories present only in the model
+    surface as deviation rather than triggering a divide-by-zero.
+
+    Returns ``(0.0, 0, 1.0, None)`` when the model has no observations or the
+    human distribution does not normalize. Callers handle the disjoint-support
+    case (``alignment_error``) before calling.
+    """
+    n_total = sum(model_counts.values())
+    if n_total <= 0:
+        return 0.0, 0, 1.0, None
+    h_total = sum(human_dist.values())
+    if h_total <= 0:
+        return 0.0, 0, 1.0, None
+
+    normalized_h = {k: v / h_total for k, v in human_dist.items()}
+    all_keys = set(model_counts) | set(normalized_h)
+    if not all_keys:
+        return 0.0, 0, 1.0, None
+
+    observed: dict[str, int] = {k: int(model_counts.get(k, 0)) for k in all_keys}
+    expected: dict[str, float] = {}
+    for k in all_keys:
+        scaled = normalized_h.get(k, 0.0) * n_total
+        expected[k] = max(_CALIBRATION_EXPECTED_FLOOR, scaled)
+
+    result = chi_squared_test(observed, expected)
+    # Clamp to [0, 1]. GOF Cramer's V is theoretically bounded in this range
+    # but the expected-count smoothing for categories the baseline does not
+    # cover can inflate chi-squared past the bound; clamping keeps the wire
+    # value interpretable as a Cohen-style effect size.
+    v = max(0.0, min(1.0, result.cramers_v))
+    return v, result.df, result.p_value, result.warning
+
+
+def _lead_interpretation_for_calibration(
+    cramers_v: float,
+    *,
+    p_value: float,
+    n_categories: int,
+    total_n: int,
+    chi2_warning: str | None,
+) -> str:
+    """Effect-size readout for Cramer's V vs a human baseline (GH-313).
+
+    Uses Cohen-style thresholds for Cramer's *V* on categorical data
+    (negligible <0.1, small 0.1-0.3, medium 0.3-0.5, large >=0.5). For
+    calibration the framing is "how far is the synthetic panel from the
+    human baseline" rather than the leading-prompt framing used by
+    :func:`_lead_interpretation_for_uniform_skew`.
+    """
+    if chi2_warning:
+        reliability = f"p={p_value:.4g} (approximate - {chi2_warning.rstrip('.')}); treat effect size as directional."
+    else:
+        reliability = f"p={p_value:.4g} vs baseline over {n_categories} categories (n={total_n})."
+
+    if cramers_v < 0.1:
+        bucket = "negligible"
+        gist = "Panel distribution closely matches the human baseline."
+    elif cramers_v < 0.3:
+        bucket = "small"
+        gist = "Mild deviation from baseline - panel proportions track the human shape with minor drift."
+    elif cramers_v < 0.5:
+        bucket = "medium"
+        gist = (
+            "Moderate deviation from baseline - panel emphasizes some options "
+            "more (or less) than the human distribution."
+        )
+    else:
+        bucket = "large"
+        gist = (
+            "Strong deviation from baseline - panel distribution differs "
+            "substantially from human responses; investigate persona spread or prompt wording."
+        )
+
+    return f"Cramer's V={cramers_v:.3f} ({bucket} effect vs baseline). {gist} {reliability}"
+
+
 def _lead_interpretation_for_uniform_skew(
     cramers_v: float,
     *,
@@ -563,9 +656,39 @@ class ConvergenceTracker:
                     # divergence". This is a wire-format field per P-gate.
                     model_keys = set(model_dist)
                     baseline_keys = set(human_dist)
-                    if model_keys and baseline_keys and not (model_keys & baseline_keys):
+                    disjoint = bool(model_keys and baseline_keys and not (model_keys & baseline_keys))
+                    if disjoint:
                         calibration["jsd"] = 1.0
                         calibration["alignment_error"] = f"{sorted(model_keys)} vs {sorted(baseline_keys)}"
+                    # GH-313: surface Cramer's V effect size alongside JSD so
+                    # operators can read "how different is this panel from the
+                    # human baseline" in standard categorical-effect terms.
+                    # Disjoint supports pin V to 1.0 (mirrors JSD) since the
+                    # supports cannot be sensibly compared via chi-squared.
+                    model_counts = {k: int(v) for k, v in state.cumulative.items()}
+                    n_obs_calib = sum(model_counts.values())
+                    if disjoint:
+                        calibration["cramers_v"] = 1.0
+                        calibration["lead_interpretation"] = (
+                            "Cramer's V=1.000 (large effect vs baseline). "
+                            "Panel and baseline use disjoint category vocabularies; "
+                            "see alignment_error before drawing conclusions."
+                        )
+                    elif n_obs_calib > 0 and human_dist:
+                        v, df_v, p_v, warn_v = compute_calibration_cramers_v(model_counts, human_dist)
+                        n_cats = len(set(model_counts) | set(human_dist))
+                        calibration["cramers_v"] = round(v, 6)
+                        calibration["chi2_df"] = df_v
+                        calibration["chi2_p_value"] = round(p_v, 6)
+                        if warn_v:
+                            calibration["chi2_warning"] = warn_v
+                        calibration["lead_interpretation"] = _lead_interpretation_for_calibration(
+                            v,
+                            p_value=p_v,
+                            n_categories=n_cats,
+                            total_n=n_obs_calib,
+                            chi2_warning=warn_v,
+                        )
                     entry["calibration"] = calibration
                 observed = dict(state.cumulative)
                 n_obs = sum(observed.values())

--- a/src/synth_panel/stats.py
+++ b/src/synth_panel/stats.py
@@ -799,7 +799,16 @@ class ModelDistribution:
 
 @dataclass(frozen=True)
 class FindingConvergence:
-    """Convergence assessment for a single finding/question."""
+    """Convergence assessment for a single finding/question.
+
+    GH-313: ``cramers_v`` measures the strength of association between
+    *model* and *response category* in the MxC contingency table. Closer
+    to 1 means model choice strongly predicts the response (poor
+    convergence in effect-size terms); closer to 0 means responses are
+    essentially independent of which model produced them (strong
+    convergence). It complements Krippendorff's ``alpha`` (rater
+    reliability) with a categorical effect size readers already know.
+    """
 
     question_index: int
     question_text: str
@@ -809,6 +818,9 @@ class FindingConvergence:
     top_choice_agreement: bool  # Do all models agree on the top choice?
     divergent_models: list[str]  # Models whose top choice differs from majority
     interpretation: str  # Human-readable summary
+    cramers_v: float = 0.0  # Effect size for model x category contingency
+    chi2: float = 0.0  # Chi-squared statistic backing cramers_v
+    chi2_df: int = 0  # Degrees of freedom: (M-1)*(C-1)
 
 
 @dataclass(frozen=True)
@@ -822,6 +834,7 @@ class ConvergenceReport:
     n_divergent: int  # Findings with alpha < 0.40
     n_models: int
     model_names: list[str]
+    overall_cramers_v: float = 0.0  # Mean Cramer's V across findings (GH-313)
 
 
 def _classify_alpha(alpha: float) -> ConvergenceLevel:
@@ -834,6 +847,84 @@ def _classify_alpha(alpha: float) -> ConvergenceLevel:
         return ConvergenceLevel.WEAK
     else:
         return ConvergenceLevel.NONE
+
+
+def _classify_cramers_v_effect(v: float) -> str:
+    """Cohen-style effect-size label for Cramer's V (GH-313)."""
+    if v < 0.1:
+        return "negligible"
+    if v < 0.3:
+        return "small"
+    if v < 0.5:
+        return "medium"
+    return "large"
+
+
+def _model_category_cramers_v(
+    rows_by_model: list[list[str]],
+) -> tuple[float, float, int]:
+    """Cramer's V for a model x category contingency table (GH-313).
+
+    ``rows_by_model[i]`` is the flat list of categorical responses produced by
+    model *i*. The function builds an MxC contingency table (M = number of
+    models, C = number of distinct categories observed across all rows),
+    computes Pearson's chi-squared via expected = row_total x col_total / N,
+    and returns ``(cramers_v, chi2, df)``.
+
+    Returns ``(0.0, 0.0, 0)`` when fewer than two models are supplied, fewer
+    than two distinct categories are observed, or the total count is zero
+    (those cases have no defined effect size). Reads cleanly even with
+    empty rows: empty rows contribute zero observations and the function
+    treats the remaining models as the active set.
+    """
+    n_rows = len(rows_by_model)
+    if n_rows < 2:
+        return 0.0, 0.0, 0
+
+    categories: list[str] = sorted({c for row in rows_by_model for c in row})
+    n_cols = len(categories)
+    if n_cols < 2:
+        return 0.0, 0.0, 0
+    cat_index = {c: j for j, c in enumerate(categories)}
+
+    table: list[list[int]] = [[0] * n_cols for _ in range(n_rows)]
+    for i, row in enumerate(rows_by_model):
+        for value in row:
+            j = cat_index.get(value)
+            if j is not None:
+                table[i][j] += 1
+
+    row_totals = [sum(table[i]) for i in range(n_rows)]
+    col_totals = [sum(table[i][j] for i in range(n_rows)) for j in range(n_cols)]
+    n_total = sum(row_totals)
+    if n_total <= 0:
+        return 0.0, 0.0, 0
+
+    chi2 = 0.0
+    for i in range(n_rows):
+        if row_totals[i] == 0:
+            continue
+        for j in range(n_cols):
+            if col_totals[j] == 0:
+                continue
+            expected = (row_totals[i] * col_totals[j]) / n_total
+            if expected <= 0:
+                continue
+            diff = table[i][j] - expected
+            chi2 += diff * diff / expected
+
+    df = (n_rows - 1) * (n_cols - 1)
+    if df <= 0 or n_total <= 0:
+        return 0.0, chi2, df
+
+    denom = n_total * min(n_rows - 1, n_cols - 1)
+    if denom <= 0:
+        return 0.0, chi2, df
+
+    v = math.sqrt(chi2 / denom)
+    # Clamp for numerical safety — V is bounded in [0, 1] in theory.
+    v = max(0.0, min(1.0, v))
+    return v, chi2, df
 
 
 def convergence_report(
@@ -911,6 +1002,10 @@ def convergence_report(
         # Classify
         level = _classify_alpha(alpha_q)
 
+        # GH-313: cross-model effect size — does model choice predict the
+        # response category? Built from the same MxN matrix used for alpha.
+        cramers_v_q, chi2_q, df_q = _model_category_cramers_v(reliability_data)
+
         # Per-model distributions
         per_model: list[ModelDistribution] = []
         model_top_choices: dict[str, str] = {}
@@ -938,24 +1033,29 @@ def convergence_report(
         divergent = [m for m in model_names if model_top_choices[m] != majority_top]
         top_choice_agreement = len(divergent) == 0
 
-        # Interpretation
+        # Interpretation — leads with effect size (Cramer's V) per GH-313 so the
+        # reader's first impression is "how strongly does model predict
+        # response?" rather than the more abstract Krippendorff's alpha.
+        effect_label = _classify_cramers_v_effect(cramers_v_q)
+        effect_lead = f"Cramer's V={cramers_v_q:.3f} ({effect_label} effect)"
         if level == ConvergenceLevel.STRONG:
             interpretation = (
-                f"Strong convergence (alpha={alpha_q:.2f}). All models agree: {majority_top} is the top choice."
+                f"Strong convergence — {effect_lead}; alpha={alpha_q:.2f}. "
+                f"All models agree: {majority_top} is the top choice."
             )
         elif level == ConvergenceLevel.MODERATE:
             interpretation = (
-                f"Moderate convergence (alpha={alpha_q:.2f}). "
+                f"Moderate convergence — {effect_lead}; alpha={alpha_q:.2f}. "
                 f"Models mostly agree on {majority_top} but with some variation."
             )
         elif level == ConvergenceLevel.WEAK:
             interpretation = (
-                f"Weak convergence (alpha={alpha_q:.2f}). "
+                f"Weak convergence — {effect_lead}; alpha={alpha_q:.2f}. "
                 f"Interpret with caution. {divergent} disagree with the majority."
             )
         else:
             interpretation = (
-                f"No convergence (alpha={alpha_q:.2f}). "
+                f"No convergence — {effect_lead}; alpha={alpha_q:.2f}. "
                 f"Model choice dominates this finding. {divergent} diverge. Not reliable."
             )
 
@@ -969,12 +1069,16 @@ def convergence_report(
                 top_choice_agreement=top_choice_agreement,
                 divergent_models=divergent,
                 interpretation=interpretation,
+                cramers_v=cramers_v_q,
+                chi2=chi2_q,
+                chi2_df=df_q,
             )
         )
 
     # Overall metrics
     overall_alpha = sum(f.alpha for f in findings) / len(findings)
     overall_level = _classify_alpha(overall_alpha)
+    overall_cramers_v = sum(f.cramers_v for f in findings) / len(findings)
     n_convergent = sum(1 for f in findings if f.alpha >= 0.60)
     n_divergent = sum(1 for f in findings if f.alpha < 0.40)
 
@@ -986,6 +1090,7 @@ def convergence_report(
         n_divergent=n_divergent,
         n_models=n_models,
         model_names=model_names,
+        overall_cramers_v=overall_cramers_v,
     )
 
 

--- a/tests/fixtures/convergence/calibration_report.json
+++ b/tests/fixtures/convergence/calibration_report.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "sp-bldz golden fixture — pins per_question[key].calibration wire format. Field names, casing, and nesting are committed; downstream sp-pack-registry consumes this shape. Additive-only changes per structure.md §6 and plan.md R3.",
+  "_comment": "sp-bldz / GH-313 golden fixture — pins per_question[key].calibration wire format. Field names, casing, and nesting are committed; downstream sp-pack-registry consumes this shape. Additive-only changes per structure.md §6 and plan.md R3.",
   "per_question": {
     "happy": {
       "final_n": 10,
@@ -10,7 +10,12 @@
         "jsd": 0.008454,
         "baseline_spec": "gss:HAPPY",
         "extractor": "pick_one:auto-derived",
-        "auto_derived": true
+        "auto_derived": true,
+        "cramers_v": 0.15,
+        "chi2_df": 2,
+        "chi2_p_value": 0.798516,
+        "chi2_warning": "Some expected count(s) < 5 (min=1.0). Chi-squared approximation may be unreliable.",
+        "lead_interpretation": "Cramer's V=0.150 (small effect vs baseline). Mild deviation from baseline - panel proportions track the human shape with minor drift. p=0.7985 (approximate - Some expected count(s) < 5 (min=1.0). Chi-squared approximation may be unreliable); treat effect size as directional."
       },
       "skew_vs_uniform": {
         "chi2": 3.8,
@@ -31,7 +36,9 @@
         "baseline_spec": "gss:HAPPY",
         "extractor": "pick_one:auto-derived",
         "auto_derived": true,
-        "alignment_error": "['blue', 'red'] vs ['Not too happy', 'Pretty happy', 'Very happy']"
+        "alignment_error": "['blue', 'red'] vs ['Not too happy', 'Pretty happy', 'Very happy']",
+        "cramers_v": 1.0,
+        "lead_interpretation": "Cramer's V=1.000 (large effect vs baseline). Panel and baseline use disjoint category vocabularies; see alignment_error before drawing conclusions."
       },
       "skew_vs_uniform": {
         "chi2": 1.6,

--- a/tests/test_convergence_metric.py
+++ b/tests/test_convergence_metric.py
@@ -365,12 +365,27 @@ def test_build_report_attaches_calibration_subobject_with_provenance():
     )
 
     calib = report["per_question"]["happy"]["calibration"]
-    assert set(calib.keys()) == {"jsd", "baseline_spec", "extractor", "auto_derived"}
+    # GH-313: cramers_v effect size + chi-squared provenance attached
+    # alongside the original sp-bldz fields. Schema is additive — order is
+    # not pinned but all keys must be present.
+    assert set(calib.keys()) == {
+        "jsd",
+        "baseline_spec",
+        "extractor",
+        "auto_derived",
+        "cramers_v",
+        "chi2_df",
+        "chi2_p_value",
+        "chi2_warning",
+        "lead_interpretation",
+    }
     assert 0.0 <= calib["jsd"] <= 1.0
     assert calib["jsd"] == 0.008454  # rounded to 6 dp per wire format
     assert calib["baseline_spec"] == "gss:HAPPY"
     assert calib["extractor"] == "pick_one:auto-derived"
     assert calib["auto_derived"] is True
+    assert 0.0 <= calib["cramers_v"] <= 1.0
+    assert calib["lead_interpretation"].startswith("Cramer's V=")
     # human_baseline still spliced in verbatim.
     assert report["human_baseline"] is baseline
 
@@ -533,6 +548,114 @@ def test_compute_calibration_jsd_wraps_local_implementation():
     assert compute_calibration_jsd({"a": 1.0}, {"b": 1.0}) == pytest.approx(1.0)
     # Empty model distribution → 0.0 (no panelist signal yet).
     assert compute_calibration_jsd({}, {"a": 1.0}) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# GH-313: compute_calibration_cramers_v
+# ---------------------------------------------------------------------------
+
+
+def test_compute_calibration_cramers_v_exact_match_yields_zero():
+    """Model dist matches baseline proportions exactly → Cramer's V is 0."""
+    from synth_panel.convergence import compute_calibration_cramers_v
+
+    v, df, p, warn = compute_calibration_cramers_v(
+        {"a": 5, "b": 3, "c": 2},
+        {"a": 0.5, "b": 0.3, "c": 0.2},
+    )
+    assert v == pytest.approx(0.0, abs=1e-9)
+    assert df == 2
+    assert p == pytest.approx(1.0, abs=1e-9)
+    # Expected counts (5, 3, 2) include a value < 5, so a small-counts warning fires.
+    assert warn is not None
+
+
+def test_compute_calibration_cramers_v_small_deviation():
+    """Mild deviation from baseline → small effect size in [0.1, 0.3)."""
+    from synth_panel.convergence import compute_calibration_cramers_v
+
+    v, df, _p, _warn = compute_calibration_cramers_v(
+        {"a": 6, "b": 3, "c": 1},
+        {"a": 0.5, "b": 0.4, "c": 0.1},
+    )
+    assert df == 2
+    assert 0.1 <= v < 0.3
+
+
+def test_compute_calibration_cramers_v_clamped_to_one():
+    """Smoothed expected counts can blow up chi-squared past 1.0; result is clamped."""
+    from synth_panel.convergence import compute_calibration_cramers_v
+
+    v, _df, _p, _warn = compute_calibration_cramers_v(
+        {"red": 7, "blue": 3},
+        {"never": 0.3, "sometimes": 0.3, "often": 0.4},
+    )
+    assert 0.0 <= v <= 1.0
+
+
+def test_compute_calibration_cramers_v_rejects_empty_inputs():
+    """Empty model or empty baseline → zero effect, no chi-squared computed."""
+    from synth_panel.convergence import compute_calibration_cramers_v
+
+    v, df, p, warn = compute_calibration_cramers_v({}, {"a": 1.0})
+    assert (v, df, p, warn) == (0.0, 0, 1.0, None)
+    v, df, p, warn = compute_calibration_cramers_v({"a": 5}, {})
+    assert (v, df, p, warn) == (0.0, 0, 1.0, None)
+
+
+def test_build_report_calibration_disjoint_pegs_cramers_v_to_one():
+    """Disjoint supports: cramers_v mirrors the JSD upper bound (1.0)."""
+    questions = [_pick_one_question("color")]
+    tracked = identify_tracked_questions(questions)
+    tracker = ConvergenceTracker(tracked, check_every=100, min_n=0, m_consecutive=2)
+    for _ in range(5):
+        tracker.record({"color": "red"})
+    for _ in range(5):
+        tracker.record({"color": "blue"})
+
+    baseline = {
+        "human_distribution": {
+            "Very happy": 0.5,
+            "Pretty happy": 0.3,
+            "Not too happy": 0.2,
+        }
+    }
+    report = tracker.build_report(
+        baseline=baseline,
+        calibration_spec="gss:HAPPY",
+        extractor_label="pick_one:auto-derived",
+        auto_derived=True,
+    )
+    calib = report["per_question"]["color"]["calibration"]
+    assert calib["cramers_v"] == 1.0
+    assert "lead_interpretation" in calib
+    assert "disjoint" in calib["lead_interpretation"]
+
+
+def test_build_report_calibration_lead_interpretation_uses_cohen_buckets():
+    """Effect size string surfaces a recognisable Cohen-style label."""
+    questions = [_pick_one_question("happy")]
+    tracked = identify_tracked_questions(questions)
+    tracker = ConvergenceTracker(tracked, check_every=100, min_n=0, m_consecutive=2)
+    # Strong skew vs baseline (model concentrates on "Very happy", baseline spreads).
+    for _ in range(20):
+        tracker.record({"happy": "Very happy"})
+    baseline = {
+        "human_distribution": {
+            "Very happy": 0.3,
+            "Pretty happy": 0.4,
+            "Not too happy": 0.3,
+        }
+    }
+    report = tracker.build_report(
+        baseline=baseline,
+        calibration_spec="gss:HAPPY",
+        extractor_label="pick_one",
+        auto_derived=False,
+    )
+    calib = report["per_question"]["happy"]["calibration"]
+    assert calib["cramers_v"] > 0.5
+    assert "large effect" in calib["lead_interpretation"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pack_calibrate.py
+++ b/tests/test_pack_calibrate.py
@@ -68,6 +68,43 @@ def test_calibration_entry_keeps_alignment_error_when_set():
     assert d["alignment_error"] == "['x'] vs ['y']"
 
 
+def test_calibration_entry_drops_none_cramers_v():
+    """GH-313: omitted effect size must not pollute the YAML wire shape."""
+    entry = CalibrationEntry(
+        dataset="gss",
+        question="HAPPY",
+        jsd=0.18,
+        n=100,
+        samples_per_question=15,
+        models=["haiku:1.0"],
+        extractor="pick_one:auto-derived",
+        panelist_cost_usd=0.5,
+        calibrated_at="2026-04-26T14:23:00Z",
+        synthpanel_version="0.11.1",
+    )
+    d = entry.to_yaml_dict()
+    assert "cramers_v" not in d
+
+
+def test_calibration_entry_emits_cramers_v_when_set():
+    """GH-313: surfaced effect size flows through to the YAML wire shape."""
+    entry = CalibrationEntry(
+        dataset="gss",
+        question="HAPPY",
+        jsd=0.04,
+        n=100,
+        samples_per_question=15,
+        models=["haiku:1.0"],
+        extractor="pick_one:auto-derived",
+        panelist_cost_usd=0.5,
+        calibrated_at="2026-04-26T14:23:00Z",
+        synthpanel_version="0.11.1",
+        cramers_v=0.123,
+    )
+    d = entry.to_yaml_dict()
+    assert d["cramers_v"] == 0.123
+
+
 def test_merge_calibration_appends_when_no_existing_match():
     existing = [
         {"dataset": "gss", "question": "HAPPY", "jsd": 0.9},
@@ -212,10 +249,12 @@ def _write_pack(tmp_path: Path) -> Path:
 def _mock_panel_run_result() -> dict:
     return {
         "jsd": 0.234567,
+        "cramers_v": 0.182345,
         "extractor": "pick_one:auto-derived",
         "models": ["haiku:1.0"],
         "panelist_cost_usd": 0.1234,
         "alignment_error": None,
+        "lead_interpretation": "Cramer's V=0.182 (small effect vs baseline). Mild deviation.",
     }
 
 
@@ -247,6 +286,40 @@ def test_cli_pack_calibrate_dry_run_does_not_write(tmp_path, capsys):
     assert "calibration:" in out
     assert "dataset: gss" in out
     assert "jsd: 0.234567" in out
+
+
+def test_cli_pack_calibrate_persists_cramers_v(tmp_path, capsys):
+    """GH-313: the panel run's cramers_v lands in the pack YAML and the success
+    line leads with effect size (large/medium/small/negligible) before JSD."""
+    pack = _write_pack(tmp_path)
+    with patch(
+        "synth_panel.cli.commands._run_calibration_panel",
+        return_value=_mock_panel_run_result(),
+    ):
+        rc = main(
+            [
+                "pack",
+                "calibrate",
+                str(pack),
+                "--against",
+                "gss:HAPPY",
+                "--n",
+                "20",
+                "--samples-per-question",
+                "5",
+                "--yes",
+            ]
+        )
+    assert rc == 0
+    parsed = yaml.safe_load(pack.read_text(encoding="utf-8"))
+    cal = parsed["calibration"][0]
+    assert cal["cramers_v"] == 0.182345
+    out = capsys.readouterr().out
+    # Effect-size readout MUST appear before the JSD scalar in the success summary.
+    assert "Cramer's V=0.182" in out
+    assert "small" in out
+    assert "JSD=" in out
+    assert out.index("Cramer's V") < out.index("JSD=")
 
 
 def test_cli_pack_calibrate_writes_in_place(tmp_path):

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -527,6 +527,56 @@ class TestConvergenceReport:
         assert result.n_models == 2
         assert set(result.model_names) == {"gemini", "haiku"}
 
+    # GH-313: cross-model effect size (Cramer's V) on the model × category
+    # contingency table — independent of Krippendorff's alpha so calibrated
+    # convergence claims can be read in standard categorical-effect terms.
+
+    def test_cramers_v_zero_when_models_agree(self):
+        """All models produce identical responses → no model-effect on response."""
+        responses = {
+            "model_a": [["X"], ["X"], ["Y"], ["X"]],
+            "model_b": [["X"], ["X"], ["Y"], ["X"]],
+            "model_c": [["X"], ["X"], ["Y"], ["X"]],
+        }
+        result = convergence_report(responses, ["Q1"])
+        finding = result.findings[0]
+        assert finding.cramers_v == pytest.approx(0.0, abs=1e-9)
+        assert finding.chi2_df == 2  # (3-1)*(2-1) = 2 (3 models, 2 categories)
+
+    def test_cramers_v_one_when_models_fully_diverge(self):
+        """Each model picks a different category systematically → V → 1.0."""
+        responses = {
+            "model_a": [["X"]] * 5,
+            "model_b": [["Y"]] * 5,
+            "model_c": [["Z"]] * 5,
+        }
+        result = convergence_report(responses, ["Q1"])
+        finding = result.findings[0]
+        assert finding.cramers_v == pytest.approx(1.0, abs=1e-9)
+        assert finding.chi2_df == 4  # (3-1) * (3-1)
+
+    def test_overall_cramers_v_is_mean_of_findings(self):
+        """ConvergenceReport.overall_cramers_v averages per-finding effect sizes."""
+        responses = {
+            "model_a": [["X", "M"], ["X", "M"], ["X", "M"], ["X", "M"]],
+            "model_b": [["X", "N"], ["X", "N"], ["X", "N"], ["X", "N"]],
+        }
+        result = convergence_report(responses, ["Q1", "Q2"])
+        # Q1: both models agree → cramers_v ≈ 0; Q2: full disagreement → 1.0
+        v_per_q = [f.cramers_v for f in result.findings]
+        assert result.overall_cramers_v == pytest.approx(sum(v_per_q) / len(v_per_q))
+
+    def test_finding_interpretation_leads_with_effect_size(self):
+        """GH-313: per-finding interpretation surfaces Cramer's V before alpha."""
+        responses = {
+            "model_a": [["X"]] * 5,
+            "model_b": [["Y"]] * 5,
+        }
+        result = convergence_report(responses, ["Q1"])
+        text = result.findings[0].interpretation
+        assert "Cramer's V=" in text
+        assert text.index("Cramer's V=") < text.index("alpha=")
+
 
 # ---------------------------------------------------------------------------
 # cluster_personas (sp-5on.9)


### PR DESCRIPTION
## Summary
- Surfaces Cramer's V effect size in the calibration block of `convergence.build_report` and `CalibrationEntry`
- Adds the metric to `pack calibrate` success line and `stats.convergence_report` cross-model findings
- Gives panel runs an interpretable measure of effect strength alongside p-values

## Test plan
- [x] 11 new tests added
- [x] All 1940 tests in suite pass
- [x] `ruff` + `mypy` clean

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)