### PR TITLE
[SP#344] mcp/sampling.py: panels truncate silently when MCP host caps tokens (sp-k2ed4a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ### Changed (loudness)
 - (sp-g59o) Detection: warn loudly when synthesis output appears unstructured (likely model schema-adherence flake). Triggered when every list field — themes, agreements, disagreements, surprises — is empty while the recommendation slot carries >600 chars of prose. Surfaces as a `synth_panel.synthesis` `logger.warning`, on `SynthesisResult.warnings`, and propagated up to `PanelResult.warnings`. Schema-honoring runs are unchanged. Observed at ~25% on `gemini-flash-lite` synthesis; detection is provider-agnostic.
+- (sp-k2ed4a) MCP sampling truncation surfacing: `synth_panel.mcp.sampling.sample_text` now detects host-side `stopReason="maxTokens"` truncation, logs a `logger.warning`, and returns `truncated`/`requested_max_tokens`/`warning` fields. The sampling paths in `run_prompt`, `run_panel`, and `run_quick_poll` propagate truncated turns into the response `warnings` list with persona/synthesis labels, so a failed structured-output parse can be attributed to the host clipping output rather than the model ignoring the schema. No protocol-level startup check is possible — MCP capability negotiation does not expose the host's max_tokens cap — so per-turn detection is the loud surface.
 
 ## [0.12.0] - 2026-04-26
 

--- a/src/synth_panel/mcp/sampling.py
+++ b/src/synth_panel/mcp/sampling.py
@@ -27,8 +27,11 @@ Tool handlers call :func:`sample_text` once the decision is made.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 # Sampling mode guardrails — keep invocations light so we don't blast
 # the host agent's context window. Heavy research panels still require
@@ -37,13 +40,23 @@ SAMPLING_MAX_PERSONAS = 3
 SAMPLING_MAX_QUESTIONS = 5
 SAMPLING_MAX_TOKENS_DEFAULT = 2048
 
+# sp-k2ed4a: canonical MCP stop_reason value indicating the host's token
+# ceiling cut the response off mid-stream. Hosts (Claude Desktop, Cursor,
+# Windsurf...) commonly cap output more aggressively than the request,
+# silently truncating the JSON a structured-output engine then fails to
+# parse. We surface this as a warning so callers can distinguish "host
+# clipped me" from generic schema-fail.
+SAMPLING_STOP_REASON_TRUNCATED = "maxTokens"
+
 __all__ = [
     "SAMPLING_CRED_ENV_VARS",
     "SAMPLING_FIRST_RUN_HINT",
     "SAMPLING_MAX_PERSONAS",
     "SAMPLING_MAX_QUESTIONS",
     "SAMPLING_MAX_TOKENS_DEFAULT",
+    "SAMPLING_STOP_REASON_TRUNCATED",
     "SamplingDecision",
+    "build_truncation_warning",
     "client_supports_sampling",
     "decide_mode",
     "has_byok_credentials",
@@ -213,6 +226,27 @@ def decide_mode(
     )
 
 
+def build_truncation_warning(*, max_tokens: int, model: str | None) -> str:
+    """Build a user-facing message describing host-side token-cap truncation.
+
+    Surfaced in panel/quick-poll ``warnings`` lists so MCP/CLI consumers
+    can distinguish a host max_tokens cap from a generic schema-fail when
+    a structured-output post-parse fallback fires. ``model`` is whatever
+    the host reported running (e.g. ``"claude-opus-4-6"``); ``None`` when
+    the host did not name a model.
+    """
+    model_part = f" (host model: {model})" if model else ""
+    return (
+        f"MCP host truncated sampling output at the {max_tokens}-token "
+        f"ceiling{model_part} — the response may be incomplete and any "
+        "structured-output parse failure on this turn is likely caused by "
+        "truncation rather than the model ignoring the schema. Hosts may "
+        "cap output more aggressively than requested; for longer schemas, "
+        "set a provider key (e.g. ANTHROPIC_API_KEY) to use BYOK with a "
+        "higher token budget."
+    )
+
+
 async def sample_text(
     ctx: Any,
     *,
@@ -223,11 +257,21 @@ async def sample_text(
 ) -> dict[str, Any]:
     """Run one sampling round via ``ctx.session.create_message``.
 
-    Returns a dict with keys ``text``, ``model``, ``stop_reason``, and
-    ``role``. The model string is whatever the host agent chose to run
-    (e.g. ``"claude-opus-4-6"`` when invoked from Claude Desktop). We
+    Returns a dict with keys ``text``, ``model``, ``stop_reason``,
+    ``role``, ``truncated``, ``requested_max_tokens``, and ``warning``.
+    The model string is whatever the host agent chose to run (e.g.
+    ``"claude-opus-4-6"`` when invoked from Claude Desktop). We
     normalise content blocks to a single joined string so downstream
     consumers don't have to special-case multi-block responses.
+
+    Truncation detection (sp-k2ed4a): when the host reports
+    ``stopReason == "maxTokens"`` the response was cut short by the
+    host's output cap. This commonly happens because hosts (Claude
+    Desktop, Cursor, Windsurf...) impose their own ceiling that ignores
+    or undershoots ``max_tokens``. We log a warning, set ``truncated``,
+    and surface a ready-to-display ``warning`` string so callers can
+    propagate the signal into their ``warnings`` payload instead of
+    chalking the partial JSON up to a generic schema-fail.
     """
     from mcp.types import SamplingMessage, TextContent
 
@@ -245,11 +289,26 @@ async def sample_text(
     )
 
     text = _extract_text(result.content)
+    stop_reason = getattr(result, "stopReason", None)
+    truncated = stop_reason == SAMPLING_STOP_REASON_TRUNCATED
+    warning: str | None = None
+    if truncated:
+        warning = build_truncation_warning(max_tokens=max_tokens, model=result.model)
+        logger.warning(
+            "MCP sampling truncated: stopReason=%s requested_max_tokens=%d model=%s output_chars=%d",
+            stop_reason,
+            max_tokens,
+            result.model,
+            len(text),
+        )
     return {
         "text": text,
         "model": result.model,
-        "stop_reason": getattr(result, "stopReason", None),
+        "stop_reason": stop_reason,
         "role": result.role,
+        "truncated": truncated,
+        "requested_max_tokens": max_tokens,
+        "warning": warning,
     }
 
 

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -822,6 +822,9 @@ async def run_prompt(
             max_tokens=4096,
             temperature=temperature,
         )
+        # sp-k2ed4a: surface host-side truncation so callers see why a
+        # prompt response is short, not just a generic empty result.
+        warnings = [sample["warning"]] if sample.get("truncated") and sample.get("warning") else []
         return json.dumps(
             {
                 "response": sample["text"],
@@ -830,6 +833,7 @@ async def run_prompt(
                 "usage": None,
                 "cost": None,
                 "hint": decision.hint,
+                "warnings": warnings,
             },
             indent=2,
         )
@@ -1439,6 +1443,10 @@ async def _run_panel_sampling(
     question_texts = [str(q["text"]) for q in questions]
     joined_questions = "\n\n".join(f"Q{i + 1}: {t}" for i, t in enumerate(question_texts))
 
+    # sp-k2ed4a: collect host-side truncation warnings so the run summary
+    # can flag turns that were silently cut off by the host's max_tokens
+    # ceiling (otherwise indistinguishable from generic schema-fail).
+    sampling_warnings: list[str] = []
     for i, persona in enumerate(personas):
         system_prompt = persona_system_prompt(persona)
         user_prompt = (
@@ -1453,6 +1461,9 @@ async def _run_panel_sampling(
             temperature=temperature,
         )
         host_model = sample["model"]
+        if sample.get("truncated") and sample.get("warning"):
+            persona_name = persona.get("name", f"persona_{i}")
+            sampling_warnings.append(f"panelist '{persona_name}': {sample['warning']}")
         # Surface the full answer string against every question so the
         # output matches BYOK shape: one response entry per question.
         responses = [{"question": q_text, "answer": sample["text"]} for q_text in question_texts]
@@ -1483,6 +1494,8 @@ async def _run_panel_sampling(
             max_tokens=SAMPLING_MAX_TOKENS_DEFAULT,
             temperature=temperature,
         )
+        if synth.get("truncated") and synth.get("warning"):
+            sampling_warnings.append(f"synthesis: {synth['warning']}")
         synthesis_block = {
             "summary": synth["text"],
             "model": synth["model"],
@@ -1505,7 +1518,7 @@ async def _run_panel_sampling(
         ],
         "synthesis": synthesis_block,
         "path": [],
-        "warnings": [],
+        "warnings": sampling_warnings,
         "usage": None,
         "cost": None,
         "metadata": None,
@@ -1538,6 +1551,7 @@ async def _run_quick_poll_sampling(
     await ctx.report_progress(0, len(personas))
     panelist_entries: list[dict[str, Any]] = []
     host_model: str | None = None
+    sampling_warnings: list[str] = []
     for i, persona in enumerate(personas):
         system_prompt = persona_system_prompt(persona)
         user_prompt = build_question_prompt({"text": question})
@@ -1549,6 +1563,9 @@ async def _run_quick_poll_sampling(
             temperature=temperature,
         )
         host_model = sample["model"]
+        if sample.get("truncated") and sample.get("warning"):
+            persona_name = persona.get("name", f"persona_{i}")
+            sampling_warnings.append(f"panelist '{persona_name}': {sample['warning']}")
         panelist_entries.append(
             {
                 "persona": persona,
@@ -1578,6 +1595,8 @@ async def _run_quick_poll_sampling(
             max_tokens=2048,
             temperature=temperature,
         )
+        if synth.get("truncated") and synth.get("warning"):
+            sampling_warnings.append(f"synthesis: {synth['warning']}")
         synthesis_block = {
             "summary": synth["text"],
             "model": synth["model"],
@@ -1600,7 +1619,7 @@ async def _run_quick_poll_sampling(
         ],
         "synthesis": synthesis_block,
         "path": [],
-        "warnings": [],
+        "warnings": sampling_warnings,
         "usage": None,
         "cost": None,
         "metadata": None,

--- a/tests/test_mcp_sampling.py
+++ b/tests/test_mcp_sampling.py
@@ -226,7 +226,12 @@ class TestDecideMode:
 # ---------------------------------------------------------------------------
 
 
-def _make_sampling_ctx(supports: bool, *, sample_text: str = "sampled!"):
+def _make_sampling_ctx(
+    supports: bool,
+    *,
+    sample_text: str = "sampled!",
+    stop_reason: str = "endTurn",
+):
     """Build a MagicMock Context that the tool can invoke without
     hitting the FastMCP test harness's Context auto-injection path."""
     ctx = MagicMock()
@@ -241,7 +246,7 @@ def _make_sampling_ctx(supports: bool, *, sample_text: str = "sampled!"):
         msg.content = text_block
         msg.model = "host-agent-model"
         msg.role = "assistant"
-        msg.stopReason = "endTurn"
+        msg.stopReason = stop_reason
         return msg
 
     ctx.session.create_message = AsyncMock(side_effect=_create_message)
@@ -525,3 +530,211 @@ class TestRunPanelSampling:
         assert "error" in data
         assert "ANTHROPIC_API_KEY" in data["error"]
         ctx.session.create_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# sp-k2ed4a — host-side max_tokens truncation detection
+# ---------------------------------------------------------------------------
+
+
+class TestSampleTextTruncationDetection:
+    """Unit tests for the new truncation flag on ``sample_text``."""
+
+    @pytest.mark.asyncio
+    async def test_max_tokens_stop_reason_flags_truncation(self):
+        from synth_panel.mcp.sampling import sample_text
+
+        ctx = _make_sampling_ctx(
+            supports=True,
+            sample_text='{"summary":"partial',
+            stop_reason="maxTokens",
+        )
+        result = await sample_text(ctx, prompt="hi", max_tokens=256)
+
+        assert result["truncated"] is True
+        assert result["stop_reason"] == "maxTokens"
+        assert result["requested_max_tokens"] == 256
+        assert result["warning"] is not None
+        assert "256" in result["warning"]
+        assert "host-agent-model" in result["warning"]
+
+    @pytest.mark.asyncio
+    async def test_end_turn_stop_reason_does_not_flag_truncation(self):
+        from synth_panel.mcp.sampling import sample_text
+
+        ctx = _make_sampling_ctx(supports=True, sample_text="full reply", stop_reason="endTurn")
+        result = await sample_text(ctx, prompt="hi", max_tokens=4096)
+
+        assert result["truncated"] is False
+        assert result["warning"] is None
+        assert result["requested_max_tokens"] == 4096
+
+    @pytest.mark.asyncio
+    async def test_other_stop_reasons_do_not_flag_truncation(self):
+        # ``stopSequence`` and ``toolUse`` are well-formed terminations —
+        # only ``maxTokens`` indicates host-side cap truncation.
+        from synth_panel.mcp.sampling import sample_text
+
+        for reason in ("stopSequence", "toolUse"):
+            ctx = _make_sampling_ctx(supports=True, stop_reason=reason)
+            result = await sample_text(ctx, prompt="hi", max_tokens=2048)
+            assert result["truncated"] is False, reason
+            assert result["warning"] is None, reason
+
+    @pytest.mark.asyncio
+    async def test_truncation_logs_warning(self, caplog):
+        import logging
+
+        from synth_panel.mcp.sampling import sample_text
+
+        ctx = _make_sampling_ctx(
+            supports=True,
+            sample_text="cut off",
+            stop_reason="maxTokens",
+        )
+        with caplog.at_level(logging.WARNING, logger="synth_panel.mcp.sampling"):
+            await sample_text(ctx, prompt="hi", max_tokens=512)
+
+        assert any(
+            "MCP sampling truncated" in r.message and "requested_max_tokens=512" in r.message for r in caplog.records
+        )
+
+
+class TestRunPromptTruncationWarnings:
+    """sp-k2ed4a integration: ``run_prompt`` surfaces truncation warnings."""
+
+    @pytest.mark.asyncio
+    async def test_truncation_in_sampling_branch_surfaces_warning(self):
+        from synth_panel.mcp.server import run_prompt
+
+        ctx = _make_sampling_ctx(
+            supports=True,
+            sample_text="partial json",
+            stop_reason="maxTokens",
+        )
+        raw = await run_prompt(prompt="anything", ctx=ctx)
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        assert data["warnings"]  # non-empty
+        assert "truncated" in data["warnings"][0].lower()
+
+    @pytest.mark.asyncio
+    async def test_no_truncation_yields_empty_warnings_list(self):
+        from synth_panel.mcp.server import run_prompt
+
+        ctx = _make_sampling_ctx(supports=True, sample_text="ok", stop_reason="endTurn")
+        raw = await run_prompt(prompt="anything", ctx=ctx)
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        assert data["warnings"] == []
+
+
+class TestRunPanelSamplingTruncationWarnings:
+    """sp-k2ed4a integration: panel sampling propagates per-turn truncation."""
+
+    @pytest.mark.asyncio
+    async def test_panelist_truncation_appears_in_warnings(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(
+            supports=True,
+            sample_text="cut off",
+            stop_reason="maxTokens",
+        )
+        raw = await run_panel(
+            questions=[{"text": "What do you think?"}],
+            personas=[{"name": "Alice"}, {"name": "Bob"}],
+            synthesis=False,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+
+        assert data["mode"] == "sampling"
+        # One warning per panelist when every turn was truncated.
+        assert len(data["warnings"]) == 2
+        assert all("truncated" in w.lower() for w in data["warnings"])
+        # Persona name is included so operators can pinpoint the turn.
+        assert any("Alice" in w for w in data["warnings"])
+        assert any("Bob" in w for w in data["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_synthesis_truncation_labelled_separately(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(
+            supports=True,
+            sample_text="part",
+            stop_reason="maxTokens",
+        )
+        raw = await run_panel(
+            questions=[{"text": "Q1?"}],
+            personas=[{"name": "Alice"}],
+            synthesis=True,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+
+        # 1 panelist + 1 synthesis = 2 warnings, with the synthesis
+        # turn distinguishable by the "synthesis:" prefix.
+        assert len(data["warnings"]) == 2
+        assert any(w.startswith("synthesis:") for w in data["warnings"])
+        assert any(w.startswith("panelist") for w in data["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_clean_run_yields_empty_warnings(self):
+        from synth_panel.mcp.server import run_panel
+
+        ctx = _make_sampling_ctx(supports=True, sample_text="full reply", stop_reason="endTurn")
+        raw = await run_panel(
+            questions=[{"text": "Q1?"}],
+            personas=[{"name": "Alice"}],
+            synthesis=True,
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+
+        assert data["warnings"] == []
+
+
+class TestRunQuickPollSamplingTruncationWarnings:
+    @pytest.mark.asyncio
+    async def test_quick_poll_truncation_surfaces_warnings(self):
+        from synth_panel.mcp.server import run_quick_poll
+
+        ctx = _make_sampling_ctx(
+            supports=True,
+            sample_text="cut",
+            stop_reason="maxTokens",
+        )
+        raw = await run_quick_poll(
+            question="Sky blue?",
+            personas=[{"name": "Alice"}],
+            ctx=ctx,
+        )
+        data = json.loads(raw)
+
+        # 1 panelist + 1 synthesis = 2 truncated turns surfaced.
+        assert data["mode"] == "sampling"
+        assert len(data["warnings"]) == 2
+        assert any(w.startswith("panelist 'Alice'") for w in data["warnings"])
+        assert any(w.startswith("synthesis:") for w in data["warnings"])
+
+
+class TestBuildTruncationWarning:
+    def test_includes_max_tokens_and_model(self):
+        from synth_panel.mcp.sampling import build_truncation_warning
+
+        msg = build_truncation_warning(max_tokens=512, model="claude-opus-4-6")
+        assert "512" in msg
+        assert "claude-opus-4-6" in msg
+        # Operator-actionable hint to set BYOK key for longer schemas.
+        assert "ANTHROPIC_API_KEY" in msg
+
+    def test_no_model_omits_model_part(self):
+        from synth_panel.mcp.sampling import build_truncation_warning
+
+        msg = build_truncation_warning(max_tokens=2048, model=None)
+        assert "2048" in msg
+        assert "(host model:" not in msg


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery.

- Issue: sp-k2ed4a
- Branch: polecat/sp-k2ed4a
- Target: main