### PR TITLE
[record] [SP#288] Add `--dry-run` to `panel run` — print composition + cost estimate without calling LLM (sp-ekayy9)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -747,6 +747,37 @@ def _load_schema(value: str) -> dict[str, Any]:
     return schema
 
 
+# sp-ekayy9: rough output-token defaults per response_schema type. The
+# dry-run preview multiplies these by persona_count × question_count to
+# get a worst-case bound for cost estimation. Real responses are usually
+# shorter (especially for free text), so the printed estimate is an upper
+# bound — exactly what an operator needs before paying for a panel run.
+_DRY_RUN_OUTPUT_TOKENS_TEXT_DEFAULT = 300
+_DRY_RUN_OUTPUT_TOKENS_BY_SCHEMA: dict[str, int] = {
+    "scale": 30,
+    "enum": 30,
+    "tagged_themes": 100,
+}
+
+
+def _estimate_output_tokens_per_response(question: Any) -> int:
+    """Return a rough per-response output-token estimate for *question*."""
+    if not isinstance(question, dict):
+        return _DRY_RUN_OUTPUT_TOKENS_TEXT_DEFAULT
+    rs = question.get("response_schema")
+    if not isinstance(rs, dict):
+        return _DRY_RUN_OUTPUT_TOKENS_TEXT_DEFAULT
+    rs_type = rs.get("type")
+    if rs_type == "text":
+        max_tokens = rs.get("max_tokens")
+        if isinstance(max_tokens, int) and not isinstance(max_tokens, bool) and max_tokens > 0:
+            return max_tokens
+        return _DRY_RUN_OUTPUT_TOKENS_TEXT_DEFAULT
+    if isinstance(rs_type, str) and rs_type in _DRY_RUN_OUTPUT_TOKENS_BY_SCHEMA:
+        return _DRY_RUN_OUTPUT_TOKENS_BY_SCHEMA[rs_type]
+    return _DRY_RUN_OUTPUT_TOKENS_TEXT_DEFAULT
+
+
 def _emit_dry_run_preview(
     *,
     personas: list[dict[str, Any]],
@@ -761,11 +792,13 @@ def _emit_dry_run_preview(
 
     Shows each question as it will appear to the LLM (after --var
     substitution, which has already been applied to the instrument),
-    plus persona/question counts and a rough input-token estimate.
+    persona/question counts, panel composition, a rough token estimate,
+    and an estimated cost from the local pricing table.
     """
     persona_count = len(personas)
     questions = instrument.questions
     question_count = len(questions)
+    llm_calls = persona_count * question_count
 
     system_prompt_chars = sum(len(system_prompt_fn(p)) for p in personas)
     question_chars = sum(len(build_question_prompt(q)) for q in questions)
@@ -782,6 +815,18 @@ def _emit_dry_run_preview(
     total_chars = system_prompt_chars + persona_count * (question_chars + follow_up_chars)
     estimated_input_tokens = max(1, total_chars // 4)
 
+    output_tokens_per_persona = sum(_estimate_output_tokens_per_response(q) for q in questions)
+    estimated_output_tokens = persona_count * output_tokens_per_persona
+
+    pricing, pricing_is_estimated = lookup_pricing(model)
+    cost = estimate_cost(
+        TokenUsage(
+            input_tokens=estimated_input_tokens,
+            output_tokens=estimated_output_tokens,
+        ),
+        pricing,
+    )
+
     if fmt is OutputFormat.TEXT:
         print("DRY RUN — no LLM calls will be made", file=sys.stderr)
         print(f"Model: {model}", file=sys.stderr)
@@ -790,6 +835,10 @@ def _emit_dry_run_preview(
             print(f"Questions: {question_count} across {len(instrument.rounds)} rounds", file=sys.stderr)
         else:
             print(f"Questions: {question_count}", file=sys.stderr)
+        print(
+            f"Panel: {persona_count} personas x {question_count} questions = {llm_calls:,} LLM calls",
+            file=sys.stderr,
+        )
         print("", file=sys.stderr)
 
         for round_ in instrument.rounds:
@@ -813,6 +862,17 @@ def _emit_dry_run_preview(
             f"({persona_count} personas x {question_count} questions, ~4 chars/token)",
             file=sys.stderr,
         )
+        print(
+            f"Estimated output tokens: ~{estimated_output_tokens:,} "
+            f"(rough heuristic from response_schema)",
+            file=sys.stderr,
+        )
+        cost_suffix = " [pricing=estimated-default]" if pricing_is_estimated else ""
+        print(
+            f"Estimated cost ({model}): ~${cost.total_cost:.4f}{cost_suffix}",
+            file=sys.stderr,
+        )
+        print("Validation: OK", file=sys.stderr)
         return
 
     preview: dict[str, Any] = {
@@ -820,7 +880,12 @@ def _emit_dry_run_preview(
         "model": model,
         "persona_count": persona_count,
         "question_count": question_count,
+        "llm_calls": llm_calls,
         "estimated_input_tokens": estimated_input_tokens,
+        "estimated_output_tokens": estimated_output_tokens,
+        "estimated_cost_usd": round(cost.total_cost, 6),
+        "cost_is_estimated": pricing_is_estimated,
+        "validation": "ok",
         "rounds": [
             {
                 "name": r.name,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3300,6 +3300,192 @@ class TestPanelRunDryRun:
         assert data["rounds"][0]["questions"] == ["Why now?"]
         mock_run_panel.assert_not_called()
 
+    # --- sp-ekayy9: cost estimate + validation + composition --------------
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_text_shows_panel_composition_and_cost(
+        self, mock_client_cls, mock_run_panel, capsys, tmp_path
+    ):
+        """Text preview prints LLM call count, cost estimate, and validation."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n  - name: Carol\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n  questions:\n    - text: Q1?\n    - text: Q2?\n    - text: Q3?\n    - text: Q4?\n"
+        )
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "sonnet",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "Panel: 3 personas x 4 questions = 12 LLM calls" in err
+        assert "Estimated output tokens" in err
+        assert "Estimated cost (sonnet):" in err
+        assert "Validation: OK" in err
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_json_includes_cost_and_validation(
+        self, mock_client_cls, mock_run_panel, capsys, tmp_path
+    ):
+        """JSON payload exposes llm_calls, cost, and validation fields."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n  - name: Bob\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q1\n    - text: Q2\n    - text: Q3\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "sonnet",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["llm_calls"] == 6
+        assert data["estimated_output_tokens"] > 0
+        assert data["estimated_cost_usd"] > 0
+        assert data["cost_is_estimated"] is False  # sonnet is in the pricing table
+        assert data["validation"] == "ok"
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_unknown_model_flags_estimated_pricing(
+        self, mock_client_cls, mock_run_panel, capsys, tmp_path
+    ):
+        """Models not in the pricing table fall back to DEFAULT_PRICING."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: Q1?\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "some-unlisted-model-9000",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["cost_is_estimated"] is True
+        assert data["estimated_cost_usd"] > 0
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_response_schema_max_tokens_drives_output_estimate(
+        self, mock_client_cls, mock_run_panel, capsys, tmp_path
+    ):
+        """A response_schema.max_tokens override scales the output estimate."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_small = tmp_path / "small.yaml"
+        survey_small.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: Q1?\n"
+            "      response_schema:\n"
+            "        type: text\n"
+            "        max_tokens: 50\n"
+        )
+        survey_big = tmp_path / "big.yaml"
+        survey_big.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: Q1?\n"
+            "      response_schema:\n"
+            "        type: text\n"
+            "        max_tokens: 1000\n"
+        )
+
+        def _run(survey_path):
+            code = main(
+                [
+                    "--output-format",
+                    "json",
+                    "panel",
+                    "run",
+                    "--personas",
+                    str(personas_file),
+                    "--instrument",
+                    str(survey_path),
+                    "--model",
+                    "sonnet",
+                    "--dry-run",
+                ]
+            )
+            assert code == 0
+            return json.loads(capsys.readouterr().out)
+
+        small = _run(survey_small)
+        big = _run(survey_big)
+
+        assert small["estimated_output_tokens"] == 50
+        assert big["estimated_output_tokens"] == 1000
+        assert big["estimated_cost_usd"] > small["estimated_cost_usd"]
+
+    def test_dry_run_invalid_instrument_yaml_returns_nonzero(self, capsys, tmp_path):
+        """Schema errors in the instrument fail the dry-run before any preview."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        # Bad: scale schema with min >= max should be rejected by parse_instrument.
+        survey_file.write_text(
+            "instrument:\n"
+            "  questions:\n"
+            "    - text: How much?\n"
+            "      response_schema:\n"
+            "        type: scale\n"
+            "        min: 5\n"
+            "        max: 1\n"
+        )
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--dry-run",
+            ]
+        )
+        assert code != 0
+        err = capsys.readouterr().err
+        assert "Validation: OK" not in err
+
 
 # --- sp-nn8k: _build_rounds_shape propagates cost_fallback_warnings ------
 


### PR DESCRIPTION
## Retroactive PR — direct-pushed work being recorded for review

This change was direct-pushed to `main` as commit `c30fb26` by Gastown Refinery for work bead `sp-ekayy9` / GitHub issue #288, **bypassing the standard PR flow**. The change is already in `main`; this PR opens against a `pre/sp-ekayy9` snapshot of main from before the direct push so reviewers can see the diff that landed.

**Action requested:** review the diff (already on main). Close this PR without merging — it's documentation, not a merge.

## Why this happened

The polecat that submitted this work didn't set `metadata.merge_strategy` on the work bead, and the refinery defaulted to `direct` and did `git push origin temp:main`. The push succeeded because the refinery's GitHub token has rule-bypass; the bypass surfaced as a warning rather than a blocking error.

Root cause was that the `gc-fix-merge-strategy` patch — which adds branch-protection auto-detect to the polecat done-sequence so beads get `merge_strategy=mr` whenever the target is protected — was missing from yggdrasil's polecat formula. asgard had it; yggdrasil didn't (pack drift). Without the patch, polecats only set `mr` if the LLM happens to set it explicitly.

## Fix shipped

- `gc-fix-merge-strategy ~/yggdrasil` re-applied. Polecats spawned after the fix will reliably auto-detect protection and set `merge_strategy=mr`.
- Refinery PR-body formula updated with `Closes #N` + GitHub issue link going forward (DataViking-Tech/dv-gascity-utils#15).
- Wiring-gap doc in DataViking-Tech/dv-gascity-utils#17 documents the host-state drift.

## See also

- Work bead: `sp-ekayy9`
- GitHub issue: https://github.com/DataViking-Tech/SynthPanel/issues/288 (already closed)
- Direct-push commit: c30fb26

Closes #288 (already closed; this PR is for the audit trail).

Generated with [Claude Code](https://claude.com/claude-code)