### PR TITLE
[record] [SP#293] [docs] MCP setup guide: clarify model resolution order when host has no sampling capability (sp-rvae9q)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Site: <https://synthpanel.dev> · Benchmark: <https://synthbench.org>
 
 Open-source synthetic focus groups. Any LLM. Your terminal or your agent's tool call.
 
-**Zero-config inside any MCP host that speaks sampling** (Claude Desktop, Claude Code, Cursor, Windsurf) — drop the config in and run a panel with **no API key set**. The host runs the model on your behalf, using its own subscription. Bring your own provider key (Claude, GPT, Gemini, Grok, local) when you want reproducibility, ensembles, or larger panels. Personas and instruments are plain YAML; every response is schema-validated with per-turn cost telemetry. Runs from your terminal, a pipeline, or an AI agent's MCP tool call.
+**Zero-config inside any MCP host that speaks sampling** (Claude Desktop, Claude Code, Cursor, Windsurf) — drop the config in and run a panel with **no API key set**. The host runs the model on your behalf, using its own subscription. [Bring your own provider key](docs/mcp.md#model-resolution-order) (Claude, GPT, Gemini, Grok, local) when you want reproducibility, ensembles, or larger panels. Personas and instruments are plain YAML; every response is schema-validated with per-turn cost telemetry. Runs from your terminal, a pipeline, or an AI agent's MCP tool call.
 
 ```bash
 pip install synthpanel
@@ -228,8 +228,9 @@ setup:
 Sampling mode is great for first-touch UX and quick exploratory polls.
 For cross-provider ensembles, larger panels, and reproducible model
 versioning, set a provider key in `env` to graduate to BYOK. See
-[docs/mcp.md#sampling-mode](docs/mcp.md#sampling-mode) for the full
-matrix of when sampling kicks in and what it costs.
+[docs/mcp.md#model-resolution-order](docs/mcp.md#model-resolution-order)
+for the full matrix of when sampling kicks in and which default model
+each provider key picks.
 
 ### Tools (12)
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -141,6 +141,71 @@ All panel runs (`run_panel`, `run_quick_poll`, `extend_panel`) return a uniform 
 
 For v1/v2 instruments and raw `questions` input, `path` is empty or linear and `warnings` is typically empty — the shape is uniform across versions.
 
+## Model Resolution Order
+
+Two questions are answered at the start of every MCP tool call: **which
+execution mode** (sampling vs BYOK) and, in BYOK, **which default
+model**. Both are deterministic and observable from the response payload
+(`mode` and `model` fields).
+
+Source of truth: `decide_mode()` in `src/synth_panel/mcp/sampling.py`
+and `_resolve_mcp_default_model()` in `src/synth_panel/mcp/server.py`.
+
+### Stage 1 — execution mode
+
+| Host advertises `sampling`? | Provider key available? | `use_sampling` arg | Mode |
+|------|------|------|------|
+| yes | no  | (auto)  | **sampling** |
+| yes | yes | (auto)  | **BYOK** — local key wins |
+| yes | (any) | `true`  | **sampling** — even when a key is set |
+| yes | (any) | `false` | **BYOK** — never sample |
+| no  | no  | (auto)  | **error** — set a key OR use a sampling-capable client |
+| no  | yes | (auto)  | **BYOK** |
+| no  | (any) | `true`  | **error** — host did not advertise `sampling` |
+| no  | (any) | `false` | **BYOK** — falls through to a missing-creds error if no key is set |
+
+"Provider key available" means any of `ANTHROPIC_API_KEY`,
+`OPENAI_API_KEY`, `XAI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_API_KEY`, or
+`OPENROUTER_API_KEY` — checked first against the process environment,
+then against the on-disk credential store written by `synthpanel login`
+(so MCP-launched subprocesses recognise keys the CLI can see).
+
+The auto rule "local key wins over sampling" exists so users who *have*
+configured BYOK keep BYOK's full feature set (cross-provider ensembles,
+structured-output extraction, deterministic model versioning, per-call
+cost telemetry). Pass `use_sampling=true` to force the host's model
+even with a key configured.
+
+### Stage 2 — default model (BYOK only)
+
+When `model` is omitted, the server picks a cheap-and-fast default
+based on which credential is present. The preference chain is walked in
+order; the first match wins:
+
+| Order | Credential | Default alias |
+|-------|------------|---------------|
+| 1 | `ANTHROPIC_API_KEY` | `haiku` |
+| 2 | `OPENAI_API_KEY` | `gpt-4o-mini` |
+| 3 | `GEMINI_API_KEY` | `gemini-2.5-flash` |
+| 4 | `GOOGLE_API_KEY` | `gemini-2.5-flash` |
+| 5 | `XAI_API_KEY` | `grok-3` |
+| 6 | `OPENROUTER_API_KEY` | `openrouter/auto` |
+| (none) | — | `haiku` (terminal fallback; the LLM client surfaces the missing-creds error) |
+
+Pass `model=` explicitly to override (e.g. `"opus"`, `"gpt-4o"`,
+`"gemini-2.5-pro"`). The CLI's weighted-spec syntax
+(`haiku:0.25,gpt-4o-mini:0.25`) is **not** supported on the MCP surface
+— pass plain aliases. In sampling mode the `model` argument is ignored;
+the host agent picks its own model, and the actual model used is
+reported back in the response's `model` field.
+
+### Tool coverage
+
+`run_prompt` and `run_quick_poll` go through both stages and accept
+`use_sampling`. `run_panel`, `extend_panel`, and the pack/result
+management tools always use BYOK and skip Stage 1 — heavier workflows
+benefit from direct provider access and structured outputs.
+
 ## Sampling Mode
 
 MCP has a spec-level feature called
@@ -151,21 +216,8 @@ first-run UX: if you haven't set a provider API key and your client
 advertises `sampling`, the `run_prompt` and `run_quick_poll` tools
 borrow the client's own LLM access instead of failing.
 
-### When sampling kicks in
-
-| Client supports sampling? | Provider key set? | `use_sampling` flag | Mode |
-|---------------------------|-------------------|---------------------|------|
-| yes                       | no                | (auto)              | **sampling** |
-| yes                       | yes               | (auto)              | BYOK |
-| yes                       | (any)             | `true`              | **sampling** |
-| yes                       | (any)             | `false`             | BYOK |
-| no                        | no                | (auto)              | **friendly error** |
-| no                        | yes               | (auto)              | BYOK |
-| no                        | (any)             | `true`              | **error** — client lacks sampling |
-
-The auto logic only routes to sampling when it's *necessary* for a
-first-run experience (no keys set) — existing BYOK users see no change
-in behaviour.
+See [Model Resolution Order](#model-resolution-order) for the full
+configuration → mode matrix.
 
 ### Tradeoffs
 


### PR DESCRIPTION
## Retroactive PR — direct-pushed work being recorded for review

This change was direct-pushed to `main` as commit `8f823b6` by Gastown Refinery for work bead `sp-rvae9q` / GitHub issue #293, **bypassing the standard PR flow**. The change is already in `main`; this PR opens against a `pre/sp-rvae9q` snapshot of main from before the direct push so reviewers can see the diff that landed.

**Action requested:** review the diff (already on main). Close this PR without merging — it's documentation, not a merge.

## Why this happened

The polecat that submitted this work didn't set `metadata.merge_strategy` on the work bead, and the refinery defaulted to `direct` and did `git push origin temp:main`. The push succeeded because the refinery's GitHub token has rule-bypass; the bypass surfaced as a warning rather than a blocking error.

Root cause was that the `gc-fix-merge-strategy` patch — which adds branch-protection auto-detect to the polecat done-sequence so beads get `merge_strategy=mr` whenever the target is protected — was missing from yggdrasil's polecat formula. asgard had it; yggdrasil didn't (pack drift). Without the patch, polecats only set `mr` if the LLM happens to set it explicitly.

## Fix shipped

- `gc-fix-merge-strategy ~/yggdrasil` re-applied. Polecats spawned after the fix will reliably auto-detect protection and set `merge_strategy=mr`.
- Refinery PR-body formula updated with `Closes #N` + GitHub issue link going forward (DataViking-Tech/dv-gascity-utils#15).
- Wiring-gap doc in DataViking-Tech/dv-gascity-utils#17 documents the host-state drift.

## See also

- Work bead: `sp-rvae9q`
- GitHub issue: https://github.com/DataViking-Tech/SynthPanel/issues/293 (already closed)
- Direct-push commit: 8f823b6

Closes #293 (already closed; this PR is for the audit trail).

Generated with [Claude Code](https://claude.com/claude-code)