### PR TITLE
fix(logging): cap anthropic and openai SDK loggers at WARNING (Closes #309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 - (sp-g59o) Detection: warn loudly when synthesis output appears unstructured (likely model schema-adherence flake). Triggered when every list field — themes, agreements, disagreements, surprises — is empty while the recommendation slot carries >600 chars of prose. Surfaces as a `synth_panel.synthesis` `logger.warning`, on `SynthesisResult.warnings`, and propagated up to `PanelResult.warnings`. Schema-honoring runs are unchanged. Observed at ~25% on `gemini-flash-lite` synthesis; detection is provider-agnostic.
 - (sp-k2ed4a) MCP sampling truncation surfacing: `synth_panel.mcp.sampling.sample_text` now detects host-side `stopReason="maxTokens"` truncation, logs a `logger.warning`, and returns `truncated`/`requested_max_tokens`/`warning` fields. The sampling paths in `run_prompt`, `run_panel`, and `run_quick_poll` propagate truncated turns into the response `warnings` list with persona/synthesis labels, so a failed structured-output parse can be attributed to the host clipping output rather than the model ignoring the schema. No protocol-level startup check is possible — MCP capability negotiation does not expose the host's max_tokens cap — so per-turn detection is the loud surface.
 
+### Fixed
+- (sp-4y5.7, GH #309) Cap `anthropic` and `openai` SDK loggers at WARNING by default, completing the third-party DEBUG-leak fix from PR #352. Issue #309 explicitly listed both libraries as noisy at DEBUG; they were missing from the `_NOISY_LOGGERS` set. `--debug-all` (and its help text) now surface them alongside `httpx`/`httpcore`/`urllib3`/MCP/websocket libs.
+
 ## [0.12.0] - 2026-04-26
 
 Minor bump shipping two new CLI features (`--best-model-for`,

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -77,8 +77,9 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help=(
-            "Enable DEBUG for synthpanel and common third-party loggers (httpx, "
-            "httpcore, urllib3, MCP/websocket libs). Overrides --quiet / verbosity caps."
+            "Enable DEBUG for synthpanel and common third-party loggers (anthropic, "
+            "httpx, httpcore, openai, urllib3, MCP/websocket libs). "
+            "Overrides --quiet / verbosity caps."
         ),
     )
 

--- a/src/synth_panel/logging_config.py
+++ b/src/synth_panel/logging_config.py
@@ -31,11 +31,13 @@ _VERBOSITY_MAP: dict[str, int] = {
 
 # Roots for ecosystems that spam at INFO/DEBUG when left unchecked.
 _NOISY_LOGGERS: tuple[str, ...] = (
+    "anthropic",
     "httpcore",
     "httpx",
     "hpack",
     "mcp",
     "multipart",
+    "openai",
     "urllib3",
     "websockets",
 )


### PR DESCRIPTION
## Summary

- Add `anthropic` and `openai` to `_NOISY_LOGGERS` so their DEBUG output is capped at WARNING by default.
- Refresh `--debug-all` help text to list the newly covered SDKs.
- Per issue #309: these two SDKs were listed alongside `urllib3` / `httpx` / `httpcore` as noisy DEBUG-leaking third-party loggers but were missed by the original fix in #352.

## Test plan

- [x] `pytest tests/` — 2114 passed
- [ ] Manual: `synthpanel prompt "hi" --verbose` shows no anthropic/openai DEBUG chatter
- [ ] Manual: `synthpanel prompt "hi" --debug-all` re-enables full SDK DEBUG output

Closes #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)