### PR TITLE
feat(cli): add install-skills subcommand for Claude Code slash commands + skills (GH-342)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -39,7 +39,34 @@ Prefer a zero-config first run? Skip the `env` block entirely — see
 /plugin install synthpanel
 ```
 
-This adds the `/focus-group` skill to your Claude Code session.
+This adds the `/focus-group` skill plus the `/synthpanel-poll` slash command to your Claude Code session. The plugin auto-discovers the bundled `commands/` and `skills/` directories.
+
+### Manual Install (Claude Code without plugin)
+
+If you configured the MCP server manually (without `/plugin install`) you can still get all commands and skills by running:
+
+```bash
+synthpanel install-skills
+```
+
+This copies the bundled slash commands and skills into `~/.claude/`:
+
+| Type | Name | Installs to |
+|------|------|-------------|
+| Slash command | `/synthpanel-poll` | `~/.claude/commands/synthpanel-poll.md` |
+| Skill | `concept-test` | `~/.claude/skills/concept-test/SKILL.md` |
+| Skill | `focus-group` | `~/.claude/skills/focus-group/SKILL.md` |
+| Skill | `name-test` | `~/.claude/skills/name-test/SKILL.md` |
+| Skill | `pricing-probe` | `~/.claude/skills/pricing-probe/SKILL.md` |
+| Skill | `survey-prescreen` | `~/.claude/skills/survey-prescreen/SKILL.md` |
+
+For a project-scoped install (places files in `.claude/` relative to the current directory instead of `~/.claude/`):
+
+```bash
+synthpanel install-skills --target .claude
+```
+
+The command is idempotent — running it again overwrites existing files with the current bundled versions.
 
 ## Tools (12)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,14 @@ where = ["src"]
 [tool.setuptools.package-data]
 "synth_panel.packs" = ["*.yaml"]
 "synth_panel.packs.instruments" = ["*.yaml"]
+"synth_panel.agent_assets" = [
+    "commands/*.md",
+    "skills/concept-test/*.md",
+    "skills/focus-group/*.md",
+    "skills/name-test/*.md",
+    "skills/pricing-probe/*.md",
+    "skills/survey-prescreen/*.md",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/synth_panel/agent_assets/__init__.py
+++ b/src/synth_panel/agent_assets/__init__.py
@@ -1,0 +1,3 @@
+"""Bundled Claude Code slash commands and skills shipped with synthpanel."""
+
+from __future__ import annotations

--- a/src/synth_panel/agent_assets/commands/synthpanel-poll.md
+++ b/src/synth_panel/agent_assets/commands/synthpanel-poll.md
@@ -1,0 +1,75 @@
+---
+description: Run a one-question synthetic poll across AI personas and synthesize the themes
+allowed-tools:
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+argument-hint: <question to ask the panel>
+---
+
+Run a quick synthetic poll using the SynthPanel MCP server. One question, a
+handful of AI personas, one synthesized writeup.
+
+Question: $ARGUMENTS
+
+## What to do
+
+1. **Resolve the question.** If `$ARGUMENTS` is empty, ask the user for the
+   question before continuing. Do not invent one.
+
+2. **Pick personas.** Default to the built-in zero-config persona set by
+   omitting the `personas` argument. Only build a custom list when the user
+   names a specific audience (e.g. "three enterprise SRE personas"). In that
+   case, either:
+   - Call `mcp__synth_panel__list_persona_packs` and `get_persona_pack` to
+     pull an installed pack, or
+   - Hand-author 3–5 dicts with `name`, `age`, `occupation`, `background`,
+     and `personality_traits`.
+
+   Keep panels small — `run_quick_poll` caps at 3 personas when running in
+   sampling mode (no API key).
+
+3. **Run the poll.** Call `mcp__synth_panel__run_quick_poll` with:
+   - `question`: the user's question
+   - `personas`: omit for the default set, or pass your custom list
+   - `synthesis`: leave as `true` (default) — the synthesis pass is the
+     point of this command
+
+   Do not pass `model` unless the user explicitly asked for a specific one.
+   The MCP server picks a sensible default (haiku in BYOK mode, or the
+   host's own model in sampling mode).
+
+4. **Report the result.** Present the output in this shape:
+
+   ```
+   Question: <the question>
+   Panel: <n> personas (<mode: BYOK model-name | sampling>)
+
+   ## Themes
+   <bulleted list from the synthesis>
+
+   ## Per-persona responses
+   - <persona name>: <one-line summary of their response>
+   - ...
+
+   ## Notable divergences
+   <any disagreements the synthesis flagged>
+
+   Cost: <$X.XX from the response's `cost` field, or "n/a" in sampling mode>
+   ```
+
+   Keep each persona summary to one line. The full transcripts are in the
+   raw tool output — don't re-print them.
+
+## Guardrails
+
+- **Synthetic panels are exploratory, not validating.** End the report with
+  a single-line caveat: "Synthetic panel — directional signal only, not a
+  substitute for real user research."
+- **Don't loop.** If the user wants a second question, that's another
+  `/synthpanel-poll` invocation, not a follow-up inside this one. For
+  multi-question structured studies, suggest the `/focus-group` skill
+  instead.
+- **Report errors honestly.** If the tool returns an `error` field
+  (missing API key, persona cap exceeded, etc.), show it verbatim and
+  suggest the fix — don't silently fall back.

--- a/src/synth_panel/agent_assets/skills/concept-test/SKILL.md
+++ b/src/synth_panel/agent_assets/skills/concept-test/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: concept-test
+description: Validate a product concept or value proposition with a target audience — surfaces whether the problem is real, whether the solution lands, and what would prevent adoption.
+allowed-tools:
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__save_persona_pack
+  - mcp__synth_panel__list_instrument_packs
+---
+
+You are running a **concept test** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user pressure-test an early-stage product concept, value prop, or feature idea against a specific target audience before they build or ship it. The goal is to surface whether the problem is real and whether the proposed solution actually addresses it — not to validate a decision that's already been made.
+
+1. **Clarify the concept and the audience.**
+2. **Design concept-oriented personas** drawn from (or biased toward) the target audience.
+3. **Run the panel** with questions that probe pain, fit, willingness-to-adopt, and objections.
+4. **Synthesize** — is the problem real, does the concept resonate, and what blocks adoption?
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_panel`** — Primary tool. Run a multi-question panel with target-audience personas.
+- **`mcp__synth_panel__run_quick_poll`** — Use for a single "would you try this?" temperature check.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Reuse saved target-audience packs.
+- **`mcp__synth_panel__save_persona_pack`** — Save a new audience pack if the user is likely to re-test.
+- **`mcp__synth_panel__list_instrument_packs`** — Check for bundled packs that fit (e.g. `product-feedback`, `market-research`).
+
+## Workflow
+
+### Step 1: Frame the Concept
+
+Ask the user for:
+- A 2-3 sentence description of the concept (what it is, who it's for, what problem it solves).
+- The target audience (role, demographic, or psychographic).
+- What decision this test is meant to inform ("should we keep exploring?" vs. "which direction?").
+
+### Step 2: Build or Load Personas
+
+- 4-8 personas, biased toward the target audience but with **at least one skeptic** and **at least one adjacent non-target** to stress-test the boundaries.
+- Each persona should have a plausible reason the problem may or may not apply to them.
+
+### Step 3: Design the Instrument
+
+Include questions in this order:
+1. **Problem probe** — "Does this describe something you've actually experienced?" (don't lead with the solution)
+2. **Concept reveal** — present the concept, ask for gut reaction.
+3. **Fit** — "Who do you know this would be for?" (reveals whether they see themselves in it)
+4. **Adoption blockers** — "What would stop you from trying this?"
+5. **Willingness** — rough price sensitivity or alternative-they'd-pick.
+
+Add 1-2 follow-ups on the concept reveal for depth.
+
+### Step 4: Run and Synthesize
+
+After results return, report:
+- **Problem validity** — did panelists actually experience the problem, or did you have to convince them?
+- **Concept resonance** — who lit up, who shrugged, who pushed back.
+- **Top 2-3 adoption blockers** across panelists.
+- **Surprising insights** — anything you didn't expect.
+- **Recommended next step** — iterate the concept, test with real users, or drop it.
+- **Total cost**.
+
+## Guidelines
+
+- **Don't sell the concept to the panel.** Describe it neutrally. Leading questions produce leading answers.
+- **Respect dissent.** If 2 of 6 panelists hate it, that's signal — don't average it away.
+- **Distinguish "I'd use this" from "This is a good idea."** Only the first predicts adoption.
+- **Concept tests are exploration, not validation.** Say so when the user asks "should we build this?" — the honest answer is "this is one data point; go talk to real users."

--- a/src/synth_panel/agent_assets/skills/focus-group/SKILL.md
+++ b/src/synth_panel/agent_assets/skills/focus-group/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: focus-group
+description: Run a synthetic focus group — define personas, craft questions, and collect structured qualitative feedback from AI panelists.
+allowed-tools:
+  - mcp__synth_panel__prompt
+  - mcp__synth_panel__panel_run
+  - mcp__synth_panel__list_personas
+  - mcp__synth_panel__list_instruments
+---
+
+You are orchestrating a **synthetic focus group** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user design and run synthetic focus groups — structured qualitative research using AI-powered personas. You handle the full workflow:
+
+1. **Understand the research question** — What does the user want to learn?
+2. **Define personas** — Create a personas YAML file with realistic, diverse participants.
+3. **Design the instrument** — Create a survey YAML with targeted questions and follow-ups.
+4. **Run the panel** — Execute the focus group via MCP tools.
+5. **Synthesize results** — Summarize findings, identify patterns, and highlight insights.
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__prompt`** — Run a single prompt against one persona (quick test).
+- **`mcp__synth_panel__panel_run`** — Run a full panel with multiple personas and a survey instrument.
+- **`mcp__synth_panel__list_personas`** — List available persona definition files.
+- **`mcp__synth_panel__list_instruments`** — List available instrument/survey files.
+
+## Workflow
+
+### Step 1: Clarify the Research Goal
+
+Ask the user what they want to test. Examples:
+- "What do people think of the name 'Traitprint' for a career app?"
+- "How would different demographics react to this pricing page?"
+- "Pre-screen this survey before we send it to real participants."
+
+### Step 2: Create Personas
+
+Write a `personas.yaml` file with 3-6 diverse personas. Each persona needs:
+- `name`, `age`, `occupation`
+- `background` — 2-3 sentences of life context
+- `personality_traits` — 3-5 traits that shape their perspective
+
+Ensure demographic and psychographic diversity relevant to the research question.
+
+### Step 3: Design the Instrument
+
+Write a `survey.yaml` file with 2-5 focused questions. Each question can have:
+- `text` — The question itself
+- `response_schema` — Usually `{type: text}`
+- `follow_ups` — Probing questions for depth
+
+### Step 4: Run the Panel
+
+Use `mcp__synth_panel__panel_run` with the personas and instrument files.
+
+### Step 5: Synthesize
+
+After results return:
+- Summarize each persona's perspective in 1-2 sentences
+- Identify consensus vs. divergence across personas
+- Flag surprising or non-obvious insights
+- Recommend next steps (iterate instrument, test with real users, etc.)
+
+## Guidelines
+
+- **Don't over-engineer personas** — 3-5 well-chosen personas beat 10 generic ones.
+- **Ask pointed questions** — Vague questions get vague answers.
+- **Use follow-ups** — They surface depth that initial responses miss.
+- **Report costs** — Always mention the total cost of the panel run.
+- **Be honest about limitations** — Synthetic panels are for exploration, not validation.

--- a/src/synth_panel/agent_assets/skills/name-test/SKILL.md
+++ b/src/synth_panel/agent_assets/skills/name-test/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: name-test
+description: Quickly test 1-3 candidate product or feature names with a synthetic panel — surfaces confusion, pronounceability, and memorability concerns in one pass.
+allowed-tools:
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__list_instrument_packs
+---
+
+You are running a **quick name test** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user decide between candidate names for a product, feature, or brand. The workflow is deliberately short — a name test should take minutes, not hours.
+
+1. **Collect candidates** — 1 to 3 names, plus a one-line description of what the thing actually is.
+2. **Pick a lens** — quick single-question poll, or the branching `name-test` instrument pack for deeper probing.
+3. **Run the panel** — small, diverse personas; keep it cheap.
+4. **Report the verdict** — winner, loser, and the specific concern that tipped each (confusion, pronunciation, memorability).
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_quick_poll`** — Single-question poll across personas (fastest, cheapest).
+- **`mcp__synth_panel__run_panel`** — Full panel run. Pass `instrument_pack: "name-test"` to use the bundled branching instrument that probes meaning, pronounceability, or memorability based on first reactions.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Reuse saved personas instead of inventing new ones.
+- **`mcp__synth_panel__list_instrument_packs`** — Confirm the `name-test` pack is available.
+
+## Workflow
+
+### Step 1: Gather Inputs
+
+Ask for:
+- The candidate names (comma-separated).
+- A one-sentence description of what the product/feature does.
+- Target audience (so personas are relevant).
+
+### Step 2: Choose Depth
+
+- **Quick gut check** → `run_quick_poll` with a question like *"Which of these names best fits a {description}: {candidates}? Why?"*
+- **Full branching evaluation** → `run_panel` with `instrument_pack: "name-test"` and `instrument_vars: { candidates: "<names>" }`. The instrument branches into meaning-probe, pronounce-probe, or memorability-probe based on what surfaces first.
+
+### Step 3: Run
+
+Default to 4-6 personas. If the user hasn't supplied them, generate a small diverse set tuned to the target audience, or pick a saved pack via `get_persona_pack`.
+
+### Step 4: Report
+
+Produce a tight summary:
+- **Winner** and why (quote 1-2 panelists).
+- **Loser** and the specific failure mode (misread, hard to say, forgettable).
+- **Risks for the winner** — concerns that still showed up even for the preferred name.
+- **Total cost** of the run.
+
+## Guidelines
+
+- Keep it small — 4-6 personas is plenty for a name test.
+- Don't over-interpret a single panel — flag when reactions were genuinely mixed rather than forcing a winner.
+- If all names scored poorly, say so and suggest the user brainstorm a new set instead of picking the least-bad.
+- Name tests are exploratory signal, not validation. Say this when the user asks "should we ship this?"

--- a/src/synth_panel/agent_assets/skills/pricing-probe/SKILL.md
+++ b/src/synth_panel/agent_assets/skills/pricing-probe/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pricing-probe
+description: Probe pricing sensitivity with a target audience using the bundled 'pricing-discovery' branching instrument — surfaces pain, price anchoring, or competitor alternatives based on what the panel volunteers first.
+allowed-tools:
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__get_instrument_pack
+  - mcp__synth_panel__list_instrument_packs
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__run_quick_poll
+---
+
+You are running a **pricing sensitivity probe** using the synthpanel MCP tools and the bundled `pricing-discovery` v3 branching instrument.
+
+## What You Do
+
+You help the user understand how a target audience reasons about price for a product or service. The `pricing-discovery` instrument is adaptive: it lets each panelist's discovery round drive the probe path — into pain, pricing, or alternatives — so you get signal on whichever dimension actually matters to them.
+
+1. **Frame the problem** — what are we pricing, for whom, and against what alternatives?
+2. **Assemble a target-audience panel.**
+3. **Run the `pricing-discovery` pack** via `run_panel` with `instrument_pack: "pricing-discovery"`.
+4. **Interpret the branches** — panelists who went down `probe_pain` are telling you something different than those who went down `probe_pricing` or `probe_alternatives`.
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_panel`** — Primary tool. Pass `instrument_pack: "pricing-discovery"` plus `instrument_vars: { problem: "<the problem being solved>" }`.
+- **`mcp__synth_panel__get_instrument_pack`** / **`mcp__synth_panel__list_instrument_packs`** — Inspect the bundled pricing-discovery pack.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Load a saved target-audience pack.
+- **`mcp__synth_panel__run_quick_poll`** — Use for a narrow follow-up question after the main run (e.g. "Would $X/month feel fair?").
+
+## Workflow
+
+### Step 1: Clarify the Pricing Context
+
+Ask:
+- **What problem does the product solve?** (The `pricing-discovery` instrument substitutes this into its opening question.)
+- **Who is it for?** (shapes personas)
+- **Are there competitors or alternatives?** (panelists will volunteer these if real)
+- **What price range is the user considering?** (optional — don't reveal it to the panel until after discovery)
+
+### Step 2: Build or Load the Panel
+
+- 5-8 personas matching the target audience.
+- Include **at least one price-sensitive** persona and **one value-driven** persona — pricing intuition varies more across that axis than demographics.
+- Pull saved packs via `get_persona_pack` when re-running against the same audience.
+
+### Step 3: Run the Instrument
+
+Call `run_panel` with:
+- `instrument_pack: "pricing-discovery"`
+- `instrument_vars: { problem: "<problem statement>" }`
+- the persona set
+
+Note: the pack branches via theme tags (`pain`, `price`, `alternative`). Route outcomes live in each panelist's `path` in the result — inspect this; it's the primary signal.
+
+### Step 4: Interpret the Branches
+
+Report, per panelist:
+- **Which branch did they take?** (pain / price / alternatives / else)
+- That branch *is* the insight: a panelist who routed to `probe_alternatives` is telling you price is benchmarked against an incumbent, not derived from value.
+
+Then overall:
+- **Branch distribution** across the panel — if most went to `probe_alternatives`, your pricing problem is really a positioning problem.
+- **Price anchors** that surfaced organically (vs. ones you asked about).
+- **Willingness-to-pay range** — cluster the numbers panelists volunteered.
+- **Deal-breakers** — what would stop them from paying anything.
+- **Suggested price test** — one specific follow-up (e.g. a `run_quick_poll` at a target price point).
+- **Total cost**.
+
+## Guidelines
+
+- **Don't anchor the panel with your target price** until after discovery — price sensitivity is contaminated by any number you drop first.
+- **Trust the branches.** The router is how this instrument earns its keep; interpreting which branch fired matters more than individual answers.
+- **Synthetic WTP is directional, not predictive.** Real people are stingier than personas. Discount synthetic price points before fielding.
+- **Watch for `else` fall-through.** If many panelists bypass the routed branches, the synthesizer isn't emitting the canonical theme tags — say so and suggest re-running or editing the instrument's theme-tag guidance.

--- a/src/synth_panel/agent_assets/skills/survey-prescreen/SKILL.md
+++ b/src/synth_panel/agent_assets/skills/survey-prescreen/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: survey-prescreen
+description: Pre-screen a survey instrument with synthetic respondents before sending to real participants — catches ambiguous wording, leading questions, and dead-end branches cheaply.
+allowed-tools:
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__get_instrument_pack
+  - mcp__synth_panel__list_instrument_packs
+  - mcp__synth_panel__save_instrument_pack
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+---
+
+You are pre-screening a **user-authored survey instrument** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user catch problems in a survey before they spend real budget fielding it. Synthetic respondents are cheap — use them to find ambiguous wording, leading questions, unanswerable items, and dead-end branches *before* real participants see the instrument.
+
+1. **Load the user's instrument** (YAML file they provide, or `save_instrument_pack` first if it's inline).
+2. **Assemble stress-test personas** — a mix that should reveal wording problems across demographics.
+3. **Run the instrument** as a full panel.
+4. **Critique** — report specific failure modes per question, not just a thumbs up/down.
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_panel`** — Run the user's instrument against the stress-test personas. Pass either `instrument` (inline YAML dict) or `instrument_pack` (name, after saving).
+- **`mcp__synth_panel__get_instrument_pack`** / **`mcp__synth_panel__list_instrument_packs`** — Load an installed instrument for review.
+- **`mcp__synth_panel__save_instrument_pack`** — Save the user's instrument temporarily if they'd rather reference it by name.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Load a realistic audience pack for the survey's intended population.
+
+## Workflow
+
+### Step 1: Load the Instrument
+
+Read the user's YAML. Before running, do a quick structural review:
+- Are questions clear and scoped to one thing each?
+- Any double-barreled questions ("How satisfied and how often do you...")?
+- Any leading wording ("How much do you *love*...")?
+- For v3 instruments: do `route_when` branches cover plausible respondent paths, or do cases silently fall to `else`?
+- Are follow-ups specific enough to produce depth?
+
+Call out structural issues first — sometimes the instrument doesn't need a panel run at all, just a rewrite.
+
+### Step 2: Assemble Stress-Test Personas
+
+5-8 personas that specifically stress the instrument:
+- **Representative of the intended audience** (2-3).
+- **Adjacent-but-different** — slightly outside the target, to reveal questions that assume audience knowledge (1-2).
+- **A literal responder** who answers exactly what's asked (catches ambiguity).
+- **A confused/distracted responder** (catches comprehension failures).
+- **An opinionated outlier** (catches leading questions — they'll push back).
+
+### Step 3: Run the Panel
+
+Use `run_panel`. If the instrument is v3 branching, note which rounds each persona was routed into — `path` in the result tells you whether branches fired or fell through to `else`.
+
+### Step 4: Critique (Report Format)
+
+For each question, report:
+- **Did everyone understand it?** Quote a confused answer verbatim if so.
+- **Did answers cluster or scatter?** Scattering often means the question is too open or ambiguous.
+- **Were follow-ups productive** or did they produce filler?
+
+Then overall:
+- **Top 3 problems** with the instrument, in priority order.
+- **Specific rewrites** for the worst offenders.
+- **Branch coverage** (v3 only) — which `route_when` clauses never fired, and whether that's a coverage gap or just this persona sample.
+- **Go/no-go** — is this instrument ready to field, or does it need another pass?
+- **Total cost**.
+
+## Guidelines
+
+- **Diagnose, don't just score.** "Question 3 is unclear" is useless; "Question 3 was interpreted three different ways; here are the three readings" is actionable.
+- **Preserve the user's intent.** When suggesting rewrites, match what they were trying to ask — don't silently redesign the survey.
+- **A prescreen isn't a pilot.** Synthetic respondents won't catch fatigue, incentive gaming, or platform-specific dropout. Say so.
+- **If the instrument is broken at the structural level, stop and say so** before burning tokens on a panel run.

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -4246,6 +4246,70 @@ def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
 
 # ---------------------------------------------------------------------------
+# install-skills (sy-65k74)
+# ---------------------------------------------------------------------------
+
+_INSTALL_SKILLS_COMMANDS = ["synthpanel-poll.md"]
+_INSTALL_SKILLS_SKILLS = [
+    "concept-test",
+    "focus-group",
+    "name-test",
+    "pricing-probe",
+    "survey-prescreen",
+]
+
+
+def handle_install_skills(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Copy bundled slash commands and skills into a Claude Code target directory."""
+    from importlib.resources import files as _resource_files
+
+    target = Path(getattr(args, "target", None) or Path.home() / ".claude").expanduser()
+    pkg = _resource_files("synth_panel.agent_assets")
+
+    installed: list[str] = []
+    errors: list[str] = []
+
+    commands_dst = target / "commands"
+    commands_dst.mkdir(parents=True, exist_ok=True)
+    for name in _INSTALL_SKILLS_COMMANDS:
+        src = pkg / "commands" / name
+        dst = commands_dst / name
+        try:
+            dst.write_bytes(src.read_bytes())
+            installed.append(f"commands/{name}")
+        except Exception as exc:
+            errors.append(f"commands/{name}: {exc}")
+
+    skills_dst = target / "skills"
+    for skill in _INSTALL_SKILLS_SKILLS:
+        skill_dir = skills_dst / skill
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        src = pkg / "skills" / skill / "SKILL.md"
+        dst = skill_dir / "SKILL.md"
+        try:
+            dst.write_bytes(src.read_bytes())
+            installed.append(f"skills/{skill}/SKILL.md")
+        except Exception as exc:
+            errors.append(f"skills/{skill}/SKILL.md: {exc}")
+
+    if fmt is OutputFormat.JSON:
+        payload: dict[str, Any] = {"target": str(target), "installed": installed}
+        if errors:
+            payload["errors"] = errors
+        print(json.dumps(payload))
+    else:
+        if installed:
+            print(f"Installed {len(installed)} file(s) to {target}:")
+            for f in installed:
+                print(f"  {f}")
+        if errors:
+            for e in errors:
+                print(f"ERROR: {e}", file=sys.stderr)
+
+    return 1 if errors else 0
+
+
+# ---------------------------------------------------------------------------
 # Cost subcommands (sy-kmw1)
 # ---------------------------------------------------------------------------
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1101,10 +1101,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--target",
         default=None,
         metavar="DIR",
-        help=(
-            "Destination directory (default: ~/.claude). "
-            "Pass .claude for project-scope install."
-        ),
+        help=("Destination directory (default: ~/.claude). Pass .claude for project-scope install."),
     )
 
     # login (sp-lve: credential UX — persist an API key to disk so CLI

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1089,6 +1089,24 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start the MCP server (stdio transport).",
     )
 
+    # install-skills (sy-65k74)
+    install_skills_parser = subparsers.add_parser(
+        "install-skills",
+        help=(
+            "Install bundled Claude Code slash commands and skills into ~/.claude/ "
+            "(or a project-level .claude/ with --target)."
+        ),
+    )
+    install_skills_parser.add_argument(
+        "--target",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Destination directory (default: ~/.claude). "
+            "Pass .claude for project-scope install."
+        ),
+    )
+
     # login (sp-lve: credential UX — persist an API key to disk so CLI
     # use without exported env vars isn't a dead end).
     login_parser = subparsers.add_parser(

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -12,6 +12,7 @@ from synth_panel.cli.commands import (
     handle_analyze,
     handle_cost_summary,
     handle_doctor,
+    handle_install_skills,
     handle_instruments_graph,
     handle_instruments_install,
     handle_instruments_list,
@@ -122,6 +123,8 @@ def main(argv: list[str] | None = None) -> int:
         return handle_report(args, output_format)
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
+    elif args.command == "install-skills":
+        return handle_install_skills(args, output_format)
     elif args.command == "login":
         return handle_login(args, output_format)
     elif args.command == "logout":

--- a/tests/test_install_skills.py
+++ b/tests/test_install_skills.py
@@ -1,0 +1,84 @@
+"""Tests for `synthpanel install-skills` (sy-65k74)."""
+
+from __future__ import annotations
+
+import json
+
+from synth_panel.cli.commands import _INSTALL_SKILLS_COMMANDS, _INSTALL_SKILLS_SKILLS
+from synth_panel.cli.parser import build_parser
+from synth_panel.main import main
+
+
+class TestParser:
+    def test_install_skills_registered(self):
+        parser = build_parser()
+        args = parser.parse_args(["install-skills"])
+        assert args.command == "install-skills"
+        assert args.target is None
+
+    def test_install_skills_accepts_target(self, tmp_path):
+        parser = build_parser()
+        args = parser.parse_args(["install-skills", "--target", str(tmp_path)])
+        assert args.target == str(tmp_path)
+
+
+class TestInstallSkillsFiles:
+    def test_package_data_commands_exist(self):
+        from importlib.resources import files as _resource_files
+
+        pkg = _resource_files("synth_panel.agent_assets")
+        for name in _INSTALL_SKILLS_COMMANDS:
+            src = pkg / "commands" / name
+            assert src.read_bytes(), f"commands/{name} is empty or missing in package data"
+
+    def test_package_data_skills_exist(self):
+        from importlib.resources import files as _resource_files
+
+        pkg = _resource_files("synth_panel.agent_assets")
+        for skill in _INSTALL_SKILLS_SKILLS:
+            src = pkg / "skills" / skill / "SKILL.md"
+            assert src.read_bytes(), f"skills/{skill}/SKILL.md is empty or missing in package data"
+
+
+class TestInstallSkillsCommand:
+    def test_installs_all_files_to_target(self, tmp_path, capsys):
+        rc = main(["install-skills", "--target", str(tmp_path)])
+        assert rc == 0
+
+        for name in _INSTALL_SKILLS_COMMANDS:
+            assert (tmp_path / "commands" / name).is_file(), f"commands/{name} not installed"
+
+        for skill in _INSTALL_SKILLS_SKILLS:
+            assert (tmp_path / "skills" / skill / "SKILL.md").is_file(), f"skills/{skill}/SKILL.md not installed"
+
+        out = capsys.readouterr().out
+        expected = 1 + len(_INSTALL_SKILLS_SKILLS)
+        assert f"Installed {expected} file(s)" in out
+
+    def test_idempotent(self, tmp_path):
+        main(["install-skills", "--target", str(tmp_path)])
+        rc = main(["install-skills", "--target", str(tmp_path)])
+        assert rc == 0
+
+    def test_json_output(self, tmp_path, capsys):
+        rc = main(["--output-format", "json", "install-skills", "--target", str(tmp_path)])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["target"] == str(tmp_path)
+        assert isinstance(payload["installed"], list)
+        assert len(payload["installed"]) == 1 + len(_INSTALL_SKILLS_SKILLS)
+
+    def test_installed_files_have_content(self, tmp_path):
+        main(["install-skills", "--target", str(tmp_path)])
+        poll_md = (tmp_path / "commands" / "synthpanel-poll.md").read_text()
+        assert "run_quick_poll" in poll_md
+        for skill in _INSTALL_SKILLS_SKILLS:
+            skill_md = (tmp_path / "skills" / skill / "SKILL.md").read_text()
+            assert "---" in skill_md, f"skills/{skill}/SKILL.md missing frontmatter"
+
+    def test_creates_parent_directories(self, tmp_path):
+        deep = tmp_path / "a" / "b" / "c"
+        rc = main(["install-skills", "--target", str(deep)])
+        assert rc == 0
+        assert (deep / "commands").is_dir()
+        assert (deep / "skills").is_dir()


### PR DESCRIPTION
## Summary

- Adds `synthpanel install-skills` subcommand that copies all 6 bundled Claude Code artifacts to `~/.claude/` by default
- Bundles commands and skills as package data under `synth_panel.agent_assets`
- `--target` flag supports project-scope installs
- Updates `docs/mcp.md` Manual Install section with install path documentation

## Artifacts installed

- `commands/synthpanel-poll.md`
- `skills/focus-group/SKILL.md`
- `skills/concept-test/SKILL.md`
- `skills/name-test/SKILL.md`
- `skills/pricing-probe/SKILL.md`
- `skills/survey-prescreen/SKILL.md`

## Test plan

- [x] 2123 tests pass, 87.92% coverage (threshold: 80%)
- [x] 9 new tests in `test_install_skills.py`
- [x] Ruff clean
- [x] Rebased on current `origin/main` (`8a7ee78`)

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)