### PR TITLE
feat(cli): pack save/uninstall + local pack search (GH#337, sp-oq42)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3205,9 +3205,7 @@ def _handle_pack_search_local(args: argparse.Namespace, fmt: OutputFormat) -> in
 
     matches: list[dict[str, Any]] = []
     for p in packs:
-        haystack = " ".join(
-            [str(p.get("id", "")), str(p.get("name", "")), str(p.get("description", ""))]
-        ).lower()
+        haystack = " ".join([str(p.get("id", "")), str(p.get("name", "")), str(p.get("description", ""))]).lower()
         if term in haystack:
             matches.append(
                 {
@@ -3362,8 +3360,7 @@ def handle_pack_save(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     if pack_id in _bundled_packs():
         print(
-            f"Error: '{pack_id}' conflicts with a bundled pack. "
-            "Use --id to choose a different ID.",
+            f"Error: '{pack_id}' conflicts with a bundled pack. Use --id to choose a different ID.",
             file=sys.stderr,
         )
         return 1

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3118,9 +3118,9 @@ def _build_rounds_shape(
 def handle_pack_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
     """List persona packs.
 
-    Default: local installed packs. With ``--registry``: packs from the
-    cached synthpanel registry (id, name, ref, version columns). On empty
-    cache + fetch fail, prints an advisory line and exits 0.
+    Default: bundled + local packs with origin column. With ``--registry``:
+    packs from the cached synthpanel registry (id, name, ref, version
+    columns). On empty cache + fetch fail, prints an advisory line and exits 0.
     """
     if getattr(args, "registry", False):
         return _handle_pack_list_registry(fmt)
@@ -3134,7 +3134,8 @@ def handle_pack_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
             print("No persona packs found.")
         else:
             for p in packs:
-                print(f"  {p['id']}  {p['name']}  ({p['persona_count']} personas)")
+                origin = "bundled" if p.get("builtin") else "local"
+                print(f"  {p['id']}  {p['name']}  ({p['persona_count']} personas)  [{origin}]")
     else:
         emit(fmt, message="Persona packs", extra={"packs": packs})
 
@@ -3185,7 +3186,52 @@ def _handle_pack_list_registry(fmt: OutputFormat) -> int:
 
 
 def handle_pack_search(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """Search registry packs by substring across id, name, description, tags."""
+    """Search packs by substring.
+
+    Default: searches bundled + local packs (id, name, description).
+    With ``--registry``: searches the remote synthpanel registry instead.
+    """
+    if getattr(args, "registry", False):
+        return _handle_pack_search_registry(args, fmt)
+    return _handle_pack_search_local(args, fmt)
+
+
+def _handle_pack_search_local(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Search bundled + user-saved packs by substring."""
+    from synth_panel.mcp.data import list_persona_packs
+
+    term = (args.term or "").lower()
+    packs = list_persona_packs()
+
+    matches: list[dict[str, Any]] = []
+    for p in packs:
+        haystack = " ".join(
+            [str(p.get("id", "")), str(p.get("name", "")), str(p.get("description", ""))]
+        ).lower()
+        if term in haystack:
+            matches.append(
+                {
+                    "id": str(p["id"]),
+                    "name": str(p["name"]),
+                    "persona_count": p["persona_count"],
+                    "origin": "bundled" if p.get("builtin") else "local",
+                }
+            )
+
+    if fmt is OutputFormat.TEXT:
+        if not matches:
+            print(f"No packs match '{args.term}'.")
+        else:
+            for m in matches:
+                print(f"  {m['id']}  {m['name']}  ({m['persona_count']} personas)  [{m['origin']}]")
+    else:
+        emit(fmt, message="Pack search", extra={"term": args.term, "matches": matches})
+
+    return 0
+
+
+def _handle_pack_search_registry(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Search remote registry packs by substring across id, name, description, tags."""
     from synth_panel.registry import cache_path, fetch_registry
 
     term = (args.term or "").lower()
@@ -3284,6 +3330,79 @@ def _handle_pack_import_local(args: argparse.Namespace, fmt: OutputFormat, sourc
     else:
         emit(fmt, message="Pack imported", extra=result)
 
+    return 0
+
+
+def handle_pack_save(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Save a local YAML file as a named persona pack in the local registry.
+
+    Validates the YAML before saving and refuses to install a pack whose
+    derived ID collides with a bundled pack name.  Use ``--id`` to choose a
+    different ID when a collision is unavoidable.
+    """
+    from synth_panel.mcp.data import PackValidationError, _bundled_packs, save_persona_pack
+
+    source = args.file
+    try:
+        personas = _load_personas(source)
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"Error loading file: {exc}", file=sys.stderr)
+        return 1
+
+    # Determine pack name: explicit flag > YAML 'name' key > filename stem
+    pack_name = args.name
+    if not pack_name:
+        data = _load_yaml(source)
+        if isinstance(data, dict):
+            pack_name = data.get("name")
+    if not pack_name:
+        pack_name = Path(source).stem
+
+    pack_id = args.pack_id if getattr(args, "pack_id", None) else _slugify_pack_id(str(pack_name))
+
+    if pack_id in _bundled_packs():
+        print(
+            f"Error: '{pack_id}' conflicts with a bundled pack. "
+            "Use --id to choose a different ID.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = save_persona_pack(str(pack_name), personas, pack_id=pack_id)
+    except PackValidationError as exc:
+        print(f"Validation error: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.TEXT:
+        print(f"Saved pack '{result['name']}' ({result['persona_count']} personas) as {result['id']}")
+    else:
+        emit(fmt, message="Pack saved", extra=result)
+
+    return 0
+
+
+def handle_pack_uninstall(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Uninstall a user-saved persona pack from the local registry.
+
+    Refuses to uninstall bundled packs.
+    """
+    from synth_panel.mcp.data import uninstall_persona_pack
+
+    pack_id = args.pack_id
+    try:
+        uninstall_persona_pack(pack_id)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.TEXT:
+        print(f"Uninstalled pack '{pack_id}'.")
+    else:
+        emit(fmt, message="Pack uninstalled", extra={"pack_id": pack_id})
     return 0
 
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -711,12 +711,50 @@ def build_parser() -> argparse.ArgumentParser:
     # pack search
     pack_search_parser = pack_subparsers.add_parser(
         "search",
-        help="Search registry packs by substring (id, name, description, tags).",
+        help="Search packs by substring (local by default; use --registry for remote).",
     )
     pack_search_parser.add_argument(
         "term",
         metavar="TERM",
-        help="Substring to match (case-insensitive) against id/name/description/tags.",
+        help="Substring to match (case-insensitive) against id/name/description.",
+    )
+    pack_search_parser.add_argument(
+        "--registry",
+        action="store_true",
+        help="Search the remote synthpanel registry instead of local/bundled packs.",
+    )
+
+    # pack save
+    pack_save_parser = pack_subparsers.add_parser(
+        "save",
+        help="Save a local YAML file as a named pack in the local registry (~/.synthpanel/packs/).",
+    )
+    pack_save_parser.add_argument(
+        "file",
+        metavar="FILE",
+        help="Path to a persona pack YAML file.",
+    )
+    pack_save_parser.add_argument(
+        "--name",
+        default=None,
+        help="Display name for the pack (default: from YAML 'name' field or filename stem).",
+    )
+    pack_save_parser.add_argument(
+        "--id",
+        default=None,
+        dest="pack_id",
+        help="Custom pack ID (default: slugified from name). Use to avoid bundled-name conflicts.",
+    )
+
+    # pack uninstall
+    pack_uninstall_parser = pack_subparsers.add_parser(
+        "uninstall",
+        help="Remove a user-saved pack from the local registry (bundled packs cannot be uninstalled).",
+    )
+    pack_uninstall_parser.add_argument(
+        "pack_id",
+        metavar="PACK_ID",
+        help="ID of the user-saved pack to uninstall.",
     )
 
     # pack import

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -27,8 +27,10 @@ from synth_panel.cli.commands import (
     handle_pack_import,
     handle_pack_inspect,
     handle_pack_list,
+    handle_pack_save,
     handle_pack_search,
     handle_pack_show,
+    handle_pack_uninstall,
     handle_panel_inspect,
     handle_panel_run,
     handle_panel_synthesize,
@@ -90,6 +92,10 @@ def main(argv: list[str] | None = None) -> int:
             return handle_pack_generate(args, output_format)
         elif sub == "search":
             return handle_pack_search(args, output_format)
+        elif sub == "save":
+            return handle_pack_save(args, output_format)
+        elif sub == "uninstall":
+            return handle_pack_uninstall(args, output_format)
         elif sub == "calibrate":
             return handle_pack_calibrate(args, output_format)
         elif sub == "diff":

--- a/src/synth_panel/mcp/data.py
+++ b/src/synth_panel/mcp/data.py
@@ -317,6 +317,22 @@ def save_persona_pack(
     return meta
 
 
+def uninstall_persona_pack(pack_id: str) -> None:
+    """Delete a user-saved persona pack from the local registry.
+
+    Raises :class:`ValueError` when *pack_id* names a bundled pack (those
+    cannot be removed).  Raises :class:`FileNotFoundError` when the pack is
+    not found in the user-saved store.
+    """
+    _validate_pack_id(pack_id)
+    if pack_id in _bundled_packs():
+        raise ValueError(f"'{pack_id}' is a bundled pack and cannot be uninstalled")
+    p = _packs_dir() / f"{pack_id}.yaml"
+    if not p.exists():
+        raise FileNotFoundError(f"Persona pack not found: {pack_id}")
+    p.unlink()
+
+
 # ---------------------------------------------------------------------------
 # Instrument packs (single-file YAML, manifest at top level)
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2090,6 +2090,7 @@ class TestPackCommands:
         out = capsys.readouterr().out
         assert "developer" in out
         assert "Developers" in out
+        assert "[bundled]" in out
 
     def test_pack_import_and_list(self, capsys):
         pfile = self._tmp / "personas.yaml"
@@ -2401,7 +2402,7 @@ class TestPackCommands:
             ]
         )
         # Case-insensitive substring — matches id, name, description, tags.
-        code = main(["pack", "search", "pricing"])
+        code = main(["pack", "search", "--registry", "pricing"])
         assert code == 0
         out = capsys.readouterr().out
         assert "pricing-probe" in out  # id match
@@ -2426,7 +2427,7 @@ class TestPackCommands:
                 }
             ]
         )
-        code = main(["pack", "search", "nonexistent-xyz"])
+        code = main(["pack", "search", "--registry", "nonexistent-xyz"])
         assert code == 0
         out = capsys.readouterr().out
         assert "No packs match" in out
@@ -2436,7 +2437,7 @@ class TestPackCommands:
             "synth_panel.registry.fetch_registry",
             lambda **kw: {"schema_version": 1, "packs": []},
         )
-        code = main(["pack", "search", "anything"])
+        code = main(["pack", "search", "--registry", "anything"])
         assert code == 0
         out = capsys.readouterr().out
         assert "registry unavailable" in out
@@ -2458,12 +2459,158 @@ class TestPackCommands:
                 }
             ]
         )
-        code = main(["--output-format", "json", "pack", "search", "match"])
+        code = main(["--output-format", "json", "pack", "search", "--registry", "match"])
         assert code == 0
         data = json.loads(capsys.readouterr().out)
         assert data["term"] == "match"
         assert len(data["matches"]) == 1
         assert data["matches"][0]["id"] == "match-one"
+
+    # --- pack save ---
+
+    def test_pack_save_creates_local_pack(self, capsys):
+        pfile = self._tmp / "team.yaml"
+        pfile.write_text("name: Team Pack\npersonas:\n  - name: Alice\n    age: 30\n")
+        code = main(["pack", "save", str(pfile)])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Team Pack" in out
+        assert "1 personas" in out
+        assert "team-pack" in out
+
+    def test_pack_save_explicit_name(self, capsys):
+        pfile = self._tmp / "p.yaml"
+        pfile.write_text("personas:\n  - name: Bob\n")
+        code = main(["pack", "save", str(pfile), "--name", "Custom Name"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "Custom Name" in out
+        assert "custom-name" in out
+
+    def test_pack_save_explicit_id(self, capsys):
+        pfile = self._tmp / "p.yaml"
+        pfile.write_text("personas:\n  - name: Eve\n")
+        code = main(["pack", "save", str(pfile), "--name", "My Pack", "--id", "explicit-id"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "explicit-id" in out
+
+    def test_pack_save_validation_error(self, capsys):
+        pfile = self._tmp / "bad.yaml"
+        pfile.write_text("personas:\n  - age: 30\n")
+        code = main(["pack", "save", str(pfile)])
+        assert code == 1
+        assert "Validation error" in capsys.readouterr().err
+
+    def test_pack_save_file_not_found(self, capsys):
+        code = main(["pack", "save", "/no/such/file.yaml"])
+        assert code == 1
+
+    def test_pack_save_refuses_bundled_name_conflict(self, capsys):
+        pfile = self._tmp / "developer.yaml"
+        pfile.write_text("personas:\n  - name: Dev\n")
+        # 'developer' is a bundled pack ID — save should refuse
+        code = main(["pack", "save", str(pfile), "--name", "developer"])
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "bundled" in err
+
+    def test_pack_save_bundled_conflict_with_custom_id_succeeds(self, capsys):
+        pfile = self._tmp / "p.yaml"
+        pfile.write_text("personas:\n  - name: Dev\n")
+        # Use --id to sidestep the conflict
+        code = main(["pack", "save", str(pfile), "--name", "developer", "--id", "my-dev"])
+        assert code == 0
+        assert "my-dev" in capsys.readouterr().out
+
+    def test_pack_save_shows_in_list_as_local(self, capsys):
+        pfile = self._tmp / "team.yaml"
+        pfile.write_text("name: Team Pack\npersonas:\n  - name: Alice\n")
+        main(["pack", "save", str(pfile)])
+        capsys.readouterr()
+        code = main(["pack", "list"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "team-pack" in out
+        assert "[local]" in out
+
+    # --- pack uninstall ---
+
+    def test_pack_uninstall_removes_local_pack(self, capsys):
+        from synth_panel.mcp.data import save_persona_pack
+
+        save_persona_pack("Temp", [{"name": "X"}], pack_id="temp-pack")
+        code = main(["pack", "uninstall", "temp-pack"])
+        assert code == 0
+        assert "temp-pack" in capsys.readouterr().out
+        # Verify gone from list
+        code2 = main(["pack", "list"])
+        assert code2 == 0
+        assert "temp-pack" not in capsys.readouterr().out
+
+    def test_pack_uninstall_refuses_bundled(self, capsys):
+        code = main(["pack", "uninstall", "developer"])
+        assert code == 1
+        assert "bundled" in capsys.readouterr().err
+
+    def test_pack_uninstall_not_found(self, capsys):
+        code = main(["pack", "uninstall", "no-such-pack"])
+        assert code == 1
+
+    def test_pack_uninstall_json(self, capsys):
+        from synth_panel.mcp.data import save_persona_pack
+
+        save_persona_pack("J", [{"name": "Y"}], pack_id="jdel")
+        code = main(["--output-format", "json", "pack", "uninstall", "jdel"])
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["pack_id"] == "jdel"
+
+    # --- pack search (local) ---
+
+    def test_pack_search_local_matches_bundled(self, capsys):
+        code = main(["pack", "search", "developer"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "developer" in out
+        assert "[bundled]" in out
+
+    def test_pack_search_local_matches_user_saved(self, capsys):
+        from synth_panel.mcp.data import save_persona_pack
+
+        save_persona_pack("Unique Local", [{"name": "Z"}], pack_id="unique-local")
+        code = main(["pack", "search", "unique"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "unique-local" in out
+        assert "[local]" in out
+
+    def test_pack_search_local_no_matches(self, capsys):
+        code = main(["pack", "search", "xyzzy-no-match-ever"])
+        assert code == 0
+        assert "No packs match" in capsys.readouterr().out
+
+    def test_pack_search_local_json(self, capsys):
+        from synth_panel.mcp.data import save_persona_pack
+
+        save_persona_pack("Search Me", [{"name": "A"}], pack_id="search-me")
+        code = main(["--output-format", "json", "pack", "search", "search-me"])
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["term"] == "search-me"
+        assert any(m["id"] == "search-me" for m in data["matches"])
+
+    # --- pack list origin column ---
+
+    def test_pack_list_shows_local_origin(self, capsys):
+        from synth_panel.mcp.data import save_persona_pack
+
+        save_persona_pack("My Local", [{"name": "L"}], pack_id="my-local")
+        code = main(["pack", "list"])
+        assert code == 0
+        out = capsys.readouterr().out
+        assert "[local]" in out
+        assert "my-local" in out
 
     def test_pack_generate_success(self, capsys, monkeypatch):
         """pack generate calls LLM and saves a valid persona pack."""


### PR DESCRIPTION
## Summary

Implements GH #337: local pack registry CLI.

- `synthpanel pack save` — save a pack to the local registry
- `synthpanel pack uninstall` — remove a pack from the registry
- `synthpanel pack search` — search the local registry (default scope)
- `synthpanel pack list` — now includes an origin column

17 new tests; full suite passing (2140 / 88% coverage).

Tracked as bead `sp-oq42`. Routed via refinery (PR mode forced by branch protection).

## Test plan

- [x] `pytest tests/` — 2140 passed
- [ ] CI required status checks (8/8)