### PR TITLE
Pre-existing test failure: test_cost_summary subprocess doesn't inherit PYTHONPATH (sy-9ni)

### DIFF
--- a/tests/test_cost_summary.py
+++ b/tests/test_cost_summary.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -510,6 +511,8 @@ class TestDefaultRunsDir:
 class TestCliSmoke:
     def _run(self, env_dir: Path, *args: str) -> subprocess.CompletedProcess:
         env = {"PATH": "/usr/bin:/bin", "SYNTH_PANEL_DATA_DIR": str(env_dir)}
+        if pythonpath := os.environ.get("PYTHONPATH"):
+            env["PYTHONPATH"] = pythonpath
         return subprocess.run(
             [sys.executable, "-m", "synth_panel", "cost", "summary", *args],
             env=env,


### PR DESCRIPTION
## Summary

Automated pull request published by Gastown Refinery.

- Issue: sy-9ni
- Branch: polecat/sy-9ni
- Target: main

The `_run` helper in `TestCliSmoke` constructed a minimal env dict
without PYTHONPATH. When the rig's editable install lacks the cost
subcommand, the subprocess falls back to that install instead of the
src/ checkout. Fix propagates PYTHONPATH so the subprocess finds the
correct checkout.