### PR TITLE
ci: add site/CLI subcommand sync check (sy-81d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,3 +133,21 @@ jobs:
         with:
           name: coverage-report
           path: htmlcov/
+
+  site-cli-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e ".[dev,mcp]"
+
+      - name: Check site/CLI subcommand sync
+        run: python scripts/check_site_cli_sync.py

--- a/scripts/check_site_cli_sync.py
+++ b/scripts/check_site_cli_sync.py
@@ -1,0 +1,65 @@
+"""Check that synthpanel's top-level subcommand list matches the site coverage manifest.
+
+Run after installing the package (pip install -e .) to verify that every
+subcommand in `synthpanel --help` is tracked in site/cli-coverage.txt.
+Exits 0 on match, 1 on drift, 2 on parse failure.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MANIFEST_PATH = REPO_ROOT / "site" / "cli-coverage.txt"
+
+
+def get_cli_subcommands() -> set[str]:
+    result = subprocess.run(
+        [sys.executable, "-m", "synth_panel", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    output = result.stdout + result.stderr
+    match = re.search(r"positional arguments:\s+\{([^}]+)\}", output, re.DOTALL)
+    if not match:
+        print("ERROR: Could not parse subcommand list from --help output.", file=sys.stderr)
+        print(output, file=sys.stderr)
+        sys.exit(2)
+    return set(match.group(1).split(","))
+
+
+def read_manifest() -> set[str]:
+    lines = MANIFEST_PATH.read_text().splitlines()
+    return {line.strip() for line in lines if line.strip() and not line.strip().startswith("#")}
+
+
+def main() -> None:
+    cli = get_cli_subcommands()
+    manifest = read_manifest()
+
+    only_in_cli = cli - manifest
+    only_in_manifest = manifest - cli
+
+    if not only_in_cli and not only_in_manifest:
+        print(f"OK: CLI subcommands match manifest ({len(cli)} subcommands)")
+        return
+
+    print("DRIFT DETECTED between `synthpanel --help` and site/cli-coverage.txt")
+    print()
+    if only_in_cli:
+        print("New subcommands not in manifest (document on site then add to site/cli-coverage.txt):")
+        for cmd in sorted(only_in_cli):
+            print(f"  + {cmd}")
+    if only_in_manifest:
+        print("Stale manifest entries (subcommand removed from CLI; delete from site/cli-coverage.txt):")
+        for cmd in sorted(only_in_manifest):
+            print(f"  - {cmd}")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/cli-coverage.txt
+++ b/site/cli-coverage.txt
@@ -1,0 +1,27 @@
+# CLI subcommand coverage manifest for synthpanel.dev
+#
+# This file lists every top-level subcommand exposed by `synthpanel --help`.
+# The CI job scripts/check_site_cli_sync.py compares this list against the
+# live --help output and fails the build on any drift.
+#
+# Workflow when adding a new subcommand:
+#   1. Add the subcommand to the CLI (src/synth_panel/cli/parser.py)
+#   2. Document it on the site (synthpanel.dev) or file a docs ticket
+#   3. Add the subcommand name to this file to keep CI green
+#
+# Removing a subcommand: delete its line here.
+
+analyze
+cost
+doctor
+install-skills
+instruments
+login
+logout
+mcp-serve
+pack
+panel
+prompt
+report
+runs
+whoami


### PR DESCRIPTION
## Summary
- Adds `scripts/check_site_cli_sync.py` that parses `synthpanel --help` subcommands and compares against `site/cli-coverage.txt` manifest; exits 1 on drift with a readable diff
- Adds `site/cli-coverage.txt` tracking all 14 current top-level subcommands
- Adds `site-cli-sync` CI job in `.github/workflows/ci.yml` to run the check on every PR

## Test plan
- [ ] `python scripts/check_site_cli_sync.py` reports "OK: CLI subcommands match manifest (14 subcommands)"
- [ ] Adding a fake subcommand to the CLI causes the script to exit 1 and print a diff
- [ ] CI job passes on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)