### PR TITLE
AC-5: flag enum + raiser (sy-ac-5)

### DIFF
--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -343,6 +343,202 @@ class PanelistResult:
     model: str | None = None
 
 
+# ---------------------------------------------------------------------------
+# v1.0.0 contract flags (sy-ac-5)
+# ---------------------------------------------------------------------------
+
+
+# The 7 enum members from schemas/v1.0.0.json#/flags_enum. Frozen at
+# the contract level; new codes ship as a parallel schema version, not
+# in-place edits. Kept as a tuple here (not re-read from the JSON) so
+# the import stays free of disk I/O — :func:`Flag.__post_init__` is on
+# the hot path of every panel run.
+FLAG_CODES: tuple[str, ...] = (
+    "low_convergence",
+    "demographic_skew",
+    "small_n",
+    "persona_collision",
+    "out_of_distribution",
+    "refusal_or_degenerate",
+    "schema_drift",
+)
+
+SEVERITIES: tuple[str, ...] = ("info", "warn", "block")
+
+
+@dataclass(frozen=True)
+class Flag:
+    """An enum-bound quality flag from the v1.0.0 contract.
+
+    Lands on ``panel_verdict.flags[]``. ``code`` must be one of
+    :data:`FLAG_CODES`; non-enum signals belong on :class:`FlagExtension`.
+    """
+
+    code: str
+    severity: str
+
+    def __post_init__(self) -> None:
+        if self.code not in FLAG_CODES:
+            raise ValueError(
+                f"Flag.code must be one of {FLAG_CODES}, got {self.code!r}; use FlagExtension for non-enum codes"
+            )
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"Flag.severity must be one of {SEVERITIES}, got {self.severity!r}")
+
+
+@dataclass(frozen=True)
+class FlagExtension:
+    """A non-enum signal carried on ``panel_verdict.extension[]``.
+
+    Lets callers surface bespoke quality concerns (e.g. a domain-specific
+    cohort warning) without touching the frozen v1.0.0 ``flags_enum``.
+    """
+
+    code: str
+    message: str
+    severity: str
+
+    def __post_init__(self) -> None:
+        if not self.code:
+            raise ValueError("FlagExtension.code must be non-empty")
+        if self.code in FLAG_CODES:
+            raise ValueError(f"FlagExtension.code {self.code!r} collides with an enum member; use Flag instead")
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"FlagExtension.severity must be one of {SEVERITIES}, got {self.severity!r}")
+
+
+@dataclass
+class PanelState:
+    """Post-synthesis snapshot the flag-raiser inspects.
+
+    Built by the orchestrator after a run finishes (or aborts — the
+    raiser is robust to partial state). The verdict assembler (AC-6)
+    consumes the same shape, so additions here are append-only.
+    """
+
+    panelist_results: list[PanelistResult] = field(default_factory=list)
+    personas: list[dict[str, Any]] = field(default_factory=list)
+    convergence: float | None = None
+    schema_drift: bool = False
+    expected_categories: list[str] | None = None
+    observed_categories: list[str] | None = None
+    extensions: list[FlagExtension] = field(default_factory=list)
+
+
+# Threshold knobs. Tuned in build-plan.md, not part of the wire contract;
+# treat as safe to nudge without bumping the schema version. The raiser
+# trips at the boundary inclusive on the lower side (n < BLOCK → block,
+# BLOCK ≤ n < WARN → warn, n ≥ WARN → no flag).
+_SMALL_N_BLOCK = 4
+_SMALL_N_WARN = 8
+_LOW_CONVERGENCE_BLOCK = 0.30
+_LOW_CONVERGENCE_WARN = 0.50
+_REFUSAL_BLOCK_FRAC = 0.50
+_REFUSAL_WARN_FRAC = 0.25
+
+# Demographic keys we check for uniformity. Limited to common persona
+# fields so the heuristic doesn't flag on incidental shared metadata
+# (e.g. every persona happening to have the same ``llm_overrides``).
+_DEMOGRAPHIC_KEYS: tuple[str, ...] = ("occupation", "age", "gender", "region", "country")
+
+
+def _is_degenerate(pr: PanelistResult) -> bool:
+    """A panelist counts as degenerate if their session errored or
+    every recorded response was an error / skipped / empty.
+
+    Mirrors how the synthesizer treats ``error`` / ``skipped_by_budget``
+    rows when building convergence inputs — keep the two in sync.
+    """
+    if pr.error:
+        return True
+    if not pr.responses:
+        return True
+    bad = 0
+    for r in pr.responses:
+        if r.get("error") or r.get("skipped_by_budget"):
+            bad += 1
+            continue
+        resp = r.get("response")
+        if resp is None or (isinstance(resp, str) and not resp.strip()):
+            bad += 1
+    return bad == len(pr.responses)
+
+
+def _detect_demographic_skew(personas: list[dict[str, Any]]) -> bool:
+    """All personas share an identical value on at least one demographic key."""
+    if len(personas) < 2:
+        return False
+    for k in _DEMOGRAPHIC_KEYS:
+        values = [p.get(k) for p in personas if isinstance(p, dict) and k in p]
+        if len(values) == len(personas) and len(set(values)) == 1:
+            return True
+    return False
+
+
+def _detect_persona_collision(personas: list[dict[str, Any]], results: list[PanelistResult]) -> bool:
+    """Two personas (or two results) carry the same name."""
+    pnames = [p.get("name") for p in personas if isinstance(p, dict) and p.get("name")]
+    if len(pnames) != len(set(pnames)):
+        return True
+    rnames = [r.persona_name for r in results]
+    return len(rnames) != len(set(rnames))
+
+
+def _raise_flags(panel_state: PanelState) -> list[Flag]:
+    """Inspect ``panel_state`` post-synthesis and emit enum-bound flags.
+
+    Each returned :class:`Flag` maps to one of the 7 ``flags_enum``
+    members in ``schemas/v1.0.0.json``. Severity is one of
+    :data:`SEVERITIES`. The function never raises on a malformed
+    ``panel_state`` — missing fields skip the relevant check so the
+    raiser stays callable on partial / aborted runs (sp-56pb).
+
+    Non-enum signals belong on ``panel_state.extensions``; the verdict
+    assembler (AC-6) surfaces them under ``panel_verdict.extension[]``
+    rather than ``flags[]``. Mixing the two would silently shadow a
+    real enum member, hence :class:`FlagExtension` rejects enum codes
+    at construction time.
+    """
+    flags: list[Flag] = []
+    n = len(panel_state.panelist_results)
+
+    if 0 < n < _SMALL_N_BLOCK:
+        flags.append(Flag(code="small_n", severity="block"))
+    elif _SMALL_N_BLOCK <= n < _SMALL_N_WARN:
+        flags.append(Flag(code="small_n", severity="warn"))
+
+    if panel_state.convergence is not None:
+        c = panel_state.convergence
+        if c < _LOW_CONVERGENCE_BLOCK:
+            flags.append(Flag(code="low_convergence", severity="block"))
+        elif c < _LOW_CONVERGENCE_WARN:
+            flags.append(Flag(code="low_convergence", severity="warn"))
+
+    if _detect_demographic_skew(panel_state.personas):
+        flags.append(Flag(code="demographic_skew", severity="warn"))
+
+    if _detect_persona_collision(panel_state.personas, panel_state.panelist_results):
+        flags.append(Flag(code="persona_collision", severity="warn"))
+
+    if panel_state.expected_categories is not None and panel_state.observed_categories is not None:
+        expected = set(panel_state.expected_categories)
+        if any(c not in expected for c in panel_state.observed_categories):
+            flags.append(Flag(code="out_of_distribution", severity="warn"))
+
+    if n > 0:
+        bad_count = sum(1 for pr in panel_state.panelist_results if _is_degenerate(pr))
+        frac = bad_count / n
+        if frac >= _REFUSAL_BLOCK_FRAC:
+            flags.append(Flag(code="refusal_or_degenerate", severity="block"))
+        elif frac >= _REFUSAL_WARN_FRAC:
+            flags.append(Flag(code="refusal_or_degenerate", severity="warn"))
+
+    if panel_state.schema_drift:
+        flags.append(Flag(code="schema_drift", severity="warn"))
+
+    return flags
+
+
 @dataclass
 class RoundResult:
     """Per-round panelist + synthesis bundle for a multi-round run."""

--- a/tests/orchestrator/test_flag_raising.py
+++ b/tests/orchestrator/test_flag_raising.py
@@ -1,0 +1,268 @@
+"""Tests for the post-synthesis flag raiser (sy-ac-5).
+
+Covers all 7 ``flags_enum`` members in the v1.0.0 contract plus the
+``extension[]`` sibling for non-enum signals. The canonical entry point
+is ``test_small_n_raises_with_severity_warn`` (named in build-plan.md
+AC-5); the remaining tests pin per-flag thresholds and the schema-bound
+guarantees on :class:`Flag` / :class:`FlagExtension`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from synth_panel.cost import ZERO_USAGE
+from synth_panel.orchestrator import (
+    Flag,
+    FlagExtension,
+    PanelistResult,
+    PanelState,
+    _raise_flags,
+)
+from synth_panel.schemas import load
+
+
+def _pr(name: str = "P", *, error: str | None = None, responses: list[dict[str, Any]] | None = None) -> PanelistResult:
+    return PanelistResult(
+        persona_name=name,
+        responses=responses if responses is not None else [{"question": "q", "response": "ok"}],
+        usage=ZERO_USAGE,
+        error=error,
+    )
+
+
+def _diverse_personas(n: int) -> list[dict[str, Any]]:
+    """Personas with distinct demographics so we don't accidentally trip
+    the demographic_skew detector when probing other flags."""
+    return [{"name": f"P{i}", "occupation": f"job-{i}", "age": 20 + i} for i in range(n)]
+
+
+# ---------------------------------------------------------------------------
+# Required test (build-plan.md AC-5)
+# ---------------------------------------------------------------------------
+
+
+def test_small_n_raises_with_severity_warn() -> None:
+    """A panel with 4-7 completed panelists raises ``small_n`` at ``warn``."""
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(5)],
+        personas=_diverse_personas(5),
+    )
+
+    flags = _raise_flags(state)
+
+    small_n = [f for f in flags if f.code == "small_n"]
+    assert len(small_n) == 1, f"expected exactly one small_n flag, got {flags!r}"
+    assert small_n[0].severity == "warn"
+
+
+# ---------------------------------------------------------------------------
+# Per-flag coverage
+# ---------------------------------------------------------------------------
+
+
+def test_small_n_blocks_below_4() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(2)],
+        personas=_diverse_personas(2),
+    )
+    flags = _raise_flags(state)
+    assert Flag(code="small_n", severity="block") in flags
+
+
+def test_no_small_n_when_n_at_threshold() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(8)],
+        personas=_diverse_personas(8),
+    )
+    flags = _raise_flags(state)
+    assert not any(f.code == "small_n" for f in flags)
+
+
+def test_low_convergence_warn_band() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+        convergence=0.40,
+    )
+    flags = _raise_flags(state)
+    assert Flag(code="low_convergence", severity="warn") in flags
+
+
+def test_low_convergence_block_band() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+        convergence=0.10,
+    )
+    flags = _raise_flags(state)
+    assert Flag(code="low_convergence", severity="block") in flags
+
+
+def test_demographic_skew_when_all_share_a_field() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=[{"name": f"P{i}", "occupation": "data scientist", "age": 30 + i} for i in range(20)],
+    )
+    flags = _raise_flags(state)
+    assert Flag(code="demographic_skew", severity="warn") in flags
+
+
+def test_demographic_skew_silent_when_diverse() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+    )
+    flags = _raise_flags(state)
+    assert not any(f.code == "demographic_skew" for f in flags)
+
+
+def test_persona_collision_on_duplicate_names() -> None:
+    personas = [{"name": "Alice", "occupation": "a"}, {"name": "Alice", "occupation": "b"}, *_diverse_personas(8)]
+    results = [_pr("Alice"), _pr("Alice"), *[_pr(f"P{i}") for i in range(8)]]
+    state = PanelState(panelist_results=results, personas=personas)
+    flags = _raise_flags(state)
+    assert Flag(code="persona_collision", severity="warn") in flags
+
+
+def test_out_of_distribution_when_unexpected_categories() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+        expected_categories=["yes", "no"],
+        observed_categories=["yes", "no", "maybe"],
+    )
+    flags = _raise_flags(state)
+    assert Flag(code="out_of_distribution", severity="warn") in flags
+
+
+def test_out_of_distribution_silent_when_subset() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+        expected_categories=["yes", "no", "maybe"],
+        observed_categories=["yes", "no"],
+    )
+    flags = _raise_flags(state)
+    assert not any(f.code == "out_of_distribution" for f in flags)
+
+
+def test_refusal_or_degenerate_warn_above_quarter() -> None:
+    # 5/20 = 25% errors → warn band
+    results = [_pr(f"P{i}") for i in range(15)] + [_pr(f"P{i}", error="refused") for i in range(15, 20)]
+    state = PanelState(panelist_results=results, personas=_diverse_personas(20))
+    flags = _raise_flags(state)
+    refusal = [f for f in flags if f.code == "refusal_or_degenerate"]
+    assert len(refusal) == 1
+    assert refusal[0].severity == "warn"
+
+
+def test_refusal_or_degenerate_block_above_half() -> None:
+    results = [_pr(f"P{i}") for i in range(8)] + [_pr(f"P{i}", error="x") for i in range(8, 20)]
+    state = PanelState(panelist_results=results, personas=_diverse_personas(20))
+    flags = _raise_flags(state)
+    refusal = [f for f in flags if f.code == "refusal_or_degenerate"]
+    assert refusal and refusal[0].severity == "block"
+
+
+def test_refusal_counts_per_response_failures() -> None:
+    """A panelist whose every response errored is degenerate even without
+    an outer ``error`` string set on the result."""
+    bad = _pr(
+        "P",
+        responses=[
+            {"question": "q1", "response": "[error: x]", "error": True},
+            {"question": "q2", "response": None, "skipped_by_budget": True},
+        ],
+    )
+    results = [bad, *[_pr(f"P{i}") for i in range(11)]]
+    state = PanelState(panelist_results=results, personas=_diverse_personas(12))
+    flags = _raise_flags(state)
+    # 1/12 ≈ 8% → no flag
+    assert not any(f.code == "refusal_or_degenerate" for f in flags)
+
+
+def test_schema_drift_passthrough() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+        schema_drift=True,
+    )
+    flags = _raise_flags(state)
+    assert Flag(code="schema_drift", severity="warn") in flags
+
+
+def test_clean_panel_emits_no_flags() -> None:
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}") for i in range(20)],
+        personas=_diverse_personas(20),
+        convergence=0.85,
+    )
+    assert _raise_flags(state) == []
+
+
+def test_empty_panel_emits_no_flags() -> None:
+    """A zero-panelist state is degenerate but not yet classifiable —
+    the verdict assembler will mark the run invalid separately. The
+    raiser must not crash on it."""
+    assert _raise_flags(PanelState()) == []
+
+
+# ---------------------------------------------------------------------------
+# Schema conformance
+# ---------------------------------------------------------------------------
+
+
+def test_all_seven_enum_members_are_reachable() -> None:
+    """Constructing a maximally-bad panel triggers every contract enum
+    member exactly once. This pins the raiser to the v1.0.0 contract:
+    if the schema gains an 8th flag, this test fails until the raiser
+    learns to produce it."""
+    schema_codes = set(load(version="1.0.0")["flags_enum"]["enum"])
+
+    state = PanelState(
+        panelist_results=[_pr(f"P{i}", error="refused") for i in range(2)],
+        personas=[{"name": "Dup", "occupation": "same"}, {"name": "Dup", "occupation": "same"}],
+        convergence=0.05,
+        expected_categories=["a"],
+        observed_categories=["a", "z"],
+        schema_drift=True,
+    )
+    raised = {f.code for f in _raise_flags(state)}
+    assert raised == schema_codes
+
+
+def test_flag_rejects_non_enum_code() -> None:
+    with pytest.raises(ValueError, match="not_a_real_flag"):
+        Flag(code="not_a_real_flag", severity="warn")
+
+
+def test_flag_rejects_invalid_severity() -> None:
+    with pytest.raises(ValueError, match="critical"):
+        Flag(code="small_n", severity="critical")
+
+
+def test_extension_rejects_enum_collision() -> None:
+    """Non-enum extensions belong on ``extension[]``; reusing an enum
+    member from there would silently shadow a real flag in the verdict
+    assembler. Raise on construction so the mistake is loud."""
+    with pytest.raises(ValueError, match="small_n"):
+        FlagExtension(code="small_n", message="x", severity="warn")
+
+
+def test_extension_rejects_invalid_severity() -> None:
+    with pytest.raises(ValueError, match="critical"):
+        FlagExtension(code="custom_thing", message="x", severity="critical")
+
+
+def test_extension_rejects_empty_code() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        FlagExtension(code="", message="x", severity="info")
+
+
+def test_extension_accepts_arbitrary_code() -> None:
+    ext = FlagExtension(code="custom_thing", message="hi", severity="info")
+    assert ext.code == "custom_thing"
+    assert ext.severity == "info"


### PR DESCRIPTION
Implements AC-5 from build-plan.md: orchestrator post-synthesis _raise_flags + extension[]. PR opened manually after gt done hung on stuck bd subprocess (rig was parked). Branch pushed by polecat quartz, commit 1d9e7bc.