### PR TITLE
site: add RFC 8288 Link headers for agent discovery (sy-7r1)

### DIFF
--- a/docs/cloudflare-pages-setup.md
+++ b/docs/cloudflare-pages-setup.md
@@ -7,9 +7,10 @@ Operational runbook for the static landing site served at <https://synthpanel.de
 - Files live in [`site/`](../site/) at the repo root.
 - Pure static HTML; Tailwind is loaded from `cdn.tailwindcss.com`. **No build
   step is required.**
-- `site/_headers` ships the security header set (CSP, HSTS, frame deny, etc.).
-  Cloudflare Pages applies these automatically for any path matched by the
-  `/*` rule.
+- `site/_headers` ships the security header set (CSP, HSTS, frame deny, etc.)
+  via the `/*` rule, plus RFC 8288 `Link` headers for agent discovery
+  (`api-catalog`, `service-doc`) on the homepage `/` rule. Cloudflare Pages
+  applies these automatically.
 
 ## Cloudflare Pages project (one-time setup)
 

--- a/site/_headers
+++ b/site/_headers
@@ -5,3 +5,9 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+
+# RFC 8288 Link headers — agent discovery (sy-7r1)
+# api-catalog target served by /.well-known/api-catalog (RFC 9727, sy-czo).
+/
+  Link: </.well-known/api-catalog>; rel="api-catalog"
+  Link: </docs/panel-run>; rel="service-doc"

--- a/tests/test_site_headers.py
+++ b/tests/test_site_headers.py
@@ -1,0 +1,82 @@
+"""Verify site/_headers ships RFC 8288 Link headers for agent discovery.
+
+The committed `_headers` file is consumed by Cloudflare Pages and applied to
+the live response on `https://synthpanel.dev/`. This test guards against
+silent removal of the `Link` headers (sy-7r1, AR-1) so agents can keep
+discovering the api-catalog and service-doc endpoints declared by the SKILL
+spec at <https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md>.
+
+This test only validates the file's contents — actual header propagation is
+verified manually via `curl -sI https://synthpanel.dev/` after deploy.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HEADERS_PATH = REPO_ROOT / "site" / "_headers"
+
+
+def _parse_headers_file(text: str) -> dict[str, list[tuple[str, str]]]:
+    """Parse a Cloudflare Pages / Netlify _headers file into {path: [(name, value), ...]}.
+
+    Comments (lines starting with '#') and blank lines separate blocks but are
+    otherwise ignored. Path lines start at column 0; header lines are indented.
+    """
+    blocks: dict[str, list[tuple[str, str]]] = {}
+    current_path: str | None = None
+    for raw in text.splitlines():
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        if not raw.startswith((" ", "\t")):
+            current_path = line.strip()
+            blocks.setdefault(current_path, [])
+            continue
+        if current_path is None:
+            continue
+        stripped = line.strip()
+        if ":" not in stripped:
+            continue
+        name, _, value = stripped.partition(":")
+        blocks[current_path].append((name.strip(), value.strip()))
+    return blocks
+
+
+def test_homepage_has_link_headers() -> None:
+    blocks = _parse_headers_file(HEADERS_PATH.read_text())
+    assert "/" in blocks, "_headers is missing a homepage (`/`) block for Link headers"
+
+    link_values = [v for n, v in blocks["/"] if n.lower() == "link"]
+    assert link_values, "homepage block has no Link headers"
+
+    rels: dict[str, str] = {}
+    for value in link_values:
+        match = re.match(r"<([^>]+)>\s*;\s*rel=\"([^\"]+)\"", value)
+        assert match, f"Link header is not RFC 8288 compliant: {value!r}"
+        rels[match.group(2)] = match.group(1)
+
+    assert rels.get("api-catalog") == "/.well-known/api-catalog", (
+        "api-catalog Link header missing or pointing at the wrong target — "
+        "must be /.well-known/api-catalog per RFC 9727"
+    )
+    assert "service-doc" in rels, "service-doc Link header missing"
+    assert rels["service-doc"].startswith("/"), (
+        f"service-doc target should be a site-relative path, got {rels['service-doc']!r}"
+    )
+
+
+def test_security_headers_still_apply_globally() -> None:
+    """Adding the homepage Link block must not displace the global /* security headers."""
+    blocks = _parse_headers_file(HEADERS_PATH.read_text())
+    assert "/*" in blocks, "_headers lost its global /* block"
+    names = {n.lower() for n, _ in blocks["/*"]}
+    for required in (
+        "x-frame-options",
+        "x-content-type-options",
+        "content-security-policy",
+        "strict-transport-security",
+    ):
+        assert required in names, f"global /* block lost {required!r}"


### PR DESCRIPTION
## Summary

Adds RFC 8288 `Link` response headers to the SynthPanel homepage so agents can discover the api-catalog and service-doc endpoints (AR-1). Implements the [link-headers SKILL spec](https://isitagentready.com/.well-known/agent-skills/link-headers/SKILL.md) with two relations: `api-catalog` -> `/.well-known/api-catalog` (target lands in AR-4 / sy-czo) and `service-doc` -> `/docs/panel-run`. Includes a parser-based regression test so the headers cannot be silently removed.

## Changes

- `site/_headers`: new `/` block emitting two `Link:` headers with `rel="api-catalog"` and `rel="service-doc"`; preserves the existing `/*` global security-header block.
- `docs/cloudflare-pages-setup.md`: notes the new `Link` header behavior in the Cloudflare Pages runbook.

## Test plan

- `tests/test_site_headers.py`: parses `_headers`; asserts homepage block exists with RFC 8288-shaped `Link` values, `api-catalog` points at `/.well-known/api-catalog`, `service-doc` resolves to a site-relative path, and the global `/*` block still carries CSP, HSTS, frame-options, and content-type-options.

## References

- Spec: build-plan.md (sp-v1-0-0-contract)
- Bead: sy-7r1

Closes #412
