### PR TITLE
structured: add v1.0.0 panel_verdict assembler (sy-ac-6)

### DIFF
--- a/src/synth_panel/structured/verdict.py
+++ b/src/synth_panel/structured/verdict.py
@@ -1,0 +1,146 @@
+"""panel_verdict assembler for the v1.0.0 frozen contract (AC-6).
+
+Builds the response artifact described by ``schemas/v1.0.0.json#/panel_verdict``
+from a post-synthesis :class:`~synth_panel.orchestrator.PanelState` snapshot
+plus the caller-supplied summary fields (headline, top verbatims, transcript
+URI). Flag raising is delegated to AC-5
+(:func:`~synth_panel.orchestrator._raise_flags`) so the contract is enforced
+in exactly one place; non-enum signals ride on
+``panel_state.extensions`` and surface under ``panel_verdict.extension[]``.
+
+The assembler defends the bound rules the JSON Schema declares
+(``headline`` ≤ 140 chars, ``top_3_verbatims`` ≤ 3 items, ``convergence``
+in [0, 1], ``dissent_count`` ≥ 0) so it physically cannot ship a
+non-conformant artifact, even if upstream code passes loose values.
+The AC-9 response gate (:func:`validate_response`) re-checks egress;
+this module is the producer-side counterpart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from synth_panel.orchestrator import Flag, PanelState, _raise_flags
+
+_SCHEMA_VERSION = "1.0.0"
+_HEADLINE_MAX_CHARS = 140
+_VERBATIMS_MAX_ITEMS = 3
+_DECISION_FIELD = "decision_being_informed"
+
+
+def _coerce_decision(value: Any) -> str:
+    """Reject the obvious decision-field violations at the producer boundary.
+
+    The validator-core (AC-2/AC-3) rejects these on ingress, but we re-check
+    here because nothing forces the caller to round-trip the request through
+    the validator before assembling — the assembler is the single chokepoint
+    for what enters ``meta.decision_being_informed``.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{_DECISION_FIELD!r} must be a string, got {type(value).__name__}")
+    if "\n" in value or "\r" in value:
+        raise ValueError(f"{_DECISION_FIELD!r} must not contain newline characters")
+    if not value.strip():
+        raise ValueError(f"{_DECISION_FIELD!r} must be non-empty after trimming")
+    return value
+
+
+def _coerce_verbatims(items: Iterable[Mapping[str, Any]]) -> list[dict[str, str]]:
+    """Clamp to ≤ 3 items and project to the schema's ``{persona_id, quote}`` shape.
+
+    Drops unknown keys silently — the v1.0.0 schema has
+    ``additionalProperties: false`` on each verbatim object, so passing
+    them through would fail :func:`validate_response`.
+    """
+    out: list[dict[str, str]] = []
+    for v in items:
+        if len(out) >= _VERBATIMS_MAX_ITEMS:
+            break
+        try:
+            out.append({"persona_id": str(v["persona_id"]), "quote": str(v["quote"])})
+        except KeyError as exc:
+            raise ValueError(f"verbatim missing required key: {exc.args[0]!r}") from None
+    return out
+
+
+def _coerce_convergence(state_value: float | None, override: float | None) -> float:
+    """Pick the override if given, else state, else 0.0; clamp to [0, 1]."""
+    raw = override if override is not None else state_value
+    if raw is None:
+        return 0.0
+    return max(0.0, min(1.0, float(raw)))
+
+
+def build_panel_verdict(
+    *,
+    decision_being_informed: str,
+    panel_state: PanelState,
+    headline: str,
+    full_transcript_uri: str,
+    top_3_verbatims: Iterable[Mapping[str, Any]] = (),
+    dissent_count: int = 0,
+    convergence: float | None = None,
+    extra_flags: Iterable[Flag] = (),
+) -> dict[str, Any]:
+    """Assemble a v1.0.0-conformant ``panel_verdict`` dict.
+
+    Parameters
+    ----------
+    decision_being_informed:
+        The request-side decision string. Must be non-empty after trimming
+        and contain no newline characters (mirrors the validator-core rule).
+    panel_state:
+        Post-synthesis snapshot. Drives flag raising (via AC-5) and supplies
+        the default ``convergence`` value when the override is omitted.
+    headline:
+        Short summary line. Truncated to 140 characters per
+        ``panel_verdict.headline.maxLength``.
+    full_transcript_uri:
+        Pointer to the persisted transcript (file://, s3://, …). Coerced to
+        ``str`` — the schema only requires a string, not a parseable URI.
+    top_3_verbatims:
+        Up to three ``{persona_id, quote}`` mappings. Extra entries are
+        dropped from the tail; unknown keys per entry are stripped.
+    dissent_count:
+        Number of panelists who dissented from the modal stance. Negative
+        values are clamped to 0 to satisfy the schema's
+        ``minimum: 0`` constraint.
+    convergence:
+        Optional override for ``panel_state.convergence``. ``None`` falls
+        through to state; any value is clamped to ``[0.0, 1.0]``.
+    extra_flags:
+        Additional :class:`Flag` instances to append after the raised set
+        (e.g. a schema-drift flag set by AC-9 just before egress). Each
+        must already be enum-valid — :class:`Flag` rejects bad codes at
+        construction.
+
+    Returns
+    -------
+    dict
+        A plain dict. Mutation is the caller's responsibility; the
+        assembler holds no reference after return.
+    """
+    decision = _coerce_decision(decision_being_informed)
+
+    raised: list[Flag] = list(_raise_flags(panel_state))
+    raised.extend(extra_flags or ())
+    flag_dicts = [{"code": f.code, "severity": f.severity} for f in raised]
+
+    extension_dicts = [{"code": e.code, "message": e.message, "severity": e.severity} for e in panel_state.extensions]
+
+    artifact: dict[str, Any] = {
+        "headline": str(headline)[:_HEADLINE_MAX_CHARS],
+        "convergence": _coerce_convergence(panel_state.convergence, convergence),
+        "dissent_count": max(0, int(dissent_count)),
+        "top_3_verbatims": _coerce_verbatims(top_3_verbatims),
+        "flags": flag_dicts,
+        "extension": extension_dicts,
+        "full_transcript_uri": str(full_transcript_uri),
+        "meta": {_DECISION_FIELD: decision},
+        "schema_version": _SCHEMA_VERSION,
+    }
+    return artifact
+
+
+__all__ = ["build_panel_verdict"]

--- a/tests/structured/test_verdict_shape.py
+++ b/tests/structured/test_verdict_shape.py
@@ -1,0 +1,258 @@
+"""Tests for the v1.0.0 panel_verdict assembler (AC-6).
+
+The assembler builds a ``panel_verdict`` dict that conforms to
+``schemas/v1.0.0.json#/panel_verdict``. It is the only sanctioned producer
+of the artifact — the AC-9 response gate validates whatever this module
+emits, so a violation here is a contract break, not a soft warning.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_panel.cost import ZERO_USAGE
+from synth_panel.orchestrator import (
+    Flag,
+    FlagExtension,
+    PanelistResult,
+    PanelState,
+)
+from synth_panel.structured.validate import validate_response
+from synth_panel.structured.verdict import build_panel_verdict
+
+_VALID_DECISION = "Should we ship the new pricing tier next quarter?"
+
+
+def _panelists(n: int) -> list[PanelistResult]:
+    return [
+        PanelistResult(
+            persona_name=f"p{i}",
+            responses=[{"response": "fine"}],
+            usage=ZERO_USAGE,
+        )
+        for i in range(n)
+    ]
+
+
+def _state(**overrides) -> PanelState:
+    """Healthy panel state — 8 panelists, no skew, no drift."""
+    base = {
+        "panelist_results": _panelists(8),
+        "personas": [{"name": f"p{i}", "occupation": f"job{i}"} for i in range(8)],
+        "convergence": 0.72,
+        "schema_drift": False,
+        "expected_categories": None,
+        "observed_categories": None,
+        "extensions": [],
+    }
+    base.update(overrides)
+    return PanelState(**base)
+
+
+# ---------------------------------------------------------------------------
+# Canonical bead test (sy-b3n)
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_echoes_decision_and_version() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="Strong support with pricing caveats.",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+
+    assert artifact["meta"]["decision_being_informed"] == _VALID_DECISION
+    assert artifact["schema_version"] == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# Schema conformance
+# ---------------------------------------------------------------------------
+
+
+def test_default_artifact_passes_response_validator() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    assert validate_response(artifact) is None
+
+
+def test_artifact_contains_all_required_top_level_fields() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    required = {
+        "headline",
+        "convergence",
+        "dissent_count",
+        "top_3_verbatims",
+        "flags",
+        "extension",
+        "full_transcript_uri",
+        "meta",
+        "schema_version",
+    }
+    assert set(artifact.keys()) >= required
+
+
+# ---------------------------------------------------------------------------
+# Bound enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_headline_is_truncated_to_140_chars() -> None:
+    long = "x" * 500
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline=long,
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    assert len(artifact["headline"]) <= 140
+
+
+def test_top_3_verbatims_clamps_to_three_items() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+        top_3_verbatims=[{"persona_id": f"p{i}", "quote": f"q{i}"} for i in range(5)],
+    )
+    assert len(artifact["top_3_verbatims"]) == 3
+    assert artifact["top_3_verbatims"][0] == {"persona_id": "p0", "quote": "q0"}
+
+
+def test_top_3_verbatims_strips_unknown_keys() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+        top_3_verbatims=[
+            {"persona_id": "p1", "quote": "great", "extra": "ignored"},
+        ],
+    )
+    assert artifact["top_3_verbatims"] == [{"persona_id": "p1", "quote": "great"}]
+
+
+def test_convergence_clamped_to_unit_interval() -> None:
+    over = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(convergence=1.7),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    under = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(convergence=-0.2),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    assert over["convergence"] == 1.0
+    assert under["convergence"] == 0.0
+
+
+def test_convergence_defaults_to_zero_when_unknown() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(convergence=None),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    assert artifact["convergence"] == 0.0
+
+
+def test_dissent_count_is_non_negative_integer() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+        dissent_count=-3,
+    )
+    assert artifact["dissent_count"] == 0
+    assert isinstance(artifact["dissent_count"], int)
+
+
+# ---------------------------------------------------------------------------
+# Flags + extension routing
+# ---------------------------------------------------------------------------
+
+
+def test_small_n_state_emits_small_n_flag() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(panelist_results=_panelists(2), personas=[]),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    flag_codes = {f["code"] for f in artifact["flags"]}
+    assert "small_n" in flag_codes
+    # Conformance: every emitted flag uses an enum-valid (code, severity).
+    assert validate_response(artifact) is None
+
+
+def test_extensions_pass_through_to_extension_array() -> None:
+    ext = FlagExtension(
+        code="custom.cohort_imbalance",
+        message="Two regions account for 90% of panel.",
+        severity="warn",
+    )
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(extensions=[ext]),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+    )
+    assert artifact["extension"] == [
+        {
+            "code": "custom.cohort_imbalance",
+            "message": "Two regions account for 90% of panel.",
+            "severity": "warn",
+        }
+    ]
+
+
+def test_extra_flags_appended_to_raised_set() -> None:
+    artifact = build_panel_verdict(
+        decision_being_informed=_VALID_DECISION,
+        panel_state=_state(),
+        headline="OK",
+        full_transcript_uri="file:///tmp/run.jsonl",
+        extra_flags=[Flag(code="schema_drift", severity="warn")],
+    )
+    flag_codes = [f["code"] for f in artifact["flags"]]
+    assert "schema_drift" in flag_codes
+
+
+# ---------------------------------------------------------------------------
+# Decision-field defenses
+# ---------------------------------------------------------------------------
+
+
+def test_decision_must_be_non_empty_string() -> None:
+    with pytest.raises(ValueError):
+        build_panel_verdict(
+            decision_being_informed="",
+            panel_state=_state(),
+            headline="OK",
+            full_transcript_uri="file:///tmp/run.jsonl",
+        )
+
+
+def test_decision_with_newline_rejected() -> None:
+    with pytest.raises(ValueError):
+        build_panel_verdict(
+            decision_being_informed="line one\nline two",
+            panel_state=_state(),
+            headline="OK",
+            full_transcript_uri="file:///tmp/run.jsonl",
+        )


### PR DESCRIPTION
## Summary

Adds `build_panel_verdict`, the single sanctioned producer of the v1.0.0 `panel_verdict` artifact described by `schemas/v1.0.0.json#/panel_verdict` (AC-6). Consumes the AC-5 `PanelState` snapshot, delegates flag raising to `_raise_flags` so the contract is enforced in exactly one place, and routes non-enum signals from `PanelState.extensions` to `panel_verdict.extension[]`. Defends every schema bound (headline truncated to 140, top_3_verbatims clamped to 3 with unknown keys stripped, convergence clamped to [0,1], dissent_count floored at 0) so it physically cannot ship a non-conformant artifact, and re-checks decision-field rules at the producer boundary because nothing forces request payloads to round-trip through the validator before assembly.

## Changes

- `src/synth_panel/structured/verdict.py`: new module with `build_panel_verdict(...)`, `_coerce_decision`, `_coerce_verbatims`, `_coerce_convergence` helpers; stamps `schema_version="1.0.0"` and the decision echo into `meta.decision_being_informed`.

## Test plan

- `tests/structured/test_verdict_shape.py`: 14 cases including the named AC test `test_verdict_echoes_decision_and_version`; covers full schema conformance via `validate_response`, presence of all required top-level fields, headline truncation, verbatim clamping/projection, convergence clamping and default, non-negative dissent count, small-n flag raising, extension pass-through, extra_flags appending, and decision-field defenses (non-string, newline, empty-after-trim).

## References

- Spec: build-plan.md (sp-v1-0-0-contract)
- Bead: sy-b3n

Closes #408
