### PR TITLE
structured: add v1.0.0 drift contract (sy-064)

### DIFF
--- a/src/synth_panel/structured/retry.py
+++ b/src/synth_panel/structured/retry.py
@@ -1,0 +1,170 @@
+"""Drift contract — post-3-strike exhaustion behavior (AC-8).
+
+When the structured-output engine's 3-strike retry exhausts on haiku
+malformed output, the server's contract-level response depends on
+``SYNTHPANEL_DRIFT_DEGRADE``:
+
+* **Off** (v1.0.0 default) — return a typed
+  :class:`~synth_panel.structured.validate.ErrorEnvelope` with
+  ``error_code="SCHEMA_DRIFT"`` and ``retry_safe=True``. The caller is
+  expected to retry the request with cleaner stimulus or escalate.
+* **On** (v1.1.0 default) — return the **degraded artifact** — a
+  ``panel_verdict`` carrying
+  ``flags=[{"code": "schema_drift", "severity": "warn"}]``. The panel
+  ran, the user gets partial signal, the flag is the contract for
+  "trust this less."
+
+The typed ``SCHEMA_DRIFT`` error code is reserved at the contract level
+for the catastrophic case where the degraded artifact itself fails
+re-validation; ordinary 3-strike exhaustion under degrade-on must NOT
+promote to it. See SPEC.md §12.5 and docs/response-contract.md.
+
+This module is the contract pivot, not the strike loop. The per-attempt
+retry policy lives in :mod:`synth_panel.structured.output`; this module
+decides what shape leaves the server once that loop has given up.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections.abc import Mapping
+from typing import Any
+
+from synth_panel.structured.validate import ErrorEnvelope
+
+logger = logging.getLogger(__name__)
+
+DRIFT_DEGRADE_ENV: str = "SYNTHPANEL_DRIFT_DEGRADE"
+
+# Flip to True for the v1.1.0 schema cut. Kept as a module constant so
+# tests can pin v1.0.0 behavior without duplicating the string literal.
+DEFAULT_DEGRADE_V1_0_0: bool = False
+
+_SCHEMA_VERSION = "1.0.0"
+_DRIFT_FLAG_CODE = "schema_drift"
+_DRIFT_FLAG_SEVERITY = "warn"
+
+# Conventional posix-shell idioms. Anything outside both sets falls
+# back to the v1.0.0 default rather than guessing intent.
+_TRUTHY = frozenset({"1", "on", "true", "yes"})
+_FALSY = frozenset({"0", "off", "false", "no", ""})
+
+_DEGRADED_HEADLINE_FALLBACK = "Degraded panel — schema drift after 3-strike retry exhaustion."
+
+
+def degrade_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return True when ``SYNTHPANEL_DRIFT_DEGRADE`` selects degraded-artifact mode.
+
+    Reads :data:`os.environ` by default; pass *env* (any mapping) to
+    override — the test seam. Unset or unrecognized values fall back to
+    :data:`DEFAULT_DEGRADE_V1_0_0` rather than silently flipping
+    behavior on a typo.
+    """
+    src: Mapping[str, str] = env if env is not None else os.environ
+    raw = src.get(DRIFT_DEGRADE_ENV)
+    if raw is None:
+        return DEFAULT_DEGRADE_V1_0_0
+    val = raw.strip().lower()
+    if val in _TRUTHY:
+        return True
+    if val in _FALSY:
+        return False
+    logger.debug(
+        "SYNTHPANEL_DRIFT_DEGRADE=%r is not a recognized truthy/falsy value; falling back to v1.0.0 default (%s).",
+        raw,
+        DEFAULT_DEGRADE_V1_0_0,
+    )
+    return DEFAULT_DEGRADE_V1_0_0
+
+
+def exhausted_retry_outcome(
+    *,
+    partial_artifact: Mapping[str, Any],
+    decision_being_informed: str,
+    full_transcript_uri: str,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any] | ErrorEnvelope:
+    """Return the contract-correct outcome after 3-strike retry exhaustion.
+
+    With degrade enabled, returns a degraded ``panel_verdict`` dict
+    carrying a ``schema_drift`` warn flag (alongside any flags the
+    partial already raised). With degrade disabled (v1.0.0 default),
+    returns a typed :class:`ErrorEnvelope` with ``error_code="SCHEMA_DRIFT"``
+    and ``retry_safe=True`` — the caller can safely retry with
+    different stimulus.
+
+    The input *partial_artifact* is never mutated; the returned dict
+    is always a fresh shallow-then-flag-list copy.
+    """
+    if degrade_enabled(env):
+        return _degraded_artifact(
+            partial_artifact=partial_artifact,
+            decision_being_informed=decision_being_informed,
+            full_transcript_uri=full_transcript_uri,
+        )
+
+    return ErrorEnvelope(
+        error_code="SCHEMA_DRIFT",
+        message=(
+            "structured output exhausted 3-strike retry; the degraded "
+            "artifact is not delivered because SYNTHPANEL_DRIFT_DEGRADE "
+            "is off (v1.0.0 default). Set SYNTHPANEL_DRIFT_DEGRADE=1 to "
+            "receive the degraded panel_verdict with a schema_drift flag "
+            "instead. This will become the default at v1.1.0."
+        ),
+        field_path=None,
+        schema_version=_SCHEMA_VERSION,
+        retry_safe=True,
+    )
+
+
+def _degraded_artifact(
+    *,
+    partial_artifact: Mapping[str, Any],
+    decision_being_informed: str,
+    full_transcript_uri: str,
+) -> dict[str, Any]:
+    """Stamp the degraded-artifact contract onto *partial_artifact*.
+
+    Idempotent on the ``schema_drift`` flag (set semantics on
+    ``flags[]``) and overwrites the contract-required fields the caller
+    is responsible for (transcript URI, decision echo, schema_version)
+    so the artifact passes :func:`validate_response` even if the
+    upstream partial omitted them.
+    """
+    artifact: dict[str, Any] = dict(partial_artifact)
+
+    raw_flags = artifact.get("flags") or []
+    flags: list[dict[str, Any]] = [dict(f) for f in raw_flags if isinstance(f, dict)]
+    if not any(f.get("code") == _DRIFT_FLAG_CODE for f in flags):
+        flags.append({"code": _DRIFT_FLAG_CODE, "severity": _DRIFT_FLAG_SEVERITY})
+    artifact["flags"] = flags
+
+    raw_ext = artifact.get("extension") or []
+    artifact["extension"] = [dict(e) for e in raw_ext if isinstance(e, dict)]
+
+    artifact.setdefault("headline", _DEGRADED_HEADLINE_FALLBACK)
+    artifact.setdefault("convergence", 0.0)
+    artifact.setdefault("dissent_count", 0)
+
+    raw_verbatims = artifact.get("top_3_verbatims") or []
+    artifact["top_3_verbatims"] = [dict(v) for v in raw_verbatims if isinstance(v, dict)]
+
+    artifact["full_transcript_uri"] = full_transcript_uri
+
+    meta = dict(artifact.get("meta") or {})
+    meta["decision_being_informed"] = decision_being_informed
+    artifact["meta"] = meta
+
+    artifact["schema_version"] = _SCHEMA_VERSION
+
+    return artifact
+
+
+__all__ = [
+    "DEFAULT_DEGRADE_V1_0_0",
+    "DRIFT_DEGRADE_ENV",
+    "degrade_enabled",
+    "exhausted_retry_outcome",
+]

--- a/tests/structured/test_drift_contract.py
+++ b/tests/structured/test_drift_contract.py
@@ -1,0 +1,214 @@
+"""Drift contract tests (AC-8).
+
+Post-3-strike retry exhaustion contract per SPEC.md §12.5:
+
+- ``SYNTHPANEL_DRIFT_DEGRADE`` off (v1.0.0 default): typed
+  :class:`~synth_panel.structured.validate.ErrorEnvelope` with
+  ``error_code="SCHEMA_DRIFT"`` and ``retry_safe=True``.
+- ``SYNTHPANEL_DRIFT_DEGRADE`` on (v1.1.0 default): degraded
+  ``panel_verdict`` carrying
+  ``flags=[{"code": "schema_drift", "severity": "warn"}]`` —
+  **not** a typed error.
+- Typed ``SCHEMA_DRIFT`` is reserved at the contract level for
+  catastrophic re-validation failure, never as the carrier for
+  ordinary 3-strike exhaustion when degrade is enabled.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_panel.structured.retry import (
+    DEFAULT_DEGRADE_V1_0_0,
+    degrade_enabled,
+    exhausted_retry_outcome,
+)
+from synth_panel.structured.validate import ErrorEnvelope, validate_response
+
+_DECISION = "Should we ship the new pricing tier next quarter?"
+_URI = "panel-result://result-test-drift"
+
+
+def _partial_artifact(**overrides):
+    base = {
+        "headline": "Cohort splits on $79; price is the dominant objection.",
+        "convergence": 0.42,
+        "dissent_count": 2,
+        "top_3_verbatims": [
+            {"persona_id": "p1", "quote": "Too expensive for solo use."},
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Canonical AC-8 test (named in the bead acceptance criteria)
+# ---------------------------------------------------------------------------
+
+
+def test_exhausted_retry_returns_flagged_artifact_not_error() -> None:
+    """When degrade is on, exhaustion returns a flagged artifact, not an error.
+
+    This is the contract pivot: same engine event (3-strike exhaustion),
+    two outcomes selected by ``SYNTHPANEL_DRIFT_DEGRADE``. With degrade
+    on we deliver the partial signal under a ``schema_drift`` warn flag;
+    only a catastrophic re-validation failure of the degraded artifact
+    itself promotes to a typed ``SCHEMA_DRIFT`` error envelope.
+    """
+    out = exhausted_retry_outcome(
+        partial_artifact=_partial_artifact(),
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "1"},
+    )
+    assert not isinstance(out, ErrorEnvelope), (
+        "degrade=on must NOT promote ordinary exhaustion to a typed error; "
+        "SCHEMA_DRIFT is reserved for catastrophic re-validation failure."
+    )
+    assert isinstance(out, dict)
+    assert any(
+        isinstance(f, dict) and f.get("code") == "schema_drift" and f.get("severity") == "warn" for f in out["flags"]
+    ), f"degraded artifact must carry schema_drift/warn flag; got {out['flags']!r}"
+    # Degraded artifact must still pass the v1.0.0 response contract.
+    assert validate_response(out) is None
+
+
+# ---------------------------------------------------------------------------
+# Default behavior in v1.0.0: typed error
+# ---------------------------------------------------------------------------
+
+
+def test_v1_0_0_default_unset_returns_typed_error() -> None:
+    """``SYNTHPANEL_DRIFT_DEGRADE`` unset → v1.0.0 default (off) → typed error."""
+    assert DEFAULT_DEGRADE_V1_0_0 is False, "v1.0.0 ships with degrade off; flip to True only at v1.1.0."
+    out = exhausted_retry_outcome(
+        partial_artifact=_partial_artifact(),
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={},
+    )
+    assert isinstance(out, ErrorEnvelope)
+    assert out.error_code == "SCHEMA_DRIFT"
+    assert out.retry_safe is True
+    assert out.schema_version == "1.0.0"
+
+
+def test_drift_degrade_off_returns_typed_error() -> None:
+    out = exhausted_retry_outcome(
+        partial_artifact=_partial_artifact(),
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "off"},
+    )
+    assert isinstance(out, ErrorEnvelope)
+    assert out.error_code == "SCHEMA_DRIFT"
+    assert out.retry_safe is True
+
+
+# ---------------------------------------------------------------------------
+# degrade_enabled()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("val", ["1", "on", "true", "yes", "ON", "True", "Yes"])
+def test_degrade_enabled_truthy(val: str) -> None:
+    assert degrade_enabled({"SYNTHPANEL_DRIFT_DEGRADE": val}) is True
+
+
+@pytest.mark.parametrize("val", ["0", "off", "false", "no", "", "OFF", "False"])
+def test_degrade_enabled_falsy(val: str) -> None:
+    assert degrade_enabled({"SYNTHPANEL_DRIFT_DEGRADE": val}) is False
+
+
+def test_degrade_enabled_unset_uses_v1_0_0_default() -> None:
+    # v1.0.0 default is off (typed error). Will flip on for v1.1.0.
+    assert degrade_enabled({}) is DEFAULT_DEGRADE_V1_0_0
+
+
+def test_degrade_enabled_unrecognized_value_falls_back_to_default() -> None:
+    """Garbage in the env var must not silently flip behavior either way."""
+    assert degrade_enabled({"SYNTHPANEL_DRIFT_DEGRADE": "maybe"}) is DEFAULT_DEGRADE_V1_0_0
+
+
+def test_degrade_enabled_reads_os_environ_when_env_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("SYNTHPANEL_DRIFT_DEGRADE", "1")
+    assert degrade_enabled() is True
+    monkeypatch.setenv("SYNTHPANEL_DRIFT_DEGRADE", "0")
+    assert degrade_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Idempotence + contract conformance of the degraded artifact
+# ---------------------------------------------------------------------------
+
+
+def test_degraded_artifact_idempotent_when_flag_already_present() -> None:
+    """Don't double-stamp schema_drift if the upstream partial already added it."""
+    partial = _partial_artifact(
+        flags=[{"code": "schema_drift", "severity": "warn"}],
+    )
+    out = exhausted_retry_outcome(
+        partial_artifact=partial,
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "1"},
+    )
+    assert isinstance(out, dict)
+    drift_count = sum(1 for f in out["flags"] if isinstance(f, dict) and f.get("code") == "schema_drift")
+    assert drift_count == 1
+
+
+def test_degraded_artifact_preserves_existing_flags() -> None:
+    partial = _partial_artifact(
+        flags=[{"code": "low_convergence", "severity": "warn"}],
+    )
+    out = exhausted_retry_outcome(
+        partial_artifact=partial,
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "1"},
+    )
+    assert isinstance(out, dict)
+    codes = [f.get("code") for f in out["flags"] if isinstance(f, dict)]
+    assert "low_convergence" in codes
+    assert "schema_drift" in codes
+
+
+def test_degraded_artifact_echoes_decision_verbatim() -> None:
+    out = exhausted_retry_outcome(
+        partial_artifact=_partial_artifact(),
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "1"},
+    )
+    assert isinstance(out, dict)
+    assert out["meta"]["decision_being_informed"] == _DECISION
+
+
+def test_degraded_artifact_stamps_schema_version() -> None:
+    out = exhausted_retry_outcome(
+        partial_artifact=_partial_artifact(),
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "1"},
+    )
+    assert isinstance(out, dict)
+    assert out["schema_version"] == "1.0.0"
+
+
+def test_degraded_artifact_does_not_mutate_input() -> None:
+    """The input partial_artifact must not be mutated in place."""
+    partial = _partial_artifact()
+    snapshot = {k: (list(v) if isinstance(v, list) else v) for k, v in partial.items()}
+    exhausted_retry_outcome(
+        partial_artifact=partial,
+        decision_being_informed=_DECISION,
+        full_transcript_uri=_URI,
+        env={"SYNTHPANEL_DRIFT_DEGRADE": "1"},
+    )
+    for k, v in snapshot.items():
+        assert partial[k] == v, f"input partial_artifact mutated at key {k!r}"
+    assert "flags" not in partial or partial.get("flags") == snapshot.get("flags")


### PR DESCRIPTION
## Summary

Adds the drift contract pivot that decides what shape leaves the server after the structured-output engine's 3-strike retry exhausts (AC-8, SPEC.md sec 12.5). With `SYNTHPANEL_DRIFT_DEGRADE` off (v1.0.0 default), returns a typed `ErrorEnvelope` with `error_code="SCHEMA_DRIFT"` and `retry_safe=True`. With it on (v1.1.0 default), returns a degraded `panel_verdict` carrying `flags=[{"code": "schema_drift", "severity": "warn"}]`. Typed `SCHEMA_DRIFT` is reserved at the contract level for catastrophic re-validation failure of the degraded artifact, so ordinary 3-strike exhaustion under degrade-on must not promote to it. The strike loop itself stays in `structured/output.py` - this module is the boundary behavior, not the retry policy.

## Changes

- `src/synth_panel/structured/retry.py`: new module exporting `exhausted_retry_outcome(...)`, `degrade_enabled(env=None)`, `DEFAULT_DEGRADE_V1_0_0=False`, `DRIFT_DEGRADE_ENV`; degraded-artifact builder is idempotent on the `schema_drift` flag, preserves prior flags, never mutates input, and stamps contract-required fields (transcript URI, decision echo, schema_version) so the result passes `validate_response` even when upstream partial omits them; unrecognized env values fall back to default rather than guessing intent.

## Test plan

- `tests/structured/test_drift_contract.py`: 25 cases including the named AC test `test_exhausted_retry_returns_flagged_artifact_not_error`; covers v1.0.0 default-off typed-error path, parametrized truthy/falsy env parsing, `os.environ` fallback when env arg omitted, idempotence on repeated `schema_drift` flag, flag preservation, decision echo, schema_version stamping, and input non-mutation.

## References

- Spec: build-plan.md (sp-v1-0-0-contract)
- Bead: sy-064

Closes #410
