### PR TITLE
persistence: stamp every JSONL row with decision_being_informed (sy-6i2)

### DIFF
--- a/src/synth_panel/persistence.py
+++ b/src/synth_panel/persistence.py
@@ -102,6 +102,10 @@ class Session:
     messages: list[ConversationMessage] = field(default_factory=list)
     compaction: CompactionMeta | None = None
     fork: ForkMeta | None = None
+    # AC-7: stamped on every JSONL row for panel-run transcripts so each line
+    # is self-describing. Omitted (None) for run_prompt and other non-panel
+    # sessions per the v1.0.0 contract in schemas/v1.0.0.json.
+    decision_being_informed: str | None = None
 
     # --- Mutation helpers --------------------------------------------------
 
@@ -158,6 +162,8 @@ class Session:
             d["compaction"] = self.compaction.to_dict()
         if self.fork is not None:
             d["fork"] = self.fork.to_dict()
+        if self.decision_being_informed is not None:
+            d["decision_being_informed"] = self.decision_being_informed
         return d
 
     @classmethod
@@ -176,12 +182,20 @@ class Session:
             messages=[ConversationMessage.from_dict(m) for m in data["messages"]],
             compaction=compaction,
             fork=fork,
+            decision_being_informed=data.get("decision_being_informed"),
         )
 
     # --- Serialisation: JSONL ---------------------------------------------
 
     def to_jsonl(self) -> str:
-        """Serialise as newline-delimited JSON records."""
+        """Serialise as newline-delimited JSON records.
+
+        When ``decision_being_informed`` is set, every emitted row carries it
+        (AC-7 transcript stamping) so each line of the transcript is
+        self-describing.
+        """
+        decision = _validated_decision_stamp(self.decision_being_informed)
+
         lines: list[str] = []
         meta: dict[str, Any] = {
             "type": "session_meta",
@@ -192,14 +206,17 @@ class Session:
         }
         if self.fork is not None:
             meta["fork"] = self.fork.to_dict()
+        _stamp(meta, decision)
         lines.append(json.dumps(meta, separators=(",", ":")))
 
         for msg in self.messages:
-            record = {"type": "message", **msg.to_dict()}
+            record: dict[str, Any] = {"type": "message", **msg.to_dict()}
+            _stamp(record, decision)
             lines.append(json.dumps(record, separators=(",", ":")))
 
         if self.compaction is not None:
             record = {"type": "compaction", **self.compaction.to_dict()}
+            _stamp(record, decision)
             lines.append(json.dumps(record, separators=(",", ":")))
 
         return "\n".join(lines) + "\n"
@@ -218,6 +235,7 @@ class Session:
         messages: list[ConversationMessage] = []
         compaction: CompactionMeta | None = None
         fork: ForkMeta | None = None
+        decision_being_informed: str | None = None
 
         for i, line in enumerate(lines, start=1):
             try:
@@ -233,10 +251,19 @@ class Session:
                 updated_at = record["updated_at"]
                 if "fork" in record:
                     fork = ForkMeta.from_dict(record["fork"])
+                # session_meta is the canonical source for the decision; if a
+                # downstream row disagrees we still trust the header so a
+                # corrupted middle line cannot rewrite session-level identity.
+                if "decision_being_informed" in record:
+                    decision_being_informed = record["decision_being_informed"]
             elif rtype == "message":
-                messages.append(ConversationMessage.from_dict(record))
+                # Strip the stamp before delegating to ConversationMessage so
+                # legacy and stamped rows produce identical message objects.
+                msg_record = {k: v for k, v in record.items() if k != "decision_being_informed"}
+                messages.append(ConversationMessage.from_dict(msg_record))
             elif rtype == "compaction":
-                compaction = CompactionMeta.from_dict(record)
+                cmp_record = {k: v for k, v in record.items() if k != "decision_being_informed"}
+                compaction = CompactionMeta.from_dict(cmp_record)
             else:
                 raise SessionFormatError(f"Unknown record type {rtype!r} at line {i}")
 
@@ -251,6 +278,7 @@ class Session:
             messages=messages,
             compaction=compaction,
             fork=fork,
+            decision_being_informed=decision_being_informed,
         )
 
 
@@ -274,6 +302,30 @@ class SessionIOError(SessionError):
 # ---------------------------------------------------------------------------
 # Atomic file writing
 # ---------------------------------------------------------------------------
+
+
+def _validated_decision_stamp(value: str | None) -> str | None:
+    """Return *value* if safe to embed as a JSONL row stamp, else raise.
+
+    A newline in the field would split a single record across multiple lines
+    and silently corrupt every downstream reader. The contract validator
+    (structured.validate.validate_request, AC-2) is the upstream authority
+    for shape rules; persistence keeps a self-protective check at its own
+    boundary so a misuse can't produce malformed transcripts.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValueError("decision_being_informed must be a string")
+    if "\n" in value or "\r" in value:
+        raise ValueError("decision_being_informed must not contain newline characters")
+    return value
+
+
+def _stamp(record: dict[str, Any], decision: str | None) -> None:
+    """Attach the decision stamp to a JSONL row when set."""
+    if decision is not None:
+        record["decision_being_informed"] = decision
 
 
 def _atomic_write(path: Path, data: str) -> None:
@@ -384,10 +436,19 @@ def load_session(path: str | Path) -> Session:
 def append_message(
     path: str | Path,
     message: ConversationMessage,
+    *,
+    decision_being_informed: str | None = None,
 ) -> None:
-    """Append a single message record to a JSONL session file."""
+    """Append a single message record to a JSONL session file.
+
+    When ``decision_being_informed`` is provided, the appended row is stamped
+    with it (AC-7) so live-streamed transcripts stay self-describing on a
+    per-row basis even before the session is closed.
+    """
     p = Path(path)
-    record = {"type": "message", **message.to_dict()}
+    decision = _validated_decision_stamp(decision_being_informed)
+    record: dict[str, Any] = {"type": "message", **message.to_dict()}
+    _stamp(record, decision)
     line = json.dumps(record, separators=(",", ":")) + "\n"
     try:
         p.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/persistence/test_transcript_stamp.py
+++ b/tests/persistence/test_transcript_stamp.py
@@ -1,0 +1,146 @@
+"""Transcript stamping tests for AC-7 of the v1.0.0 frozen contract.
+
+Every row in a panel-run JSONL transcript must carry the
+``decision_being_informed`` field, so any single line is self-describing
+and can be tied back to the decision the panel was informing.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from synth_panel.cost import TokenUsage
+from synth_panel.persistence import (
+    ConversationMessage,
+    Session,
+    append_message,
+    load_session,
+    save_session,
+)
+
+_DECISION = "Should we ship the new pricing tier next quarter?"
+
+
+def _text_msg(role: str, text: str, usage: TokenUsage | None = None) -> ConversationMessage:
+    return ConversationMessage(
+        role=role,
+        content=[{"type": "text", "text": text}],
+        usage=usage,
+    )
+
+
+def test_every_row_carries_decision(tmp_path):
+    """Canonical AC-7 test: every JSONL row is stamped with the decision."""
+    s = Session(decision_being_informed=_DECISION)
+    s.push_message(_text_msg("user", "What do you think about price?"))
+    s.push_message(_text_msg("assistant", "It feels high.", usage=TokenUsage(10, 20, 0, 0)))
+    s.push_message(_text_msg("user", "Why?"))
+    s.push_message(_text_msg("assistant", "Compared to peers."))
+    # Force a compaction record so all three row-types are exercised.
+    s.compact("Earlier turns covered price perception.", keep_last=2)
+
+    path = tmp_path / "panel.jsonl"
+    save_session(s, path, fmt="jsonl")
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert lines, "JSONL file should not be empty"
+
+    seen_types = set()
+    for i, line in enumerate(lines, start=1):
+        record = json.loads(line)
+        seen_types.add(record.get("type"))
+        assert record.get("decision_being_informed") == _DECISION, (
+            f"row {i} (type={record.get('type')!r}) missing or wrong decision_being_informed: {record!r}"
+        )
+
+    # All three row types must exist and all must be stamped.
+    assert {"session_meta", "message", "compaction"} <= seen_types
+
+
+def test_append_message_stamps_decision(tmp_path):
+    """append_message stamps the row when given decision_being_informed."""
+    path = tmp_path / "live.jsonl"
+    append_message(
+        path,
+        _text_msg("user", "first turn"),
+        decision_being_informed=_DECISION,
+    )
+    append_message(
+        path,
+        _text_msg("assistant", "reply"),
+        decision_being_informed=_DECISION,
+    )
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        assert record["type"] == "message"
+        assert record["decision_being_informed"] == _DECISION
+
+
+def test_no_decision_means_no_stamp(tmp_path):
+    """Sessions without a decision (e.g. run_prompt transcripts) emit no stamp.
+
+    decision_being_informed is explicitly NOT used on run_prompt (per the
+    v1.0.0 contract in schemas/v1.0.0.json), so its absence must be a clean
+    omission rather than an empty-string sentinel.
+    """
+    s = Session()
+    s.push_message(_text_msg("user", "hi"))
+    path = tmp_path / "prompt.jsonl"
+    save_session(s, path, fmt="jsonl")
+
+    lines = path.read_text(encoding="utf-8").strip().splitlines()
+    for line in lines:
+        record = json.loads(line)
+        assert "decision_being_informed" not in record, (
+            f"decision_being_informed must be omitted, not nulled: {record!r}"
+        )
+
+
+def test_decision_round_trips_through_jsonl(tmp_path):
+    """Loading a stamped JSONL transcript restores Session.decision_being_informed."""
+    s = Session(decision_being_informed=_DECISION)
+    s.push_message(_text_msg("user", "q"))
+    path = tmp_path / "rt.jsonl"
+    save_session(s, path, fmt="jsonl")
+
+    loaded = load_session(path)
+    assert loaded.decision_being_informed == _DECISION
+
+
+def test_decision_round_trips_through_json(tmp_path):
+    """Full-JSON format also carries the decision so format choice is lossless."""
+    s = Session(decision_being_informed=_DECISION)
+    s.push_message(_text_msg("user", "q"))
+    path = tmp_path / "rt.json"
+    save_session(s, path, fmt="json")
+
+    loaded = load_session(path)
+    assert loaded.decision_being_informed == _DECISION
+
+
+def test_legacy_jsonl_without_stamp_still_loads():
+    """Older transcripts (pre-AC-7) parse cleanly with decision = None."""
+    legacy = (
+        '{"type":"session_meta","session_id":"x","created_at":"t","updated_at":"t"}\n'
+        '{"type":"message","role":"user","content":[{"type":"text","text":"hi"}]}\n'
+    )
+    s = Session.from_jsonl(legacy)
+    assert s.session_id == "x"
+    assert s.decision_being_informed is None
+
+
+def test_decision_with_newline_is_rejected_at_persistence_boundary():
+    """Persistence refuses to stamp a value that would break JSONL framing.
+
+    A newline in the field would split a single record across multiple lines
+    and silently corrupt every downstream reader. The validator (AC-2) is the
+    contract authority, but persistence must still be self-protective at its
+    boundary so a misuse can't produce malformed transcripts.
+    """
+    with pytest.raises(ValueError, match="newline"):
+        Session(decision_being_informed="bad\nvalue").to_jsonl()


### PR DESCRIPTION
## Summary

Adds `Session.decision_being_informed` and stamps every row produced by `Session.to_jsonl()` and `append_message()` so panel-run transcripts are self-describing on a per-row basis (AC-7). The loader pulls the stamp from the canonical `session_meta` header and tolerates legacy unstamped rows. Persistence guards its own boundary by rejecting stamps that contain newline characters - the v1.0.0 contract validator (AC-2) remains the upstream authority for shape rules, but a misuse here must not silently corrupt downstream readers.

## Changes

- `src/synth_panel/persistence.py`: adds `Session.decision_being_informed` field; `to_dict`/`from_dict` round-trip; `to_jsonl()` stamps `session_meta`, `message`, and `compaction` rows via `_stamp` helper; `from_jsonl()` strips the stamp before delegating to `ConversationMessage`/`CompactionMeta` so legacy and stamped rows produce identical objects, and trusts the header as canonical when middle rows disagree; `append_message` gains a keyword-only `decision_being_informed` for live-streamed transcripts; new `_validated_decision_stamp` rejects non-string and newline-containing values.

## Test plan

- `tests/persistence/__init__.py`: new test package marker.
- `tests/persistence/test_transcript_stamp.py`: 7 cases including the named AC test `test_every_row_carries_decision` (exercises all three row types); covers `append_message` stamping, omission (not nulling) when no decision is set, JSONL and JSON round-tripping, legacy unstamped JSONL parsing with `decision=None`, and persistence-boundary rejection of newline-containing values.

## References

- Spec: build-plan.md (sp-v1-0-0-contract)
- Bead: sy-6i2

Closes #409
