### PR TITLE
feat: add Content-Signal directive to robots.txt (sy-7gl)

### DIFF
--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Content-Signal: ai-train=no, search=yes, ai-input=no
 
 Sitemap: https://synthpanel.dev/sitemap.xml


### PR DESCRIPTION
## Summary

Adds the `Content-Signal` directive to `site/robots.txt` per the [contentsignals.org spec](https://contentsignals.org/) and the [content-signals SKILL](https://isitagentready.com/.well-known/agent-skills/content-signals/SKILL.md) (AR-3). Declares opt-out of AI training and AI retrieval input while permitting search indexing.

## Changes

- `site/robots.txt`: adds `Content-Signal: ai-train=no, search=yes, ai-input=no` between the existing `User-agent: *` / `Allow: /` block and the `Sitemap:` line.

## Test plan

- No new tests were added in this PR - the change is a single-line static-file directive served by Cloudflare Pages. Verification is operational (curl https://synthpanel.dev/robots.txt after deploy).

## References

- Spec: build-plan.md (sp-v1-0-0-contract)
- Bead: sy-7gl

Closes #414
