### PR TITLE
docs: record AR-5 OAuth/OIDC discovery as N/A (sy-iaf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 Work in progress for the next release after v1.0.0 lands.
 
+### Documentation
+
+- `docs/oauth-discovery.md` — records the AR-5 (sy-iaf) determination that
+  OAuth/OIDC discovery metadata is not applicable to SynthPanel: the CLI is
+  local, the MCP server is stdio, and synthpanel.dev is a static site, so no
+  protected API exists for `/.well-known/openid-configuration` or
+  `/.well-known/oauth-authorization-server` to describe.
+
 ## [1.0.0] - TBD
 
 The frozen MCP contract release. The schema at

--- a/docs/oauth-discovery.md
+++ b/docs/oauth-discovery.md
@@ -1,0 +1,52 @@
+# OAuth / OIDC Discovery — Not Applicable
+
+**Status:** N/A — SynthPanel publishes no `/.well-known/openid-configuration`
+or `/.well-known/oauth-authorization-server` document.
+
+**Bead:** sy-iaf (GH#416, AR-5)
+
+**Skill referenced by the request:**
+[oauth-discovery SKILL.md](https://isitagentready.com/.well-known/agent-skills/oauth-discovery/SKILL.md)
+
+## Why
+
+The agent-ready intake task for AR-5 is conditional:
+
+> **If protected APIs exist**, publish `/.well-known/openid-configuration`
+> (OIDC) or `/.well-known/oauth-authorization-server` (OAuth 2.0) with
+> `issuer`, `authorization_endpoint`, `token_endpoint`, `jwks_uri`,
+> `grant_types_supported`.
+
+SynthPanel has no protected APIs to advertise. Each surface is unauthenticated
+or out of scope for OAuth discovery:
+
+| Surface | Transport | Auth model |
+|---|---|---|
+| `synthpanel` CLI | local process | none — runs on the user's machine |
+| `synthpanel mcp-serve` | stdio (per Model Context Protocol) | none — bound to the spawning client |
+| [`synthpanel.dev`](https://synthpanel.dev) | static site (Cloudflare Pages) | none — public docs only |
+
+Provider credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`,
+`GOOGLE_API_KEY` / `GEMINI_API_KEY`) are user-supplied and travel directly
+from the local CLI to the upstream provider; SynthPanel itself never brokers
+an OAuth flow.
+
+## When this should be revisited
+
+Re-open this if any of the following ship:
+
+- A hosted SynthPanel API (HTTP) requiring per-user authentication.
+- An MCP transport other than stdio (e.g. HTTP/SSE) that fronts a
+  multi-tenant deployment.
+- A first-party identity provider issuing tokens for SynthPanel resources.
+
+In those cases the discovery document(s) above become required and AR-5
+graduates from N/A to a build task.
+
+## Related
+
+- AR-1 — Link response headers (sy-7r1)
+- AR-3 — Content-Signal in robots.txt (sy-7gl, merged)
+- AR-4 — `/.well-known/api-catalog` (sy-czo)
+- AR-6 — OAuth Protected Resource Metadata, RFC 9728 (sy-4nf) — also blocked
+  on the "protected resource exists" precondition.


### PR DESCRIPTION
## Summary

Records AR-5 (OAuth/OIDC discovery metadata) as **Not Applicable** for SynthPanel. The intake task is conditional on "if protected APIs exist", and SynthPanel exposes none: the CLI runs locally, the MCP server uses stdio transport, and synthpanel.dev is a static documentation site. There is no issuer, no authorization endpoint, and no token endpoint to advertise, so neither `/.well-known/openid-configuration` nor `/.well-known/oauth-authorization-server` would have meaningful contents. Rather than ship an empty or fabricated document, this PR captures the determination, rationale, and revisit conditions in-repo so future contributors can find it.

## Changes

- `docs/oauth-discovery.md`: new doc capturing the N/A determination, the surface inventory (CLI, stdio MCP, static site), and explicit "when to revisit" triggers (e.g. introducing a hosted protected API).
- `CHANGELOG.md`: entry under Unreleased > Documentation linking to the new doc.

## Test plan

No automated tests added; this is a documentation-only change recording an architectural decision, verified by inspection. AR-6 (sy-4nf) covers the related `oauth-protected-resource` advertisement that *is* applicable.

## References

- Spec: build-plan.md (sp-v1-0-0-contract) / agentready_feedback.md
- SKILL: https://isitagentready.com/.well-known/agent-skills/oauth-discovery/SKILL.md
- Bead: sy-iaf

Closes #416
