### PR TITLE
feat(site): publish Agent Skills Discovery index (sy-uh1)

### DIFF
--- a/scripts/render_agent_skills.py
+++ b/scripts/render_agent_skills.py
@@ -1,0 +1,98 @@
+"""Render the Agent Skills Discovery index for synthpanel.dev.
+
+Publishes ``/.well-known/agent-skills/index.json`` per the Agent Skills
+Discovery RFC v0.2.0 (https://agentskills.io/), plus a mirror of each
+skill's ``SKILL.md`` under ``/.well-known/agent-skills/<name>/SKILL.md``
+so the digests in the index match what the site actually serves.
+
+Single source of truth is the top-level ``skills/`` directory. Run
+``python scripts/render_agent_skills.py`` to regenerate the published
+files; ``tests/test_agent_skills_index.py`` enforces no drift.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / "skills"
+PUBLISH_DIR = REPO_ROOT / "site" / ".well-known" / "agent-skills"
+INDEX_PATH = PUBLISH_DIR / "index.json"
+
+SCHEMA_URL = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
+
+# Stable publication order — independent of filesystem traversal so the
+# committed index.json is deterministic across platforms.
+SKILL_ORDER = (
+    "focus-group",
+    "name-test",
+    "concept-test",
+    "survey-prescreen",
+    "pricing-probe",
+)
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def _parse_description(skill_md: str, *, source: Path) -> str:
+    match = _FRONTMATTER_RE.match(skill_md)
+    if not match:
+        raise RuntimeError(f"{source}: missing YAML frontmatter")
+    for line in match.group(1).splitlines():
+        if line.startswith("description:"):
+            return line[len("description:") :].strip()
+    raise RuntimeError(f"{source}: frontmatter has no 'description' field")
+
+
+def _sha256(data: bytes) -> str:
+    return "sha256:" + hashlib.sha256(data).hexdigest()
+
+
+def render(*, write: bool = False) -> str:
+    """Build the index. When ``write`` is true, also materialise the
+    mirrored SKILL.md files and the index.json under ``site/``."""
+    skills = []
+    for name in SKILL_ORDER:
+        source = SKILLS_DIR / name / "SKILL.md"
+        body = source.read_bytes()
+        description = _parse_description(body.decode("utf-8"), source=source)
+        url = f"/.well-known/agent-skills/{name}/SKILL.md"
+
+        if write:
+            mirror = PUBLISH_DIR / name / "SKILL.md"
+            mirror.parent.mkdir(parents=True, exist_ok=True)
+            mirror.write_bytes(body)
+
+        skills.append(
+            {
+                "name": name,
+                "type": "skill-md",
+                "description": description,
+                "url": url,
+                "digest": _sha256(body),
+            }
+        )
+
+    index = {"$schema": SCHEMA_URL, "skills": skills}
+    rendered = json.dumps(index, indent=2, ensure_ascii=False) + "\n"
+
+    if write:
+        PUBLISH_DIR.mkdir(parents=True, exist_ok=True)
+        INDEX_PATH.write_text(rendered)
+
+    return rendered
+
+
+def main() -> int:
+    rendered = render(write=True)
+    rel = INDEX_PATH.relative_to(REPO_ROOT)
+    print(f"Rendered {rel} ({len(rendered)} bytes, {len(SKILL_ORDER)} skills)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/.well-known/agent-skills/concept-test/SKILL.md
+++ b/site/.well-known/agent-skills/concept-test/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: concept-test
+description: Validate a product concept or value proposition with a target audience — surfaces whether the problem is real, whether the solution lands, and what would prevent adoption.
+allowed-tools:
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__save_persona_pack
+  - mcp__synth_panel__list_instrument_packs
+---
+
+You are running a **concept test** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user pressure-test an early-stage product concept, value prop, or feature idea against a specific target audience before they build or ship it. The goal is to surface whether the problem is real and whether the proposed solution actually addresses it — not to validate a decision that's already been made.
+
+1. **Clarify the concept and the audience.**
+2. **Design concept-oriented personas** drawn from (or biased toward) the target audience.
+3. **Run the panel** with questions that probe pain, fit, willingness-to-adopt, and objections.
+4. **Synthesize** — is the problem real, does the concept resonate, and what blocks adoption?
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_panel`** — Primary tool. Run a multi-question panel with target-audience personas.
+- **`mcp__synth_panel__run_quick_poll`** — Use for a single "would you try this?" temperature check.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Reuse saved target-audience packs.
+- **`mcp__synth_panel__save_persona_pack`** — Save a new audience pack if the user is likely to re-test.
+- **`mcp__synth_panel__list_instrument_packs`** — Check for bundled packs that fit (e.g. `product-feedback`, `market-research`).
+
+## Workflow
+
+### Step 1: Frame the Concept
+
+Ask the user for:
+- A 2-3 sentence description of the concept (what it is, who it's for, what problem it solves).
+- The target audience (role, demographic, or psychographic).
+- What decision this test is meant to inform ("should we keep exploring?" vs. "which direction?").
+
+### Step 2: Build or Load Personas
+
+- 4-8 personas, biased toward the target audience but with **at least one skeptic** and **at least one adjacent non-target** to stress-test the boundaries.
+- Each persona should have a plausible reason the problem may or may not apply to them.
+
+### Step 3: Design the Instrument
+
+Include questions in this order:
+1. **Problem probe** — "Does this describe something you've actually experienced?" (don't lead with the solution)
+2. **Concept reveal** — present the concept, ask for gut reaction.
+3. **Fit** — "Who do you know this would be for?" (reveals whether they see themselves in it)
+4. **Adoption blockers** — "What would stop you from trying this?"
+5. **Willingness** — rough price sensitivity or alternative-they'd-pick.
+
+Add 1-2 follow-ups on the concept reveal for depth.
+
+### Step 4: Run and Synthesize
+
+After results return, report:
+- **Problem validity** — did panelists actually experience the problem, or did you have to convince them?
+- **Concept resonance** — who lit up, who shrugged, who pushed back.
+- **Top 2-3 adoption blockers** across panelists.
+- **Surprising insights** — anything you didn't expect.
+- **Recommended next step** — iterate the concept, test with real users, or drop it.
+- **Total cost**.
+
+## Guidelines
+
+- **Don't sell the concept to the panel.** Describe it neutrally. Leading questions produce leading answers.
+- **Respect dissent.** If 2 of 6 panelists hate it, that's signal — don't average it away.
+- **Distinguish "I'd use this" from "This is a good idea."** Only the first predicts adoption.
+- **Concept tests are exploration, not validation.** Say so when the user asks "should we build this?" — the honest answer is "this is one data point; go talk to real users."

--- a/site/.well-known/agent-skills/focus-group/SKILL.md
+++ b/site/.well-known/agent-skills/focus-group/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: focus-group
+description: Run a synthetic focus group — define personas, craft questions, and collect structured qualitative feedback from AI panelists.
+allowed-tools:
+  - mcp__synth_panel__prompt
+  - mcp__synth_panel__panel_run
+  - mcp__synth_panel__list_personas
+  - mcp__synth_panel__list_instruments
+---
+
+You are orchestrating a **synthetic focus group** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user design and run synthetic focus groups — structured qualitative research using AI-powered personas. You handle the full workflow:
+
+1. **Understand the research question** — What does the user want to learn?
+2. **Define personas** — Create a personas YAML file with realistic, diverse participants.
+3. **Design the instrument** — Create a survey YAML with targeted questions and follow-ups.
+4. **Run the panel** — Execute the focus group via MCP tools.
+5. **Synthesize results** — Summarize findings, identify patterns, and highlight insights.
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__prompt`** — Run a single prompt against one persona (quick test).
+- **`mcp__synth_panel__panel_run`** — Run a full panel with multiple personas and a survey instrument.
+- **`mcp__synth_panel__list_personas`** — List available persona definition files.
+- **`mcp__synth_panel__list_instruments`** — List available instrument/survey files.
+
+## Workflow
+
+### Step 1: Clarify the Research Goal
+
+Ask the user what they want to test. Examples:
+- "What do people think of the name 'Traitprint' for a career app?"
+- "How would different demographics react to this pricing page?"
+- "Pre-screen this survey before we send it to real participants."
+
+### Step 2: Create Personas
+
+Write a `personas.yaml` file with 3-6 diverse personas. Each persona needs:
+- `name`, `age`, `occupation`
+- `background` — 2-3 sentences of life context
+- `personality_traits` — 3-5 traits that shape their perspective
+
+Ensure demographic and psychographic diversity relevant to the research question.
+
+### Step 3: Design the Instrument
+
+Write a `survey.yaml` file with 2-5 focused questions. Each question can have:
+- `text` — The question itself
+- `response_schema` — Usually `{type: text}`
+- `follow_ups` — Probing questions for depth
+
+### Step 4: Run the Panel
+
+Use `mcp__synth_panel__panel_run` with the personas and instrument files.
+
+### Step 5: Synthesize
+
+After results return:
+- Summarize each persona's perspective in 1-2 sentences
+- Identify consensus vs. divergence across personas
+- Flag surprising or non-obvious insights
+- Recommend next steps (iterate instrument, test with real users, etc.)
+
+## Guidelines
+
+- **Don't over-engineer personas** — 3-5 well-chosen personas beat 10 generic ones.
+- **Ask pointed questions** — Vague questions get vague answers.
+- **Use follow-ups** — They surface depth that initial responses miss.
+- **Report costs** — Always mention the total cost of the panel run.
+- **Be honest about limitations** — Synthetic panels are for exploration, not validation.

--- a/site/.well-known/agent-skills/index.json
+++ b/site/.well-known/agent-skills/index.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "skills": [
+    {
+      "name": "focus-group",
+      "type": "skill-md",
+      "description": "Run a synthetic focus group — define personas, craft questions, and collect structured qualitative feedback from AI panelists.",
+      "url": "/.well-known/agent-skills/focus-group/SKILL.md",
+      "digest": "sha256:1ee1f2fd06d33f65096c2702fc1aab0821f13a5a8e0df8429fddaf18959c7e45"
+    },
+    {
+      "name": "name-test",
+      "type": "skill-md",
+      "description": "Quickly test 1-3 candidate product or feature names with a synthetic panel — surfaces confusion, pronounceability, and memorability concerns in one pass.",
+      "url": "/.well-known/agent-skills/name-test/SKILL.md",
+      "digest": "sha256:71ad5806fe3dc051b5b4d45d4a729a62b15cb63ee4872b824fedc200816c5c44"
+    },
+    {
+      "name": "concept-test",
+      "type": "skill-md",
+      "description": "Validate a product concept or value proposition with a target audience — surfaces whether the problem is real, whether the solution lands, and what would prevent adoption.",
+      "url": "/.well-known/agent-skills/concept-test/SKILL.md",
+      "digest": "sha256:7dc12d79243d92fda1a76c88ec76450b3b6f5008988be3092887df544500d7cf"
+    },
+    {
+      "name": "survey-prescreen",
+      "type": "skill-md",
+      "description": "Pre-screen a survey instrument with synthetic respondents before sending to real participants — catches ambiguous wording, leading questions, and dead-end branches cheaply.",
+      "url": "/.well-known/agent-skills/survey-prescreen/SKILL.md",
+      "digest": "sha256:a3c083d20b7af7fdb2071680b1124904775fdba8a06b3e8da1d80a2cd417abe8"
+    },
+    {
+      "name": "pricing-probe",
+      "type": "skill-md",
+      "description": "Probe pricing sensitivity with a target audience using the bundled 'pricing-discovery' branching instrument — surfaces pain, price anchoring, or competitor alternatives based on what the panel volunteers first.",
+      "url": "/.well-known/agent-skills/pricing-probe/SKILL.md",
+      "digest": "sha256:6f9b34f9b1907cc9bc69673a12746bc84dc376bc085c2a337a1b36f3dda37433"
+    }
+  ]
+}

--- a/site/.well-known/agent-skills/name-test/SKILL.md
+++ b/site/.well-known/agent-skills/name-test/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: name-test
+description: Quickly test 1-3 candidate product or feature names with a synthetic panel — surfaces confusion, pronounceability, and memorability concerns in one pass.
+allowed-tools:
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__list_instrument_packs
+---
+
+You are running a **quick name test** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user decide between candidate names for a product, feature, or brand. The workflow is deliberately short — a name test should take minutes, not hours.
+
+1. **Collect candidates** — 1 to 3 names, plus a one-line description of what the thing actually is.
+2. **Pick a lens** — quick single-question poll, or the branching `name-test` instrument pack for deeper probing.
+3. **Run the panel** — small, diverse personas; keep it cheap.
+4. **Report the verdict** — winner, loser, and the specific concern that tipped each (confusion, pronunciation, memorability).
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_quick_poll`** — Single-question poll across personas (fastest, cheapest).
+- **`mcp__synth_panel__run_panel`** — Full panel run. Pass `instrument_pack: "name-test"` to use the bundled branching instrument that probes meaning, pronounceability, or memorability based on first reactions.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Reuse saved personas instead of inventing new ones.
+- **`mcp__synth_panel__list_instrument_packs`** — Confirm the `name-test` pack is available.
+
+## Workflow
+
+### Step 1: Gather Inputs
+
+Ask for:
+- The candidate names (comma-separated).
+- A one-sentence description of what the product/feature does.
+- Target audience (so personas are relevant).
+
+### Step 2: Choose Depth
+
+- **Quick gut check** → `run_quick_poll` with a question like *"Which of these names best fits a {description}: {candidates}? Why?"*
+- **Full branching evaluation** → `run_panel` with `instrument_pack: "name-test"` and `instrument_vars: { candidates: "<names>" }`. The instrument branches into meaning-probe, pronounce-probe, or memorability-probe based on what surfaces first.
+
+### Step 3: Run
+
+Default to 4-6 personas. If the user hasn't supplied them, generate a small diverse set tuned to the target audience, or pick a saved pack via `get_persona_pack`.
+
+### Step 4: Report
+
+Produce a tight summary:
+- **Winner** and why (quote 1-2 panelists).
+- **Loser** and the specific failure mode (misread, hard to say, forgettable).
+- **Risks for the winner** — concerns that still showed up even for the preferred name.
+- **Total cost** of the run.
+
+## Guidelines
+
+- Keep it small — 4-6 personas is plenty for a name test.
+- Don't over-interpret a single panel — flag when reactions were genuinely mixed rather than forcing a winner.
+- If all names scored poorly, say so and suggest the user brainstorm a new set instead of picking the least-bad.
+- Name tests are exploratory signal, not validation. Say this when the user asks "should we ship this?"

--- a/site/.well-known/agent-skills/pricing-probe/SKILL.md
+++ b/site/.well-known/agent-skills/pricing-probe/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pricing-probe
+description: Probe pricing sensitivity with a target audience using the bundled 'pricing-discovery' branching instrument — surfaces pain, price anchoring, or competitor alternatives based on what the panel volunteers first.
+allowed-tools:
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__get_instrument_pack
+  - mcp__synth_panel__list_instrument_packs
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__run_quick_poll
+---
+
+You are running a **pricing sensitivity probe** using the synthpanel MCP tools and the bundled `pricing-discovery` v3 branching instrument.
+
+## What You Do
+
+You help the user understand how a target audience reasons about price for a product or service. The `pricing-discovery` instrument is adaptive: it lets each panelist's discovery round drive the probe path — into pain, pricing, or alternatives — so you get signal on whichever dimension actually matters to them.
+
+1. **Frame the problem** — what are we pricing, for whom, and against what alternatives?
+2. **Assemble a target-audience panel.**
+3. **Run the `pricing-discovery` pack** via `run_panel` with `instrument_pack: "pricing-discovery"`.
+4. **Interpret the branches** — panelists who went down `probe_pain` are telling you something different than those who went down `probe_pricing` or `probe_alternatives`.
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_panel`** — Primary tool. Pass `instrument_pack: "pricing-discovery"` plus `instrument_vars: { problem: "<the problem being solved>" }`.
+- **`mcp__synth_panel__get_instrument_pack`** / **`mcp__synth_panel__list_instrument_packs`** — Inspect the bundled pricing-discovery pack.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Load a saved target-audience pack.
+- **`mcp__synth_panel__run_quick_poll`** — Use for a narrow follow-up question after the main run (e.g. "Would $X/month feel fair?").
+
+## Workflow
+
+### Step 1: Clarify the Pricing Context
+
+Ask:
+- **What problem does the product solve?** (The `pricing-discovery` instrument substitutes this into its opening question.)
+- **Who is it for?** (shapes personas)
+- **Are there competitors or alternatives?** (panelists will volunteer these if real)
+- **What price range is the user considering?** (optional — don't reveal it to the panel until after discovery)
+
+### Step 2: Build or Load the Panel
+
+- 5-8 personas matching the target audience.
+- Include **at least one price-sensitive** persona and **one value-driven** persona — pricing intuition varies more across that axis than demographics.
+- Pull saved packs via `get_persona_pack` when re-running against the same audience.
+
+### Step 3: Run the Instrument
+
+Call `run_panel` with:
+- `instrument_pack: "pricing-discovery"`
+- `instrument_vars: { problem: "<problem statement>" }`
+- the persona set
+
+Note: the pack branches via theme tags (`pain`, `price`, `alternative`). Route outcomes live in each panelist's `path` in the result — inspect this; it's the primary signal.
+
+### Step 4: Interpret the Branches
+
+Report, per panelist:
+- **Which branch did they take?** (pain / price / alternatives / else)
+- That branch *is* the insight: a panelist who routed to `probe_alternatives` is telling you price is benchmarked against an incumbent, not derived from value.
+
+Then overall:
+- **Branch distribution** across the panel — if most went to `probe_alternatives`, your pricing problem is really a positioning problem.
+- **Price anchors** that surfaced organically (vs. ones you asked about).
+- **Willingness-to-pay range** — cluster the numbers panelists volunteered.
+- **Deal-breakers** — what would stop them from paying anything.
+- **Suggested price test** — one specific follow-up (e.g. a `run_quick_poll` at a target price point).
+- **Total cost**.
+
+## Guidelines
+
+- **Don't anchor the panel with your target price** until after discovery — price sensitivity is contaminated by any number you drop first.
+- **Trust the branches.** The router is how this instrument earns its keep; interpreting which branch fired matters more than individual answers.
+- **Synthetic WTP is directional, not predictive.** Real people are stingier than personas. Discount synthetic price points before fielding.
+- **Watch for `else` fall-through.** If many panelists bypass the routed branches, the synthesizer isn't emitting the canonical theme tags — say so and suggest re-running or editing the instrument's theme-tag guidance.

--- a/site/.well-known/agent-skills/survey-prescreen/SKILL.md
+++ b/site/.well-known/agent-skills/survey-prescreen/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: survey-prescreen
+description: Pre-screen a survey instrument with synthetic respondents before sending to real participants — catches ambiguous wording, leading questions, and dead-end branches cheaply.
+allowed-tools:
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__get_instrument_pack
+  - mcp__synth_panel__list_instrument_packs
+  - mcp__synth_panel__save_instrument_pack
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+---
+
+You are pre-screening a **user-authored survey instrument** using the synthpanel MCP tools.
+
+## What You Do
+
+You help the user catch problems in a survey before they spend real budget fielding it. Synthetic respondents are cheap — use them to find ambiguous wording, leading questions, unanswerable items, and dead-end branches *before* real participants see the instrument.
+
+1. **Load the user's instrument** (YAML file they provide, or `save_instrument_pack` first if it's inline).
+2. **Assemble stress-test personas** — a mix that should reveal wording problems across demographics.
+3. **Run the instrument** as a full panel.
+4. **Critique** — report specific failure modes per question, not just a thumbs up/down.
+
+## Available MCP Tools
+
+- **`mcp__synth_panel__run_panel`** — Run the user's instrument against the stress-test personas. Pass either `instrument` (inline YAML dict) or `instrument_pack` (name, after saving).
+- **`mcp__synth_panel__get_instrument_pack`** / **`mcp__synth_panel__list_instrument_packs`** — Load an installed instrument for review.
+- **`mcp__synth_panel__save_instrument_pack`** — Save the user's instrument temporarily if they'd rather reference it by name.
+- **`mcp__synth_panel__list_persona_packs`** / **`mcp__synth_panel__get_persona_pack`** — Load a realistic audience pack for the survey's intended population.
+
+## Workflow
+
+### Step 1: Load the Instrument
+
+Read the user's YAML. Before running, do a quick structural review:
+- Are questions clear and scoped to one thing each?
+- Any double-barreled questions ("How satisfied and how often do you...")?
+- Any leading wording ("How much do you *love*...")?
+- For v3 instruments: do `route_when` branches cover plausible respondent paths, or do cases silently fall to `else`?
+- Are follow-ups specific enough to produce depth?
+
+Call out structural issues first — sometimes the instrument doesn't need a panel run at all, just a rewrite.
+
+### Step 2: Assemble Stress-Test Personas
+
+5-8 personas that specifically stress the instrument:
+- **Representative of the intended audience** (2-3).
+- **Adjacent-but-different** — slightly outside the target, to reveal questions that assume audience knowledge (1-2).
+- **A literal responder** who answers exactly what's asked (catches ambiguity).
+- **A confused/distracted responder** (catches comprehension failures).
+- **An opinionated outlier** (catches leading questions — they'll push back).
+
+### Step 3: Run the Panel
+
+Use `run_panel`. If the instrument is v3 branching, note which rounds each persona was routed into — `path` in the result tells you whether branches fired or fell through to `else`.
+
+### Step 4: Critique (Report Format)
+
+For each question, report:
+- **Did everyone understand it?** Quote a confused answer verbatim if so.
+- **Did answers cluster or scatter?** Scattering often means the question is too open or ambiguous.
+- **Were follow-ups productive** or did they produce filler?
+
+Then overall:
+- **Top 3 problems** with the instrument, in priority order.
+- **Specific rewrites** for the worst offenders.
+- **Branch coverage** (v3 only) — which `route_when` clauses never fired, and whether that's a coverage gap or just this persona sample.
+- **Go/no-go** — is this instrument ready to field, or does it need another pass?
+- **Total cost**.
+
+## Guidelines
+
+- **Diagnose, don't just score.** "Question 3 is unclear" is useless; "Question 3 was interpreted three different ways; here are the three readings" is actionable.
+- **Preserve the user's intent.** When suggesting rewrites, match what they were trying to ask — don't silently redesign the survey.
+- **A prescreen isn't a pilot.** Synthetic respondents won't catch fatigue, incentive gaming, or platform-specific dropout. Say so.
+- **If the instrument is broken at the structural level, stop and say so** before burning tokens on a panel run.

--- a/tests/test_agent_skills_index.py
+++ b/tests/test_agent_skills_index.py
@@ -1,0 +1,72 @@
+"""Verify the published Agent Skills Discovery index stays in sync with skills/.
+
+The published artifacts at ``site/.well-known/agent-skills/`` are derived
+from the canonical ``skills/`` directory by ``scripts/render_agent_skills.py``.
+If a skill's SKILL.md changes without a re-render, the digest in
+``index.json`` no longer matches the served body — agents that verify the
+digest reject the skill. These tests catch that drift in CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_DIR = REPO_ROOT / "site" / ".well-known" / "agent-skills"
+INDEX_PATH = PUBLISH_DIR / "index.json"
+
+
+def _load_renderer():
+    spec = importlib.util.spec_from_file_location(
+        "render_agent_skills", REPO_ROOT / "scripts" / "render_agent_skills.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["render_agent_skills"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_committed_index_matches_renderer() -> None:
+    rendered = _load_renderer().render()
+    committed = INDEX_PATH.read_text()
+    assert rendered == committed, (
+        "site/.well-known/agent-skills/index.json is stale. Run: python scripts/render_agent_skills.py"
+    )
+
+
+def test_index_schema_shape() -> None:
+    index = json.loads(INDEX_PATH.read_text())
+    assert index["$schema"].startswith("https://schemas.agentskills.io/discovery/")
+    assert isinstance(index["skills"], list) and index["skills"], "skills must be a non-empty list"
+    digest_re = re.compile(r"^sha256:[0-9a-f]{64}$")
+    for entry in index["skills"]:
+        assert set(entry) >= {"name", "type", "description", "url", "digest"}
+        assert entry["type"] == "skill-md"
+        assert entry["url"].startswith("/.well-known/agent-skills/")
+        assert entry["url"].endswith("/SKILL.md")
+        assert digest_re.match(entry["digest"]), f"bad digest format: {entry['digest']}"
+
+
+def test_each_digest_matches_served_body() -> None:
+    index = json.loads(INDEX_PATH.read_text())
+    for entry in index["skills"]:
+        served = (REPO_ROOT / "site" / entry["url"].lstrip("/")).read_bytes()
+        actual = "sha256:" + hashlib.sha256(served).hexdigest()
+        assert actual == entry["digest"], f"digest for {entry['name']} does not match served body at {entry['url']}"
+
+
+def test_mirrored_skill_md_matches_canonical_source() -> None:
+    """The mirror under site/.well-known is byte-identical to skills/<name>/SKILL.md."""
+    index = json.loads(INDEX_PATH.read_text())
+    for entry in index["skills"]:
+        canonical = (REPO_ROOT / "skills" / entry["name"] / "SKILL.md").read_bytes()
+        mirrored = (REPO_ROOT / "site" / entry["url"].lstrip("/")).read_bytes()
+        assert canonical == mirrored, (
+            f"skills/{entry['name']}/SKILL.md drifted from its site/ mirror. Run: python scripts/render_agent_skills.py"
+        )


### PR DESCRIPTION
## Summary

Implements AR-8 by publishing `/.well-known/agent-skills/index.json` per Agent Skills Discovery RFC v0.2.0. The index advertises the five bundled skills — `focus-group`, `name-test`, `concept-test`, `survey-prescreen`, `pricing-probe` — each with `name`, `type`, `description`, `url`, and a `sha256` digest, so AI agents can discover and integrity-check SynthPanel's skill surface via the well-known URL. The published artifacts are generated from the canonical `skills/` directory; running the renderer copies each `SKILL.md` into its served location and writes the index.

## Changes

- `scripts/render_agent_skills.py`: new generator that walks `skills/`, mirrors each `SKILL.md` under `site/.well-known/agent-skills/<name>/`, and writes `index.json` with sha256 digests.
- `site/.well-known/agent-skills/index.json`: the published discovery document.
- `site/.well-known/agent-skills/{focus-group,name-test,concept-test,survey-prescreen,pricing-probe}/SKILL.md`: rendered mirrors of the canonical skill docs.

## Test plan

- `tests/test_agent_skills_index.py`: re-renders into a tempdir on every CI run and compares against the committed artifacts (drift guard), verifies digest format, and asserts byte-equivalence between source `skills/**/SKILL.md` and the served mirror.

## References

- Spec: build-plan.md (sp-v1-0-0-contract) / agentready_feedback.md
- Agent Skills Discovery RFC v0.2.0 (https://agentskills.io/); SKILL: https://isitagentready.com/.well-known/agent-skills/agent-skills/SKILL.md
- Bead: sy-uh1

Closes #419
