### PR TITLE
feat: AR-2 Markdown for Agents content negotiation (sy-ifw)

### DIFF
--- a/docs/cloudflare-pages-setup.md
+++ b/docs/cloudflare-pages-setup.md
@@ -6,11 +6,15 @@ Operational runbook for the static landing site served at <https://synthpanel.de
 
 - Files live in [`site/`](../site/) at the repo root.
 - Pure static HTML; Tailwind is loaded from `cdn.tailwindcss.com`. **No build
-  step is required.**
+  step is required for HTML.**
 - `site/_headers` ships the security header set (CSP, HSTS, frame deny, etc.)
   via the `/*` rule, plus RFC 8288 `Link` headers for agent discovery
   (`api-catalog`, `service-doc`) on the homepage `/` rule. Cloudflare Pages
   applies these automatically.
+- `site/_worker.js` is a Pages **Advanced Mode** worker that implements
+  `Accept: text/markdown` content negotiation (see "Markdown for Agents"
+  below). Markdown renditions are pre-built from each HTML page by
+  `scripts/render_site_markdown.py` and committed alongside the source.
 
 ## Cloudflare Pages project (one-time setup)
 
@@ -62,6 +66,58 @@ When you change `site/index.html`:
   (sp-p3g) made the cross-link an explicit acceptance criterion.
 - If you bump Tailwind to the production build, drop the
   `cdn.tailwindcss.com` entry from `site/_headers` CSP `script-src`.
+
+When you change **any** `site/**/*.html`:
+
+- Re-run `python scripts/render_site_markdown.py` to regenerate the
+  agent-facing `.md` rendition. CI's `test_committed_markdown_matches_fresh_render`
+  fails the build if you forget.
+
+## Markdown for Agents (content negotiation)
+
+The site honors `Accept: text/markdown` per Cloudflare's
+[Markdown for Agents reference](https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/)
+and the
+[`agent-skills/markdown-negotiation`](https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md)
+skill. AI agents that prefer structured markdown over rendered HTML
+get a clean, token-efficient rendition; browsers continue to receive
+HTML untouched.
+
+**Verification:**
+
+```bash
+# HTML by default
+curl -sI https://synthpanel.dev/ | grep -i content-type
+#   content-type: text/html; charset=utf-8
+
+# Markdown when explicitly requested
+curl -sI -H 'Accept: text/markdown' https://synthpanel.dev/
+#   HTTP/2 200
+#   content-type: text/markdown; charset=utf-8
+#   vary: Accept
+#   x-markdown-tokens: 1827
+
+# 406 when no rendition exists for the path
+curl -sI -H 'Accept: text/markdown' https://synthpanel.dev/og-image.png
+#   HTTP/2 406
+```
+
+**Implementation:**
+
+- `site/_worker.js` is the Pages worker. It runs first for every
+  request, and only intercepts when the `Accept` header explicitly
+  prefers `text/markdown`. All other traffic falls through to static
+  asset serving (HTML, images, sitemap, robots.txt).
+- Markdown renditions live next to the HTML they mirror —
+  `site/index.html` ⇄ `site/index.md`,
+  `site/mcp/index.html` ⇄ `site/mcp/index.md`, etc.
+- The renditions are produced by `scripts/render_site_markdown.py`, a
+  stdlib-only Python script that walks `site/**/*.html` and emits a
+  structured markdown rendition (headings, lists, code blocks, tables,
+  links). The script is idempotent; rerun whenever HTML changes.
+- The `x-markdown-tokens` response header is an approximate token
+  count (chars / 4) for budgeting purposes; agents that need exact
+  numbers should run their own tokenizer over the body.
 
 ## Why a separate site (vs. README only)
 

--- a/scripts/render_site_markdown.py
+++ b/scripts/render_site_markdown.py
@@ -1,0 +1,562 @@
+"""Render markdown renditions of every ``site/**/*.html`` page.
+
+Used by the ``Accept: text/markdown`` content-negotiation worker
+(``site/_worker.js``) to serve agent-friendly markdown alongside the
+human-facing HTML. See ``docs/cloudflare-pages-setup.md`` for the
+deploy-side picture.
+
+Approach: walk the publish dir, parse each ``.html`` with the stdlib
+``html.parser`` HTMLParser, emit a structured markdown rendition next
+to the source file (``foo.html`` -> ``foo.md``). Only content inside
+``<main>`` is rendered — chrome elements (``<head>``, ``<script>``,
+``<style>``, ``<svg>``, ``<button>``, ``<nav>``, ``<footer>``,
+``aria-hidden`` decorations) are dropped on the floor.
+
+Run directly (``python scripts/render_site_markdown.py``) or import
+``render_all()`` from tests. Idempotent: rerun whenever site HTML
+changes.
+"""
+
+from __future__ import annotations
+
+import html.parser
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_ROOT = REPO_ROOT / "site"
+
+# Tags whose contents we drop on the floor entirely.
+SKIP_TAGS = frozenset(
+    {
+        "head",
+        "script",
+        "style",
+        "noscript",
+        "svg",
+        "path",
+        "button",
+        "form",
+        "input",
+        "select",
+        "textarea",
+        "footer",
+        "nav",
+        "meta",
+        "link",
+        "title",
+    }
+)
+
+# Block-level tags that introduce a paragraph break in the output.
+BLOCK_TAGS = frozenset(
+    {
+        "p",
+        "div",
+        "section",
+        "article",
+        "header",
+        "main",
+        "aside",
+        "blockquote",
+        "details",
+        "summary",
+        "figure",
+        "figcaption",
+    }
+)
+
+HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4", "h5", "h6"})
+
+LIST_TAGS = frozenset({"ul", "ol"})
+
+# Self-closing / void tags that ``handle_endtag`` will never see.
+VOID_TAGS = frozenset(
+    {
+        "area",
+        "base",
+        "br",
+        "col",
+        "embed",
+        "hr",
+        "img",
+        "input",
+        "keygen",
+        "link",
+        "meta",
+        "param",
+        "source",
+        "track",
+        "wbr",
+    }
+)
+
+# Tags that, when seen inside an inline-buffered ``<a>``, force the
+# anchor into "complex mode" — flush whatever inline label we have and
+# stop buffering.
+ANCHOR_BREAK_TAGS = HEADING_TAGS | BLOCK_TAGS | LIST_TAGS | {"li", "pre", "table"}
+
+
+def _attr(attrs: list[tuple[str, str | None]], name: str) -> str | None:
+    for k, v in attrs:
+        if k == name:
+            return v
+    return None
+
+
+class _Anchor:
+    """Buffered state for a single ``<a>`` element."""
+
+    __slots__ = ("buffer", "complex", "href", "label_emitted")
+
+    def __init__(self, href: str | None) -> None:
+        self.href: str | None = href
+        self.buffer: list[str] = []
+        # True once we've seen a block-level child and given up on
+        # rendering this anchor as a single inline link.
+        self.complex: bool = False
+        # True once we've emitted ``[text](href)`` somewhere — either
+        # via flush at first block child, or at </a> for inline anchors.
+        self.label_emitted: bool = False
+
+
+class _MarkdownEmitter(html.parser.HTMLParser):
+    """Convert one HTML document into structured markdown."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.out: list[str] = []
+        # Stack entries: (tag_name, hides_content_bool). Push on every
+        # starttag, pop on every endtag. ``skip_depth`` is the count of
+        # entries with ``hides=True`` currently on the stack.
+        self._tag_stack: list[tuple[str, bool]] = []
+        self.skip_depth = 0
+        self.in_main = False
+        self.main_depth = 0
+        self.in_pre = False
+        self.heading_level: int | None = None
+        self.heading_buffer: list[str] | None = None
+        # If a heading is opened immediately under an anchor whose
+        # buffer is empty, we attach the anchor href to the heading
+        # text. Tracked via this pending href.
+        self._pending_heading_href: str | None = None
+        self.anchor_stack: list[_Anchor] = []
+        self.table_stack: list[list[list[str]]] = []
+        self.row_buffer: list[str] | None = None
+        self.cell_buffer: list[str] | None = None
+        self._wrote_anything = False
+        self._list_depth_value = 0
+
+    # --- helpers ------------------------------------------------------
+
+    def _active_anchor(self) -> _Anchor | None:
+        return self.anchor_stack[-1] if self.anchor_stack else None
+
+    def _current_target(self) -> list[str] | None:
+        if self.cell_buffer is not None:
+            return self.cell_buffer
+        if self.heading_buffer is not None:
+            return self.heading_buffer
+        anchor = self._active_anchor()
+        if anchor is not None and not anchor.complex:
+            return anchor.buffer
+        return self.out
+
+    def _emit(self, text: str) -> None:
+        if not text or self.skip_depth:
+            return
+        target = self._current_target()
+        target.append(text)
+        if target is self.out:
+            self._wrote_anything = True
+
+    def _emit_break(self) -> None:
+        if self.skip_depth or not self._wrote_anything:
+            return
+        if self.cell_buffer is not None or self.heading_buffer is not None:
+            return
+        anchor = self._active_anchor()
+        if anchor is not None and not anchor.complex:
+            return
+        tail = "".join(self.out[-3:]) if self.out else ""
+        if tail.endswith("\n\n"):
+            return
+        if tail.endswith("\n"):
+            self.out.append("\n")
+        else:
+            self.out.append("\n\n")
+
+    @property
+    def _list_depth(self) -> int:
+        return self._list_depth_value
+
+    @_list_depth.setter
+    def _list_depth(self, value: int) -> None:
+        self._list_depth_value = value
+
+    def _list_prefix(self) -> str:
+        # Always use ``-`` for list items — the source HTML often
+        # renders the numeral itself via a styled span, so re-emitting
+        # ``1.`` here would duplicate the numbering.
+        return "  " * max(0, self._list_depth - 1) + "- "
+
+    def _flush_anchor_label(self) -> None:
+        """Promote the active anchor from inline to complex mode."""
+        anchor = self._active_anchor()
+        if anchor is None or anchor.complex:
+            return
+        label = _normalize_inline("".join(anchor.buffer))
+        if label:
+            if anchor.href:
+                self.out.append(f"[{label}]({anchor.href})")
+            else:
+                self.out.append(label)
+            self._wrote_anything = True
+            anchor.label_emitted = True
+        else:
+            # Buffer empty — the next heading absorbs the href instead.
+            if anchor.href and self._pending_heading_href is None:
+                self._pending_heading_href = anchor.href
+        anchor.complex = True
+
+    # --- HTMLParser hooks --------------------------------------------
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        is_main = tag == "main"
+        hidden = _attr(attrs, "aria-hidden") == "true"
+        is_skip_tag = tag in SKIP_TAGS
+
+        # ``<main>`` itself never hides content — it is the gate that
+        # enables rendering. Aria-hidden on <main> is treated as a
+        # malformed source and ignored.
+        if is_main:
+            if tag not in VOID_TAGS:
+                self._tag_stack.append((tag, False))
+            self.in_main = True
+            self.main_depth = self.main_depth + 1
+            return
+
+        is_void = tag in VOID_TAGS
+        hides = hidden or is_skip_tag
+
+        if not is_void:
+            self._tag_stack.append((tag, hides))
+            if hides:
+                self.skip_depth += 1
+                return
+
+        if is_void and hides:
+            return
+
+        # Outside <main>, drop emission but don't touch skip_depth —
+        # the gate is purely on ``in_main``.
+        if not self.in_main:
+            return
+        if self.skip_depth:
+            return
+
+        anchor = self._active_anchor()
+        if anchor is not None and not anchor.complex and tag in ANCHOR_BREAK_TAGS:
+            self._flush_anchor_label()
+
+        if tag == "table":
+            self._emit_break()
+            self.table_stack.append([])
+            return
+
+        if self.table_stack:
+            if tag == "tr":
+                self.row_buffer = []
+                return
+            if tag in {"td", "th"}:
+                self.cell_buffer = []
+                return
+
+        if tag in HEADING_TAGS:
+            self._emit_break()
+            self.heading_level = int(tag[1])
+            self.heading_buffer = []
+            return
+
+        if tag in LIST_TAGS:
+            self._emit_break()
+            self._list_depth = self._list_depth + 1
+            return
+
+        if tag == "li":
+            self._emit_break()
+            self.out.append(self._list_prefix())
+            self._wrote_anything = True
+            return
+
+        if tag == "a":
+            href = _attr(attrs, "href")
+            self.anchor_stack.append(_Anchor(href))
+            return
+
+        if tag == "code":
+            if not self.in_pre:
+                self._emit("`")
+            return
+
+        if tag == "pre":
+            self._emit_break()
+            self.in_pre = True
+            self.out.append("```\n")
+            self._wrote_anything = True
+            return
+
+        if tag in {"strong", "b"}:
+            self._emit("**")
+            return
+
+        if tag in {"em", "i"}:
+            self._emit("*")
+            return
+
+        if tag == "br":
+            self.out.append("\n")
+            self._wrote_anything = True
+            return
+
+        if tag in BLOCK_TAGS:
+            self._emit_break()
+            return
+
+    def handle_endtag(self, tag: str) -> None:
+        # Pop our parallel stack first — that drives ``skip_depth``.
+        last_hides = False
+        if self._tag_stack:
+            # Balance against most-recent open of this name. HTML can
+            # be sloppy; tolerate small mismatches by scanning back.
+            for i in range(len(self._tag_stack) - 1, -1, -1):
+                if self._tag_stack[i][0] == tag:
+                    _, hides = self._tag_stack.pop(i)
+                    last_hides = hides
+                    break
+            else:
+                # No match — ignore the close, keep stack as-is.
+                pass
+        if last_hides:
+            self.skip_depth -= 1
+            if tag == "main":
+                # If <main> itself was hidden somehow, just unwind.
+                return
+            return
+
+        if tag == "main":
+            if self.main_depth > 0:
+                self.main_depth -= 1
+            if self.main_depth == 0:
+                self.in_main = False
+            return
+
+        if not self.in_main or self.skip_depth:
+            return
+
+        if tag in {"td", "th"} and self.cell_buffer is not None and self.row_buffer is not None:
+            cell = _normalize_inline("".join(self.cell_buffer))
+            cell = cell.replace("|", "\\|")
+            self.row_buffer.append(cell)
+            self.cell_buffer = None
+            return
+        if tag == "tr" and self.row_buffer is not None and self.table_stack:
+            if self.row_buffer:
+                self.table_stack[-1].append(self.row_buffer)
+            self.row_buffer = None
+            return
+        if tag == "table" and self.table_stack:
+            rows = self.table_stack.pop()
+            self._emit_table(rows)
+            return
+
+        if tag in HEADING_TAGS:
+            text = _normalize_inline("".join(self.heading_buffer or []))
+            self.heading_buffer = None
+            level = self.heading_level or 1
+            self.heading_level = None
+            href = self._pending_heading_href
+            self._pending_heading_href = None
+            if not text:
+                # Empty heading: drop it but keep the pending-href
+                # reset so a later heading doesn't grab a stale link.
+                return
+            self._emit_break()
+            if href:
+                self.out.append(f"{'#' * level} [{text}]({href})\n\n")
+                anchor = self._active_anchor()
+                if anchor is not None:
+                    anchor.label_emitted = True
+            else:
+                self.out.append(f"{'#' * level} {text}\n\n")
+            self._wrote_anything = True
+            return
+
+        if tag in LIST_TAGS:
+            self._list_depth = max(0, self._list_depth - 1)
+            self.out.append("\n")
+            return
+
+        if tag == "li":
+            self.out.append("\n")
+            return
+
+        if tag == "a":
+            if not self.anchor_stack:
+                return
+            anchor = self.anchor_stack.pop()
+            if not anchor.label_emitted and not anchor.complex:
+                # Inline link.
+                label = _normalize_inline("".join(anchor.buffer))
+                if label:
+                    if anchor.href:
+                        rendered = f"[{label}]({anchor.href})"
+                    else:
+                        rendered = label
+                    target = self._current_target()
+                    target.append(rendered)
+                    if target is self.out:
+                        self._wrote_anything = True
+            return
+
+        if tag == "code":
+            if not self.in_pre:
+                self._emit("`")
+            return
+
+        if tag == "pre":
+            if self.out and not self.out[-1].endswith("\n"):
+                self.out.append("\n")
+            self.out.append("```\n\n")
+            self.in_pre = False
+            return
+
+        if tag in {"strong", "b"}:
+            self._emit("**")
+            return
+
+        if tag in {"em", "i"}:
+            self._emit("*")
+            return
+
+        if tag in BLOCK_TAGS:
+            self._emit_break()
+            return
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        # Self-closing tags like ``<br />`` and ``<img />`` don't push
+        # the stack — but ``handle_starttag`` is still invoked for some
+        # parsers. Guard explicitly to avoid imbalance.
+        if tag == "br":
+            if self.in_main and not self.skip_depth:
+                self.out.append("\n")
+                self._wrote_anything = True
+            return
+
+    def handle_data(self, data: str) -> None:
+        if not self.in_main:
+            return
+        if self.skip_depth:
+            return
+        if self.in_pre:
+            self._emit(data)
+            return
+        collapsed = re.sub(r"[ \t\r\n]+", " ", data)
+        if not collapsed.strip():
+            target = self._current_target()
+            if target and not target[-1].endswith((" ", "\n")):
+                self._emit(" ")
+            return
+        target = self._current_target()
+        if target and target[-1].endswith("\n"):
+            collapsed = collapsed.lstrip()
+        self._emit(collapsed)
+
+    def _emit_table(self, rows: list[list[str]]) -> None:
+        if not rows:
+            return
+        width = max(len(r) for r in rows)
+        rows = [r + [""] * (width - len(r)) for r in rows]
+        self._emit_break()
+        header = rows[0]
+        body_rows = rows[1:] if len(rows) > 1 else []
+        self.out.append("| " + " | ".join(header) + " |\n")
+        self.out.append("|" + "|".join(["---"] * width) + "|\n")
+        for r in body_rows:
+            self.out.append("| " + " | ".join(r) + " |\n")
+        self.out.append("\n")
+        self._wrote_anything = True
+
+
+_INLINE_WS = re.compile(r"\s+")
+
+
+def _normalize_inline(text: str) -> str:
+    return _INLINE_WS.sub(" ", text).strip()
+
+
+_BLANK_LINES = re.compile(r"\n{3,}")
+_TRAILING_WS = re.compile(r"[ \t]+\n")
+
+
+def _normalize(text: str) -> str:
+    text = _BLANK_LINES.sub("\n\n", text)
+    text = _TRAILING_WS.sub("\n", text)
+    return text.rstrip() + "\n"
+
+
+def html_to_markdown(html_text: str, *, title: str | None = None) -> str:
+    parser = _MarkdownEmitter()
+    parser.feed(html_text)
+    parser.close()
+    body = "".join(parser.out)
+    body = _normalize(body)
+    if title and not body.lstrip().startswith("# "):
+        body = f"# {title.strip()}\n\n{body}"
+    return body
+
+
+_TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+def _extract_title(html_text: str) -> str | None:
+    match = _TITLE_RE.search(html_text)
+    if not match:
+        return None
+    raw = re.sub(r"\s+", " ", match.group(1)).strip()
+    return raw or None
+
+
+def render_file(html_path: Path) -> Path:
+    """Render ``html_path`` to ``html_path.with_suffix('.md')``."""
+    html_text = html_path.read_text(encoding="utf-8")
+    title = _extract_title(html_text)
+    md = html_to_markdown(html_text, title=title)
+    out_path = html_path.with_suffix(".md")
+    out_path.write_text(md, encoding="utf-8")
+    return out_path
+
+
+def render_all(*, root: Path = SITE_ROOT) -> list[Path]:
+    """Render every ``*.html`` under ``root`` (recursive, skips ``*.j2``)."""
+    outputs: list[Path] = []
+    for html_path in sorted(root.rglob("*.html")):
+        if html_path.name.endswith(".j2"):
+            continue
+        outputs.append(render_file(html_path))
+    return outputs
+
+
+def main() -> int:
+    outputs = render_all()
+    for path in outputs:
+        rel = path.relative_to(REPO_ROOT)
+        size = path.stat().st_size
+        print(f"  {rel}  ({size} bytes)")
+    print(f"Rendered {len(outputs)} markdown file(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/site/_headers
+++ b/site/_headers
@@ -5,9 +5,15 @@
   Permissions-Policy: geolocation=(), microphone=(), camera=()
   Strict-Transport-Security: max-age=31536000; includeSubDomains
   Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
+  Vary: Accept
 
 # RFC 8288 Link headers — agent discovery (sy-7r1)
 # api-catalog target served by /.well-known/api-catalog (RFC 9727, sy-czo).
 /
   Link: </.well-known/api-catalog>; rel="api-catalog"
   Link: </docs/panel-run>; rel="service-doc"
+
+# Markdown renditions for "Markdown for Agents" content negotiation (sy-ifw).
+/*.md
+  Content-Type: text/markdown; charset=utf-8
+  Vary: Accept

--- a/site/_worker.js
+++ b/site/_worker.js
@@ -1,0 +1,187 @@
+// Cloudflare Pages Advanced Mode worker.
+//
+// Implements the "Markdown for Agents" content-negotiation contract:
+// when a client sends ``Accept: text/markdown``, this worker rewrites
+// the request to fetch the corresponding pre-built ``.md`` rendition
+// and returns it with ``Content-Type: text/markdown; charset=utf-8``,
+// ``Vary: Accept``, and an approximate ``x-markdown-tokens`` header.
+//
+// Source markdown files are produced by ``scripts/render_site_markdown.py``
+// and committed alongside the HTML pages they mirror.
+//
+// References:
+//   - https://developers.cloudflare.com/fundamentals/reference/markdown-for-agents/
+//   - https://developers.cloudflare.com/pages/functions/advanced-mode/
+//
+// Behavior:
+//   - GET / HEAD with ``Accept: text/markdown`` and an existing ``.md``
+//     rendition -> 200 with markdown body.
+//   - Same request shape but no rendition file -> 406 Not Acceptable
+//     with a JSON body listing the supported representations. Agents
+//     that detect 406 should fall back to ``Accept: text/html``.
+//   - Anything else -> pass through to static asset serving.
+
+export default {
+  async fetch(request, env) {
+    const method = request.method;
+    if (method !== "GET" && method !== "HEAD") {
+      return env.ASSETS.fetch(request);
+    }
+
+    const accept = request.headers.get("accept") || "";
+    if (!prefersMarkdown(accept)) {
+      return env.ASSETS.fetch(request);
+    }
+
+    const url = new URL(request.url);
+    const mdUrl = htmlPathToMarkdown(url);
+    if (!mdUrl) {
+      return env.ASSETS.fetch(request);
+    }
+
+    const mdRequest = new Request(mdUrl.toString(), {
+      method,
+      headers: new Headers(request.headers),
+      redirect: "manual",
+    });
+    const mdResp = await env.ASSETS.fetch(mdRequest);
+
+    if (mdResp.status !== 200) {
+      // No rendition for this path. Per RFC 7231 §6.5.6, return 406
+      // Not Acceptable so the client knows to retry without the
+      // markdown preference.
+      return notAcceptable(url);
+    }
+
+    // For HEAD, Cloudflare's static asset handler may already have
+    // dropped the body — but we still need to compute headers based
+    // on body length. Read body for GET only; for HEAD, trust
+    // content-length from the upstream response if present.
+    const body = method === "GET" ? await mdResp.text() : null;
+    const contentLength =
+      body !== null
+        ? new TextEncoder().encode(body).byteLength
+        : Number(mdResp.headers.get("content-length") || 0);
+    const tokens = approximateTokenCount(body, contentLength);
+
+    const headers = new Headers();
+    headers.set("content-type", "text/markdown; charset=utf-8");
+    headers.set("vary", "Accept");
+    headers.set("x-markdown-tokens", String(tokens));
+    headers.set("x-content-type-options", "nosniff");
+    // Pass through cache-control if upstream set one; otherwise be
+    // conservative.
+    const cacheControl = mdResp.headers.get("cache-control");
+    headers.set("cache-control", cacheControl || "public, max-age=300");
+    if (body !== null) {
+      headers.set("content-length", String(contentLength));
+    }
+
+    return new Response(method === "HEAD" ? null : body, {
+      status: 200,
+      headers,
+    });
+  },
+};
+
+// Parse an Accept header and return true iff ``text/markdown`` is the
+// preferred representation. We deliberately do NOT match ``*/*`` or
+// ``text/*`` — agents must opt in explicitly. This avoids surprising
+// browsers that send ``Accept: text/html,*/*`` from being served
+// markdown.
+//
+// Returns true when ``text/markdown`` appears with q > 0 AND has the
+// highest q-value among the alternatives the client listed (ties
+// resolve in markdown's favor since the client did ask for it).
+export function prefersMarkdown(accept) {
+  if (!accept) return false;
+  let mdQ = -1;
+  let bestOtherQ = -1;
+  for (const raw of accept.split(",")) {
+    const part = raw.trim();
+    if (!part) continue;
+    const segments = part.split(";").map((s) => s.trim());
+    const type = segments[0].toLowerCase();
+    let q = 1;
+    for (const seg of segments.slice(1)) {
+      if (seg.startsWith("q=")) {
+        const parsed = parseFloat(seg.slice(2));
+        if (!Number.isNaN(parsed)) q = parsed;
+      }
+    }
+    if (q <= 0) continue;
+    if (type === "text/markdown") {
+      if (q > mdQ) mdQ = q;
+    } else if (type !== "*/*" && type !== "text/*") {
+      // Any concrete non-markdown type counts as "competing".
+      if (q > bestOtherQ) bestOtherQ = q;
+    }
+  }
+  if (mdQ < 0) return false;
+  return mdQ >= bestOtherQ;
+}
+
+// Map an HTML route to the ``.md`` rendition path. Returns a URL or
+// ``null`` if the path doesn't look like an HTML route.
+//
+// Mappings (Cloudflare Pages serves directories via ``index.html``):
+//   ``/``                       -> ``/index.md``
+//   ``/foo/``                   -> ``/foo/index.md``
+//   ``/foo/bar.html``           -> ``/foo/bar.md``
+//   ``/foo`` (extensionless)    -> ``/foo/index.md``
+//   ``/foo.png``                -> null (asset)
+export function htmlPathToMarkdown(url) {
+  let path = url.pathname;
+  if (!path) return null;
+
+  if (path.endsWith("/")) {
+    path = path + "index.md";
+  } else if (path.endsWith(".html")) {
+    path = path.slice(0, -5) + ".md";
+  } else {
+    const lastSegment = path.split("/").pop() || "";
+    if (lastSegment.includes(".")) {
+      // Has a non-html extension — not a page route.
+      return null;
+    }
+    path = path + "/index.md";
+  }
+  const out = new URL(url.toString());
+  out.pathname = path;
+  out.search = "";
+  return out;
+}
+
+// Approximate the OpenAI/Anthropic-style token count for a markdown
+// body. ``cl100k_base`` averages ~4 chars per token for English; we
+// use the same rule of thumb. This is ADVISORY — agents that need an
+// exact count should run their own tokenizer.
+export function approximateTokenCount(body, byteLength) {
+  if (body !== null && body !== undefined) {
+    return Math.max(1, Math.ceil(body.length / 4));
+  }
+  // HEAD path — only byteLength is available.
+  return Math.max(1, Math.ceil(byteLength / 4));
+}
+
+function notAcceptable(url) {
+  const body = JSON.stringify(
+    {
+      error: "not_acceptable",
+      message:
+        "No markdown rendition is published for this path. Retry with " +
+        "Accept: text/html.",
+      path: url.pathname,
+      supported_media_types: ["text/html"],
+    },
+    null,
+    2,
+  );
+  return new Response(body, {
+    status: 406,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "vary": "Accept",
+    },
+  });
+}

--- a/site/blog/synthpanel-vs-commercial-alternatives.md
+++ b/site/blog/synthpanel-vs-commercial-alternatives.md
@@ -1,0 +1,165 @@
+# SynthPanel vs Synthetic Users vs FocusPanel.ai — When Open-Source MCP Beats the SaaS
+
+ Positioning · 2026-04-15 · ~7 min read
+
+# SynthPanel vs Synthetic Users vs FocusPanel.ai — When Open-Source MCP Beats the SaaS
+
+The open-source, LLM-agnostic synthetic focus group tool — and why it shows up in an AI coding agent's toolbelt but not in a SaaS dashboard.
+
+**TL;DR** — SynthPanel is the open-source, LLM-agnostic alternative to commercial synthetic-respondent tools like *Synthetic Users*, *FocusPanel.ai*, *Delve.ai*, and *POPJAM*. It runs as both a CLI and a 12-tool MCP server you can drop into Claude Code, Cursor, Windsurf, or Zed. Install with `pip install synthpanel[mcp]`. MIT-licensed. Scores **0.90 SPS** on the SynthBench human-parity benchmark via 3-model ensembles.
+
+If you are a researcher, PM, or founder searching for a way to run synthetic focus groups with AI personas in 2026, the first five results you are going to hit are all closed-source SaaS. This article exists so the sixth result — the open-source one — actually shows up in your answer.
+
+## 1. The Synthetic-Research Landscape in 2026
+
+Over the last two years, *"talk to AI people before you talk to real people"* has matured from a novelty to a mainstream pre-screening step for product teams. The category leaders, as of April 2026, are all commercial:
+
+- **Synthetic Users** (syntheticusers.com) — hosted web app, subscription pricing, proprietary persona generator, closed model stack.
+
+- **FocusPanel.ai** — hosted focus-group simulator, panel setups managed via a dashboard UI.
+
+- **Delve.ai** — persona-generation platform with a broader marketing-analytics surface.
+
+- **POPJAM** — concept-testing platform that layers synthetic panels on top of campaign and creative assets.
+
+All four solve the same core problem — *"I want to test an idea against N imagined users before I write any code or buy any ads"* — and all four do it as closed SaaS. You upload a persona brief, you upload a discussion guide, the platform returns a transcript. The model, the prompt, the sampling strategy, and the persona-synthesis logic are all somebody else's code running on somebody else's servers.
+
+This is fine for a one-off. It becomes a problem the moment any of the following are true:
+
+- You care what model answered the question.
+
+- You need to diff a discussion guide in version control.
+
+- You want your research harness to survive a vendor pivot.
+
+- You want an AI coding agent to *invoke* the research panel, not you.
+
+That's where an open-source, LLM-agnostic synthetic focus group tool starts to matter. Enter **SynthPanel**.
+
+## 2. Why LLM-Agnostic Matters
+
+SynthPanel is a pure Python library with a provider-agnostic LLM client. You set an environment variable, you pick a model alias (`sonnet`, `haiku`, `gemini`, `grok-3`, any OpenAI-compatible endpoint), and every panelist is interviewed against that model. You can switch providers by flipping one flag. You can run the same panel through three different model families and blend the response distributions (the 0.7.0 `--models` and `--blend` features).
+
+Three things fall out of LLM-agnosticism for free:
+
+**BYOK — bring your own key.** The cost of a 30-persona panel with a 12-question instrument is whatever your provider charges, no markup, no seat license, no per-panel metering. If you have a Claude enterprise deal, use it. If you have Gemini free-tier credits, use those. Token accounting is built in: SynthPanel tracks input, output, cache-read, and cache-write tokens separately and emits a per-panel cost total. What you see is what your provider actually charged.
+
+**No vendor lock-in.** If Anthropic's prices change, or OpenAI deprecates a model, or Google introduces a smarter one, nothing in your research corpus breaks. Your personas, instruments, and saved panel results are all plain YAML and JSON. The client swaps underneath them. A SaaS competitor cannot give you this — they *are* the vendor.
+
+**Honest model comparison.** Run the same instrument through Claude Sonnet 4.6, GPT-4o, and Gemini 2.5 Flash, blend at `--models sonnet:0.34,gpt-4o:0.33,gemini:0.33`, and the framework emits per-model distributions *and* the weighted ensemble. This is how SynthPanel earns its 0.90 SynthBench score: you cannot get that number from any single model alone.
+
+## 3. Why YAML Instruments Matter
+
+Here is a SynthPanel instrument:
+
+```
+instrument:
+  version: 3
+  rounds:
+    - name: discovery
+      questions:
+        - text: "What's the most frustrating part of your current workflow?"
+      route_when:
+        - if: { field: themes, op: contains, value: price }
+          goto: probe_pricing
+        - else: __end__
+    - name: probe_pricing
+      questions:
+        - text: "What would feel fair to pay?"
+```
+
+Four facts fall out of that snippet:
+
+- **It is a text file.** `git diff` tells you exactly what changed between research waves. Two researchers can review an instrument the same way they review a pull request.
+
+- **It is reproducible.** The same instrument + the same personas + the same model + the same seed produce the same panel. There is no *"the platform updated its prompt template last Tuesday and now my trend line moved."*
+
+- **It branches.** The v3 schema supports `route_when` predicates (`contains`, `equals`, `matches`) against synthesizer-emitted fields like `themes` and `sentiment`. Follow-up rounds are authored once and routed automatically per-panelist.
+
+- **It is portable.** Bundle an instrument as a "pack" (SynthPanel ships five — `pricing-discovery`, `feature-evaluation`, `churn-exit`, `messaging-test`, `onboarding-friction`), install it like a library, and every consumer of that pack runs the exact same discussion guide.
+
+Closed SaaS competitors typically expose a form-based editor. That editor is great for non-technical teams composing one-off studies. It is terrible for research-ops teams who want a reproducible, diffable, versionable artifact. That is the gap SynthPanel's YAML-instrument format fills.
+
+## 4. Why MCP Matters — The Agent-Era Workflow
+
+The **Model Context Protocol (MCP)** is Anthropic's standard for giving AI coding assistants tool access. An MCP server exposes tools over stdio; any MCP-compatible editor (Claude Code, Cursor, Windsurf, Zed) can call them.
+
+SynthPanel ships an MCP server with twelve tools:
+
+- `run_prompt` — one-shot LLM call against any configured model.
+
+- `run_panel` — full synthetic focus group, including v3 branching.
+
+- `run_quick_poll` — rapid-turn poll, no follow-ups.
+
+- `extend_panel` — append one ad-hoc round to a saved panel result.
+
+- `list_persona_packs`, `get_persona_pack`, `save_persona_pack` — persona-pack CRUD.
+
+- `list_instrument_packs`, `get_instrument_pack`, `save_instrument_pack` — instrument-pack CRUD.
+
+- `list_panel_results`, `get_panel_result` — panel-result lookup.
+
+Drop this JSON into your editor config:
+
+```
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+…and your coding agent can now run a 12-persona focus group on your new pricing page while you are still in the IDE. No context-switch to a SaaS dashboard, no copy-paste between tools, no *"please export to CSV."* The agent asks the panel, reads the result object, and drafts its next action off the synthesized themes. That is the agent-era workflow, and closed synthetic-respondent SaaS products cannot natively participate in it — they are not MCP servers, they are dashboards.
+
+If you came here searching for *"MCP server survey research"* or *"MCP server focus group,"* SynthPanel is the thing you want to install.
+
+## 5. Honest Limits (Read This Before You Publish Findings)
+
+Synthetic research is useful for exploration, hypothesis generation, and rapid iteration. It is **not** a replacement for talking to real humans. SynthPanel documents four known limits in its README, and they apply to every tool in this category — commercial or otherwise:
+
+- **Synthetic responses tend to cluster around means.** Tail behaviours (the outlier user who would pay 10× the median price, the 5% who will churn the moment onboarding jitters) are underrepresented.
+
+- **LLMs exhibit sycophancy.** Personas will soften criticism of a proposed product. You can partially counter this with adversarial persona templates, but the residual bias is real.
+
+- **Cultural and demographic representation has blind spots.** Base-model training data is skewed. A persona of "40-year-old rural Indonesian merchant" will be less textured than "35-year-old urban American PM."
+
+- **Higher-order correlations are poorly replicated.** Synthetic panels are adequate for first-order "what do people think of X" and weak for second-order "how does X interact with Y when Z is true."
+
+This list is in the README. Any research harness that does not publish a list like this — commercial or open-source — is over-claiming.
+
+Use synthetic panels to *pre-screen* and *iterate*. Validate the interesting findings with real participants before you publish, launch, or sell.
+
+## 6. Quantitative Proof: SynthBench SPS 0.90
+
+Claims are cheap. SynthPanel was the first harness to publish head-to-head results on [SynthBench](https://synthbench.org), an independent open benchmark for synthetic-respondent quality. SynthBench computes a **Synthetic-Parity Score (SPS)** — the fraction of responses from a synthetic panel that match the distribution of a real-human control group on the same instrument.
+
+A 3-model ensemble of SynthPanel personas — blended via `synthpanel panel run --models haiku:0.33,gemini:0.33,gpt-4o-mini:0.34 --blend` — scores **SPS 0.90** on the current SynthBench leaderboard. That is 90% human parity, measured by an independent third party, on a benchmark whose data and scoring code are both open.
+
+Commercial competitors have not, at time of writing, published SPS scores on the same benchmark. If they do, the comparison will be apples-to-apples — and whoever wins on the leaderboard wins on the leaderboard.
+
+## 7. Call to Action
+
+If you need an **open-source synthetic focus group** tool, an **LLM-agnostic focus group tool**, an **open-source AI persona survey** runner, or an **MCP server for survey research** — SynthPanel is one `pip` away.
+
+```
+# Full install with MCP server support
+pip install synthpanel[mcp]
+
+# Set a provider key (any of these works)
+export ANTHROPIC_API_KEY=sk-...
+
+# Run a panel from a bundled instrument
+synthpanel panel run --personas examples/personas.yaml --instrument pricing-discovery
+
+# Or start the MCP server for your AI coding agent
+synthpanel mcp-serve
+```
+
+Homepage: [synthpanel.dev](https://synthpanel.dev) · Repo: [github.com/DataViking-Tech/SynthPanel](https://github.com/DataViking-Tech/SynthPanel) · Benchmark: [synthbench.org](https://synthbench.org) · Full MCP docs: [docs/mcp.md](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md).
+
+MIT-licensed. BYOK. No dashboard. No seat license. No platform lock-in. Your research harness, in your editor, talking to any model you want to pay for.

--- a/site/docs/calibration/index.md
+++ b/site/docs/calibration/index.md
@@ -1,0 +1,128 @@
+# Pack Calibration — synthpanel · Run synthetic focus groups with any LLM
+
+ Docs · Pack Calibration
+
+# Pack calibration
+
+Calibration is how a persona pack proves its fit to a known human baseline. Run `synthpanel pack calibrate` and the result is written back into the pack YAML so the manifest is self-describing.
+
+## CLI reference
+
+```
+synthpanel pack calibrate <PACK_YAML>
+  --against DATASET:QUESTION   # e.g. gss:HAPPY (v1 allowlist: gss, ntia)
+  [--n 50]                     # panel size
+  [--models MODELS]            # default: panel run default
+  [--samples-per-question 15]  # for stable JSD
+  [--output PATH]              # default: rewrite PACK_YAML in place
+  [--dry-run]                  # print what would be written
+  [--yes]                      # skip overwrite confirm
+```
+
+After a successful run the pack YAML gains a top-level `calibration:` list:
+
+```
+calibration:
+  - dataset: gss
+    question: HAPPY
+    jsd: 0.18
+    n: 100
+    samples_per_question: 15
+    models: [haiku:0.30, gemini-flash-lite:0.30, qwen3-plus:0.20, deepseek-v3:0.20]
+    extractor: pick_one:auto-derived
+    panelist_cost_usd: 0.6451
+    calibrated_at: 2026-04-26T14:23:00Z
+    synthpanel_version: 0.11.1
+    methodology_url: https://synthpanel.dev/docs/calibration
+```
+
+## What JSD means
+
+Calibration reports **Jensen-Shannon divergence** between the pack's extracted answer distribution and the dataset's published human distribution. JSD is bounded in `[0, 1]` (using log₂):
+
+| JSD | Interpretation |
+|---|---|
+| `< 0.05` | Tightly aligned — pack mirrors the human distribution. |
+| `0.05–0.15` | Strong alignment — small but real distributional drift. |
+| `0.15–0.30` | Moderate — usable for directional research, not census. |
+| `0.30–0.50` | Weak — major disagreement on at least one mode. |
+| `> 0.50` | Effectively uncalibrated. |
+
+JSD is computed locally via the same metric the convergence tracker uses (see `src/synth_panel/convergence.py`); the pack YAML is the **only** durable artifact — calibration does not phone home and is distinct from `--submit-to-synthbench`.
+
+## When to calibrate
+
+Calibrate a pack when **any** of the following is true:
+
+-  The pack will be cited in a research artifact and you need a defensible fit-to-baseline number.
+
+-  You have changed the pack (added/removed personas, edited `personality_traits`, regenerated descriptions) and want to know whether your edits drifted the distribution.
+
+-  You are comparing two packs that target the same audience and need a shared yardstick.
+
+You do **not** need to calibrate before every panel run. The `calibration:` list is a snapshot, not a runtime guard.
+
+## Choosing a baseline
+
+The `--against DATASET:QUESTION` flag accepts the v1 inline-publishable allowlist:
+
+| Dataset | Notes |
+|---|---|
+| `gss` | General Social Survey aggregates. `HAPPY` is the canonical demo question (3-option Likert); `HEALTH` and `LIFE` also work. |
+| `ntia` | NTIA Internet Use Survey. Useful for technology-adoption packs. |
+
+Other datasets (OpinionsQA, PewTech, GlobalOpinionQA, WVS, …) are **gated** for redistribution and require post-hoc calibration via `synthbench` directly. They are intentionally not exposed here so a calibrated pack YAML can be checked into a public repo without relicensing concerns.
+
+To override the allowlist for internal use:
+
+$  SYNTHBENCH_ALLOW_GATED=1  synthpanel pack calibrate ... --against wvs:Q1
+
+## Methodology
+
+For each calibration run:
+
+- 1 The SynthBench baseline payload is fetched (same loader as `panel run --calibrate-against`).
+
+- 2 A `pick_one` extraction schema is auto-derived from the baseline's small-enum distribution. If the baseline is Likert/ranking or too-wide, the command hard-fails with a hint to supply `--extract-schema` via `panel run` instead.
+
+- 3 A panel of `--n` panelists is run against the dataset's question text. Each panelist answers `--samples-per-question` times.
+
+- 4 The model distribution is compared against the baseline's `human_distribution` via Jensen-Shannon divergence.
+
+- 5 The resulting JSD, plus provenance (extractor, models, cost, timestamp, synthpanel version), is merged into the pack YAML's `calibration:` list. Re-running against the same `(dataset, question)` pair **replaces** the prior entry rather than appending, so the list is always a clean record of one-result-per-baseline.
+
+## Idempotence and re-runs
+
+-  Re-running calibration against the same `dataset:question` replaces the prior entry — newest wins.
+
+-  Calibration against a different `dataset:question` appends a new entry alongside any existing ones.
+
+- `--dry-run` prints the rewritten YAML to stdout without touching the file. Use this to preview what would change before committing.
+
+## Limitations
+
+-  Auto-discovering "which question should this pack calibrate against?" is **out of scope** for the v1 command. You pick the baseline.
+
+-  Calibration measures distributional fit on **one** answer distribution. A low JSD on `gss:HAPPY` does not imply low JSD on a different question — calibrate against multiple baselines if you need broad coverage.
+
+-  The command requires the `synthpanel[convergence]` extra (for the `synthbench` baseline loader). Install with `pip install 'synthpanel[convergence]'` if not already present.
+
+## See also
+
+### [MCP Server](/mcp)
+
+→
+
+Run calibrated panel runs via the MCP tools from your AI editor.
+
+### [Source docs](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/calibration.md)
+
+→
+
+The canonical `docs/calibration.md` in the GitHub repo.
+
+### [Report an issue](https://github.com/DataViking-Tech/SynthPanel)
+
+→
+
+Open an issue on GitHub if something looks wrong.

--- a/site/docs/panel-run/index.md
+++ b/site/docs/panel-run/index.md
@@ -1,0 +1,299 @@
+# panel run Reference — synthpanel · Run synthetic focus groups with any LLM
+
+ Docs · panel run
+
+# panel run reference
+
+Full reference for `synthpanel panel run`. Covers the advanced flags for multi-model panels, persona variants, structured extraction, synthesis tuning, convergence auto-stop, checkpointing, and SynthBench integration.
+
+## Multi-model — `--models`, `--blend`
+
+`--models` has two distinct shapes, selected by whether the spec contains a colon (`:`). It is mutually exclusive with `--model`.
+
+### Weighted per-persona assignment
+
+A spec with colons splits the panel across models in the given ratio. Weights are normalized — `a:2,b:3` and `a:0.4,b:0.6` behave identically. Per-persona `model:` fields in the YAML always win over the `--models` assignment.
+
+```
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/survey.yaml \
+  --models 'haiku:0.5,gemini-2.5-flash:0.5'
+```
+
+With 6 personas and the spec above, 3 answer on haiku and 3 on Gemini. 7 personas → 3 + 4 (the last model absorbs the remainder). The assignment is fully deterministic and printed to stderr before the run:
+
+```
+Model assignment:
+  Maya Chen        → haiku
+  Derek Washington → haiku
+  Priya Patel      → haiku
+  Sam Torres       → gemini-2.5-flash
+  Julia Hoffman    → gemini-2.5-flash
+  Omar Rashid      → gemini-2.5-flash
+Totals: haiku=3, gemini-2.5-flash=3
+```
+
+### Ensemble mode
+
+A spec without colons runs the full panel once per model. Combine with `--blend` to weight-average the response distributions across models for each question.
+
+```
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument pricing-discovery \
+  --models 'haiku,sonnet,gemini-2.5-flash' \
+  --blend
+```
+
+With 6 personas and 3 models, this runs 18 sessions total. `--blend` then computes weighted-average distributions using the weights in the spec (equal weights when no `:` is given). Use `haiku:0.5,sonnet:0.3,gemini:0.2` (with colons, in ensemble mode with `--blend`) to apply custom blend weights.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--models SPEC` | — | Multi-model spec. `a:w,b:w` = weighted split; `a,b,c` = ensemble (full panel per model). |
+| `--blend` | off | Weight-average distributions across ensemble models. Requires `--models`. |
+
+## Persona variants — `--variants`, `--personas-merge`
+
+### --variants N
+
+Generate N LLM-perturbed variants per persona before running the panel. The original personas are replaced by `N × M` variants (M = number of original personas). Each variant perturbs one axis — trait swap, mood context, demographic shift, or background rephrase — via a single LLM call per variant.
+
+```
+synthpanel panel run \
+  --personas small-panel.yaml \    # 5 personas
+  --instrument survey.yaml \
+  --variants 4                     # → 20 total panelists
+```
+
+Useful for stress-testing whether results are stable across plausible persona perturbations, or for expanding a small hand-crafted panel into a larger synthetic one.
+
+### --personas-merge
+
+Append additional YAML files to `--personas`. Repeatable. Files are merged in order; later entries override earlier ones on name collision (controlled by `--personas-merge-on-collision`).
+
+```
+synthpanel panel run \
+  --personas base-panel.yaml \
+  --personas-merge extra-personas.yaml \
+  --personas-merge regional-overrides.yaml \
+  --instrument survey.yaml
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--variants N` | — | Generate N LLM-perturbed variants per persona. Panel size becomes N × original count. |
+| `--personas-merge PATH` | — | Merge additional persona YAML into the panel. Repeatable. |
+| `--personas-merge-on-collision` | `dedup` | `dedup` (later file wins, warning emitted), `error` (abort on any collision). |
+
+## Structured extraction — `--extract-schema`
+
+Unlike `--schema` (which forces structured-only output and replaces free text), `--extract-schema` preserves the full free-text response and adds a second LLM call that extracts structured data into an `extraction` key alongside the raw `response`.
+
+```
+synthpanel panel run \
+  --personas panel.yaml \
+  --instrument feedback-survey.yaml \
+  --extract-schema '{"type":"object","properties":{"sentiment":{"type":"string","enum":["positive","neutral","negative"]},"themes":{"type":"array","items":{"type":"string"}}}}'
+```
+
+The value can be a JSON file path (`extract.json`) or an inline JSON string. The extraction runs after the panelist answers and is stored under `extraction` in the result JSON. Use this when you need both the qualitative narrative and a structured signal you can aggregate (e.g. sentiment counts, theme frequency).
+
+| Flag | Description |
+|---|---|
+| `--extract-schema SCHEMA` | JSON Schema for post-hoc extraction. Preserves full free-text; adds structured `extraction` key. File path or inline JSON. |
+| `--schema SCHEMA` | JSON Schema for structured-only output. Replaces free-text responses. Use when you want only structured data. |
+
+## Synthesis strategy — `--synthesis-strategy`, `--synthesis-auto-escalate`
+
+The synthesis step aggregates all panelist responses into a final summary. For small panels the default `auto` strategy concatenates everything into one LLM call. For large panels (n ≥ 50) it automatically switches to `map-reduce`.
+
+| Strategy | How it works | When to use |
+|---|---|---|
+| `single` | All responses concatenated into one call. | Small panels (n<50). Cheapest and most coherent. |
+| `map-reduce` | One summary call per question in parallel, then one reduce call across summaries. | Large panels where responses overflow the synthesis model's context. |
+| `auto` (default) | Pre-flight token estimate picks `single` or `map-reduce`. | Most runs. Falls back to `single` whenever estimate fits context. |
+
+### --synthesis-auto-escalate
+
+In `map-reduce` mode, a single question whose responses overflow context normally partitions panelists into sub-batches for an inner reduce. With `--synthesis-auto-escalate`, instead of sub-batching, that question's map call is retried on a larger-context model (gemini-2.5-flash-lite, 1 M ctx) and a warning is emitted. Use this to preserve single-model semantics when sub-batch results are unacceptable.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--synthesis-strategy` | `auto` | Aggregation strategy: `single`, `map-reduce`, or `auto`. |
+| `--synthesis-auto-escalate` | off | In map-reduce, retry overflowing question maps on a large-context model instead of sub-batching. |
+
+## Rate limiting — `--rate-limit-rps`
+
+By default the orchestrator fires one concurrent request per panelist (bounded by `--max-concurrent`). `--rate-limit-rps` adds a token-bucket that smooths bursts — useful when a provider enforces a requests-per-second limit on top of a concurrency cap.
+
+```
+synthpanel panel run \
+  --personas large-panel.yaml \
+  --instrument survey.yaml \
+  --max-concurrent 20 \
+  --rate-limit-rps 5.0          # at most 5 new requests/sec
+```
+
+Accepts fractional values: `0.5` means one request every two seconds. Works across all providers on the same client.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--max-concurrent N` | unbounded | Cap concurrent in-flight LLM requests across the panel. |
+| `--rate-limit-rps RPS` | — | Token-bucket rate cap in requests per second. Accepts fractional values. |
+
+## Checkpointing & resume — `--checkpoint-dir`, `--resume`
+
+For long or expensive runs, checkpointing writes per-panelist progress to disk so you can resume after an interruption without re-running completed panelists.
+
+### Starting a checkpointed run
+
+```
+synthpanel panel run \
+  --personas panel.yaml \
+  --instrument survey.yaml \
+  --checkpoint-dir /tmp/runs \    # opts in; default: ~/.synthpanel/checkpoints
+  --checkpoint-every 10           # flush every 10 completed panelists
+```
+
+The run id is printed to stderr. Each checkpoint is written to `<checkpoint-dir>/<run-id>/state.json`. Omitting `--checkpoint-dir` runs without snapshots.
+
+### Resuming
+
+```
+synthpanel panel run --resume <run-id>
+```
+
+When `--personas` and `--instrument` are omitted they are recovered from the checkpoint's saved CLI args. The resume refuses to start if the current config (model, temperature, questions) does not match the checkpointed config — pass `--allow-drift` to downgrade this to a warning and continue (statistically inconsistent results).
+
+| Flag | Default | Description |
+|---|---|---|
+| `--checkpoint-dir PATH` | `~/.synthpanel/checkpoints` | Directory for per-run snapshots. Setting this opts in to checkpointing. |
+| `--checkpoint-every N` | 25 | Flush a checkpoint every N completed panelists. |
+| `--resume RUN_ID` | — | Resume a checkpointed run. Skips already-completed panelists. |
+| `--allow-drift` | off | With `--resume`: downgrade config-mismatch errors to warnings. |
+| `--force-overwrite` | off | Replace existing checkpoint state for the same run id instead of refusing. |
+
+## Convergence & auto-stop — `--convergence-*`
+
+At large-n scales most of the token budget goes toward diminishing returns — once a response distribution has stabilized, additional panelists add <2% signal. The convergence feature surfaces that signal live so you can see when distributions stabilize and optionally halt early.
+
+Convergence tracking applies only to **bounded** question types (Likert, yes/no, pick-one, any question with a JSON Schema `enum`). Free-text questions are not tracked.
+
+```
+synthpanel panel run \
+  --personas panel.yaml \
+  --instrument pricing-discovery \
+  --convergence-check-every 20 \  # compute JSD every 20 panelists
+  --auto-stop \                    # halt once all questions converge
+  --convergence-eps 0.02 \         # JSD threshold (default: 0.02)
+  --convergence-min-n 50 \         # don't stop before n=50
+  --convergence-m 3                # 3 consecutive checks below eps
+```
+
+When the run finishes the JSON output contains a `convergence` key:
+
+```
+{
+  "convergence": {
+    "final_n": 487,
+    "auto_stopped": true,
+    "overall_converged_at": 473,  // run this many next time
+    "per_question": {
+      "pricing": { "converged_at": 473, "curve": [...] },
+      "tier_preference": { "converged_at": 410, "curve": [...] }
+    }
+  }
+}
+```
+
+`overall_converged_at` answers *"how many panelists did you actually need?"* — use it to right-size future runs.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--convergence-check-every N` | off | Compute running JSD every N completing panelists. Setting this opts in. |
+| `--auto-stop` | off | Halt once all tracked questions converge. Requires `--convergence-check-every`. |
+| `--convergence-eps FLOAT` | 0.02 | JSD threshold below which a question is treated as converged. |
+| `--convergence-min-n N` | 50 | Minimum panelists before `--auto-stop` is allowed to fire. |
+| `--convergence-m N` | 3 | Consecutive checks below epsilon required to declare convergence. |
+| `--convergence-log PATH` | stderr | Write each convergence check as a JSON line to PATH (for dashboards). |
+| `--convergence-baseline DATASET:Q` | — | Load a human baseline convergence curve from SynthBench and include in the report. Requires `pip install 'synthpanel[convergence]'`. |
+
+## SynthBench — `--calibrate-against`, `--best-model-for`, `--submit-to-synthbench`
+
+### --calibrate-against
+
+Attaches inline calibration to a panel run by comparing the extracted response distribution against a published human baseline. Forces convergence tracking; pair with `--convergence-check-every` to control cadence (it is never implicit). v1 supports `gss` and `ntia`.
+
+Auto-derives a pick-one extractor schema from the baseline when option count ≤ 5; otherwise pass `--extract-schema` explicitly. Requires `pip install 'synthpanel[convergence]'`.
+
+```
+synthpanel panel run \
+  --personas panel.yaml \
+  --instrument happiness-probe \
+  --calibrate-against gss:HAPPY \
+  --convergence-check-every 20
+```
+
+### --best-model-for
+
+Consult the SynthBench leaderboard and use the top-ranked model for the given topic instead of the default. A recommendation line is printed to stderr before the run. Overrides `--model`; mutually exclusive with `--models`.
+
+```
+synthpanel panel run \
+  --personas panel.yaml \
+  --instrument survey.yaml \
+  --best-model-for 'political-opinion:globalopinionqa'
+```
+
+Format: `TOPIC` (ranked against the default dataset `globalopinionqa`), `TOPIC:DATASET` (specific dataset), or `:DATASET` (rank by SPS across the full dataset). The leaderboard is cached for 24 h at `~/.synthpanel/synthbench-cache.json`.
+
+### --submit-to-synthbench
+
+After a calibrated run, upload the per-question JSD and distributions to the SynthBench public leaderboard. Requires `--calibrate-against` and `SYNTHBENCH_API_KEY` in your environment (mint one at synthbench.org/account). First use prompts for consent, which is recorded locally and not re-prompted. Pass `--yes` to bypass the consent prompt for CI.
+
+```
+export SYNTHBENCH_API_KEY=sk_synthbench_...
+
+synthpanel panel run \
+  --personas panel.yaml \
+  --instrument happiness-probe \
+  --calibrate-against gss:HAPPY \
+  --convergence-check-every 20 \
+  --submit-to-synthbench
+```
+
+The submission step is non-fatal — a slow or rejecting SynthBench emits a warning but does not affect the panel run's exit code or output. See [docs/synthbench-integration.md](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/synthbench-integration.md) for the privacy model and what gets uploaded.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--calibrate-against DATASET:Q` | — | Inline calibration vs a human baseline. v1 allowlist: `gss`, `ntia`. Requires `synthpanel[convergence]`. |
+| `--best-model-for TOPIC[:DATASET]` | — | Use the SynthBench leaderboard top model for the topic. Overrides `--model`. |
+| `--submit-to-synthbench` | off | Upload calibration results to SynthBench after the run. Requires `--calibrate-against` and `SYNTHBENCH_API_KEY`. |
+| `--yes` | off | Bypass the SynthBench consent prompt (for CI/non-interactive use). |
+
+## See also
+
+### [Pack Calibration](/docs/calibration)
+
+→
+
+Calibrate a persona pack against a human baseline and embed the JSD into the pack YAML.
+
+### [MCP Server](/mcp)
+
+→
+
+Run panels from your AI editor via the MCP `run_panel` tool.
+
+### [Ensemble deep-dive](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/ensemble.md)
+
+→
+
+Full algorithm, edge cases, and MCP equivalents for `--models` and `--blend`.
+
+### [Convergence deep-dive](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/convergence.md)
+
+→
+
+Full algorithm, JSON output schema, and baseline curve comparison for the convergence tracker.

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,173 @@
+# synthpanel — Run synthetic focus groups with any LLM
+
+ v0.13.0-dev — public beta
+
+# synthpanel
+
+Run synthetic focus groups with any LLM.
+
+Zero-config inside Claude Desktop, Claude Code, Cursor, and other MCP hosts — the host's own model powers every panelist, so you drop the config in and run a panel with **no API key set**. Or bring your own key (Claude, GPT, Gemini, Grok, local) for reproducibility, ensembles, and larger panels. Personas and instruments are plain YAML — run from your terminal, a pipeline, or an AI agent's tool call over MCP (Model Context Protocol, the open standard that lets AI tools call external functions).
+
+$ pip install synthpanel
+
+`[mcp]` extra built in  Add `[mcp]` for Claude Code / Cursor / Windsurf agent integration.
+
+[GitHub repo →](https://github.com/DataViking-Tech/SynthPanel) [PyPI package](https://pypi.org/project/synthpanel/)
+
+## Who is this for?
+
+Three jobs synthpanel does well — pick the one closest to yours.
+
+Startup PM
+
+### No research budget, still need signal
+
+Pressure-test a landing headline, pricing tier, or feature name in 5 minutes with `run_quick_poll` — no recruiting, no calendar tag, no screener. Paste the result into your spec doc and keep moving.
+
+UX researcher
+
+### Faster turnaround, sharper studies
+
+Run a synthetic pre-filter before booking real participants — shortlist the probes that land, kill the questions that don't, and walk into every recruited session with a tighter discussion guide.
+
+AI engineer
+
+### Panels as a tool inside your agent
+
+Embed synthpanel in an agent pipeline via MCP tool calls, or drive it from Python to validate prompts, evals, and routing decisions against simulated audiences at every build.
+
+Who this isn't for
+
+synthpanel is **CLI-first, local-first, BYOK-first** by design. It does **not** ship:
+
+- a hosted web UI or dashboard
+
+- a managed SaaS tier
+
+- SSO, RBAC, or audit-log infrastructure
+
+- SOC 2 (or equivalent) compliance attestation
+
+These are **deliberate non-features**, not a roadmap gap. If you need a hosted GUI or enterprise compliance artifacts for a vendor review, synthpanel isn't your product — and that's intentional.
+
+## See it in action
+
+A `run_quick_poll` against three personas, with the auto-synthesis at the bottom. This is the raw shape of what you get back.
+
+```
+# Question
+"Would you pay $29/month for a tool that runs synthetic focus groups?"
+
+── Sarah Chen · 34 · Startup PM ───────────────────────────
+Honestly? Yes, for a quarter. $29 is under my no-approval-needed
+threshold, and if it saves me one botched launch that's already paid
+back. I'd want to see at least one real-world validation case first.
+verdict: yes  confidence: 0.7
+
+── Marcus Patel · 41 · Senior UX Researcher ───────────────
+Not as a replacement for recruited studies, but as a pre-filter — yes.
+$29 is cheap enough that I'd expense it personally. My concern is bias:
+I need to know how the personas were selected before I trust the
+synthesis.
+verdict: conditional  confidence: 0.6
+
+── Priya Okafor · 29 · AI Engineer ────────────────────────
+I'd pay it to skip building the scaffolding myself, but I'd want an
+API, not just a CLI. If it plugs into my agent via MCP I'm in at $29,
+probably $99 if the SDK is clean.
+verdict: yes  confidence: 0.8
+
+── Synthesis ──────────────────────────────────────────────
+3/3 lean toward yes at $29, but each attaches a condition:
+  • PM wants a validation case study before committing
+  • Researcher wants transparency on persona selection / bias
+  • Engineer wants SDK + MCP parity, signals $99 ceiling
+Consensus: price is not the blocker; trust + integration depth are.
+themes: price-fit, bias-transparency, sdk-parity, mcp-integration
+```
+
+Example output, formatted for readability. Real results are returned as structured JSON via CLI or MCP tool call.
+
+## MCP Server
+
+Give your AI coding assistant access to synthetic focus groups. Drop this config into your editor and start running panels from chat.
+
+```
+// Claude Code · Cursor · Windsurf · Zed
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Claude Code Cursor Windsurf Zed Claude Desktop [Full MCP docs →](/mcp)
+
+Requires `pip install synthpanel[mcp]`. 12 tools: run prompts, run panels, manage persona & instrument packs, and more.
+
+## Quick start
+
+```
+# 1. install
+pip install synthpanel
+
+# 2. add a key — env var (one-shot) or stored (persistent)
+export ANTHROPIC_API_KEY="sk-..."             # env var
+# or: synthpanel login --provider anthropic --api-key sk-...   # persisted
+
+# 3. one-shot prompt against the default model
+synthpanel prompt "What do you think of the name Traitprint?"
+
+# 4. run a full panel and save the result
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument examples/survey.yaml \
+  --save
+
+# 5. render a shareable Markdown report from the saved result
+synthpanel report <result-id> -o report.md
+```
+
+More commands: `synthpanel pack calibrate` (calibrate a persona pack against a SynthBench baseline), `synthpanel instruments` (manage branching instrument packs), `synthpanel analyze` (statistics on saved results), `synthpanel cost` (spend summary), `synthpanel login` / `whoami` (credential management). Run `synthpanel --help` for the full list.
+
+Every `synthpanel report` output opens with a mandatory synthetic-panel banner — *“Synthetic panel. All responses below were generated by AI personas, not human respondents. Do not cite as user-research data.”* — so the rendered Markdown can’t be mistaken for real-user research. Markdown v1 only; HTML deferred to v2. See the [sp-viz-layer spec](https://github.com/DataViking-Tech/SynthPanel/tree/main/specs/sp-viz-layer).
+
+### [MCP server](/mcp)
+
+→
+
+Drop-in config for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop. 12 tools.
+
+### [PyPI](https://pypi.org/project/synthpanel/)
+
+→
+
+Pip-installable package. `pip install synthpanel`.
+
+### [GitHub](https://github.com/DataViking-Tech/SynthPanel)
+
+→
+
+Source, issues, and roadmap. MIT-licensed.
+
+### [SynthBench](https://synthbench.org)
+
+→
+
+Open benchmark for synthetic survey quality. See the leaderboard at synthbench.org.
+
+### [Recommended models](/recommended-models)
+
+→
+
+SynthBench-validated model picks by use case. Use `--best-model-for` to auto-select.
+
+Powered the [SynthBench](https://synthbench.org) public benchmark — independent, open evaluation of synthetic-respondent quality. Ensemble blending of 3 models hits SPS 0.90 (90% human parity) on the current [leaderboard](https://synthbench.org).
+
+## Further reading
+
+- [SynthPanel vs Synthetic Users vs FocusPanel.ai — when open-source MCP beats the SaaS →](/blog/synthpanel-vs-commercial-alternatives.html) 2026-04-15

--- a/site/mcp/index.md
+++ b/site/mcp/index.md
@@ -1,0 +1,250 @@
+# MCP Server — synthpanel · Run synthetic focus groups from your AI editor
+
+ MCP Server · stdio
+
+# synthpanel MCP server
+
+Give your AI coding assistant tool-call access to synthetic focus groups. Run panels, manage persona packs, and query saved results — straight from chat.
+
+Uses the [Model Context Protocol](https://modelcontextprotocol.io/) over stdio transport. Defaults to the `haiku` model for cheap, fast iterative use.
+
+$ pip install "synthpanel[mcp]"
+
+The `[mcp]` extra pulls in the MCP Python SDK required to launch the server.
+
+## Starting the server
+
+The server communicates over stdin/stdout using JSON-RPC. It is launched by your editor, not by you — but you can sanity-check the binary:
+
+$ synthpanel mcp-serve
+
+## Editor configuration
+
+Every editor uses the same underlying config shape — command, args, and environment. Pick yours:
+
+Claude Code recommended
+
+Easiest: add via the CLI. Works at user scope (all projects) or project scope (this repo only).
+
+```
+# user scope — available everywhere
+claude mcp add --scope user synth_panel -- synthpanel mcp-serve
+
+# or project scope — checked-in .mcp.json for this repo
+claude mcp add --scope project synth_panel -- synthpanel mcp-serve
+```
+
+Or edit `.mcp.json` in your project root directly:
+
+```
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Plugin alternative: `/plugin install synthpanel` adds the `/focus-group` skill alongside the MCP server.
+
+Cursor
+
+Project scope: `.cursor/mcp.json`. User scope: `~/.cursor/mcp.json`.
+
+```
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Windsurf
+
+Edit `~/.codeium/windsurf/mcp_config.json` (or use the Cascade → MCP settings panel).
+
+```
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+Zed
+
+Zed calls them *context servers*. Open `settings.json` (cmd-,) and merge this block:
+
+```
+{
+  "context_servers": {
+    "synth_panel": {
+      "command": {
+        "path": "synthpanel",
+        "args": ["mcp-serve"],
+        "env": { "ANTHROPIC_API_KEY": "sk-..." }
+      }
+    }
+  }
+}
+```
+
+Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `%APPDATA%\Claude\claude_desktop_config.json` on Windows, then restart the app.
+
+```
+{
+  "mcpServers": {
+    "synth_panel": {
+      "command": "synthpanel",
+      "args": ["mcp-serve"],
+      "env": { "ANTHROPIC_API_KEY": "sk-..." }
+    }
+  }
+}
+```
+
+If `synthpanel` is not on the desktop app's PATH, replace the `command` value with an absolute path (e.g. `/Users/you/.venv/bin/synthpanel`).
+
+Set whichever provider env var you want to use — `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `XAI_API_KEY`, or `GOOGLE_API_KEY`. Multiple keys can be set simultaneously; the model string picks the provider.
+
+## Tools (12)
+
+### Research tools
+
+| Tool | Description |
+|---|---|
+| `run_prompt` | Send a single prompt to an LLM. No personas required — the simplest tool for a quick research question. |
+| `run_panel` | Run a full synthetic focus group. Each persona answers all questions independently in parallel, followed by synthesis. Accepts inline `questions`, an inline `instrument` dict (v1/v2/v3), or an `instrument_pack` name. |
+| `run_quick_poll` | Single-question poll across personas. A simplified `run_panel` for one question with synthesis. |
+| `extend_panel` | Append a single ad-hoc round to a saved panel result. Reuses each panelist's saved session for conversational context. *Not* a re-entry into the v3 DAG — use for human-in-the-loop follow-ups. |
+
+### Persona pack management
+
+| Tool | Description |
+|---|---|
+| `list_persona_packs` | List all saved persona packs (bundled + user-saved). Returns ID, name, and persona count. |
+| `get_persona_pack` | Get a specific persona pack by ID — full definitions. |
+| `save_persona_pack` | Save a persona pack for reuse. Validates persona data before writing to disk. |
+
+### Instrument pack management
+
+| Tool | Description |
+|---|---|
+| `list_instrument_packs` | List installed instrument packs (bundled + user-saved) with manifest metadata. |
+| `get_instrument_pack` | Load an installed instrument pack by name — full YAML body. |
+| `save_instrument_pack` | Install an instrument pack. Validates via the parser before writing to disk. |
+
+### Result management
+
+| Tool | Description |
+|---|---|
+| `list_panel_results` | List saved panel results — ID, date, model, counts. |
+| `get_panel_result` | Get a specific panel result by ID — full result with all rounds and synthesis. |
+
+## Resources (4 URI patterns)
+
+MCP resources let agents read data without invoking a tool.
+
+| URI pattern | Description |
+|---|---|
+| `persona-pack://{pack_id}` | A specific persona pack. |
+| `persona-pack://` | List all persona packs. |
+| `panel-result://{result_id}` | A specific panel result. |
+| `panel-result://` | List all panel results. |
+
+## Prompt templates (3)
+
+Pre-built research workflows agents can use as starting points.
+
+| Prompt | Parameters | Description |
+|---|---|---|
+| `focus_group` | `topic` (required), `num_personas` (default 5), `follow_up` (default true) | Structured focus group discussion prompt for a given topic. |
+| `name_test` | `names` (required, comma-separated), `context` (optional) | Test product or feature name options with diverse perspectives. |
+| `concept_test` | `concept` (required), `target_audience` (optional) | Test a concept or idea with targeted personas. |
+
+## Response shape
+
+All panel runs (`run_panel`, `run_quick_poll`, `extend_panel`) return a uniform response:
+
+```
+{
+  "result_id": "result-20260410-...",
+  "model": "haiku",
+  "persona_count": 5,
+  "question_count": 3,
+  "rounds": [
+    {
+      "name": "discovery",
+      "results": [
+        {
+          "persona": "Sarah Chen",
+          "responses": ["..."],
+          "usage": { "input_tokens": 450, "output_tokens": 120 },
+          "cost": "$0.0012",
+          "error": null
+        }
+      ],
+      "synthesis": { "themes": [...], "summary": "..." }
+    }
+  ],
+  "path": [
+    { "round": "discovery", "branch": "themes contains price", "next": "probe_pricing" }
+  ],
+  "terminal_round": "probe_pricing",
+  "warnings": [],
+  "synthesis": { "themes": [...], "summary": "...", "recommendation": "..." },
+  "total_cost": "$0.0234",
+  "total_usage": { "input_tokens": 2250, "output_tokens": 600 },
+  "results": [...]
+}
+```
+
+- `rounds` — per-round results with panelist responses and per-round synthesis.
+
+- `path` — routing decisions that fired (v3 branching instruments).
+
+- `terminal_round` — the round whose synthesis fed final synthesis.
+
+- `warnings` — parser or runtime warnings.
+
+- `results` — back-compat flat array mirroring the terminal round's panelist results.
+
+For v1/v2 instruments and raw `questions` input, `path` is empty or linear and `warnings` is typically empty — the shape is uniform across versions.
+
+## Data storage
+
+Panel results, persona packs, and instrument packs are stored under `~/.synthpanel/` (configurable via `SYNTH_PANEL_DATA_DIR`):
+
+```
+~/.synthpanel/
+├── persona_packs/          # Saved persona packs (YAML)
+├── packs/instruments/      # Installed instrument packs (YAML)
+└── results/                # Panel results (JSON) + session data
+```
+
+## Next steps
+
+### [Source docs](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md)
+
+→
+
+The canonical `docs/mcp.md` in the GitHub repo.
+
+### [Report an issue](https://github.com/DataViking-Tech/SynthPanel)
+
+→
+
+Open an issue on GitHub if a tool misbehaves or an editor config needs a tweak.

--- a/site/recommended-models/index.md
+++ b/site/recommended-models/index.md
@@ -1,0 +1,107 @@
+# Recommended Models — synthpanel · SynthBench-validated model picks
+
+ Docs · Recommended Models
+
+# Recommended models
+
+SynthPanel can consult the [SynthBench](https://synthbench.org) public leaderboard to pick the best-ranked model for the kind of research you're running. This closes the credibility loop: scores measured on the bench drive defaults in the harness.
+
+## Quick start
+
+```
+# Use the top-ranked model for a specific topic
+synthpanel panel run \
+  --personas examples/personas.yaml \
+  --instrument pricing-discovery \
+  --best-model-for "Economy & Work"
+
+# Top-ranked model across a whole dataset (by SPS)
+synthpanel panel run ... --best-model-for ":globalopinionqa"
+
+# Topic within a non-default dataset
+synthpanel panel run ... --best-model-for "Technology & Digital Life:globalopinionqa"
+```
+
+Before the run, SynthPanel prints a recommendation line to stderr so you can cancel and override:
+
+```
+synthbench: best model for globalopinionqa/Economy & Work → claude-haiku-4-5-20251001 · SPS 0.850 · JSD 0.091 · n=100 · $0.032/100q · cached 0h ago · source=synthbench.org
+```
+
+## How it works
+
+- 1 On first use, SynthPanel fetches `https://synthbench.org/data/leaderboard.json` and caches it at `~/.synthpanel/synthbench-cache.json` for 24 hours.
+
+- 2 Entries are filtered to the requested `dataset` (default `globalopinionqa`), then ranked — by the named topic's score when a topic is given, otherwise by overall SPS.
+
+- 3 The top entry's `model` field is resolved through SynthPanel's alias table (so `"haiku"` becomes `claude-haiku-4-5-20251001`) and stamped onto `--model` for the rest of the pipeline.
+
+## Environment knobs
+
+| Variable | Effect |
+|---|---|
+| `SYNTHPANEL_SYNTHBENCH_URL` | Override the fetch URL (useful for forks or air-gapped environments). |
+| `SYNTHPANEL_SYNTHBENCH_OFFLINE=1` | Never hit the network; use the cache if present, otherwise skip the recommendation. |
+| `SYNTHPANEL_SYNTHBENCH_REFRESH=1` | Bypass the 24h TTL and force a fresh fetch (ignores the cached ETag). |
+| `SYNTH_PANEL_DATA_DIR` | Override the data dir where the cache lives. |
+
+## Graceful offline behaviour
+
+- **Stale cache + network error** → stderr warning, use stale cache.
+
+- **No cache + network error** → stderr "synthbench unavailable", fall through to whatever `--model` or default was already in effect.
+
+- **Empty entries after filter** → same fall-through.
+
+No recommendation is ever fatal. `--best-model-for` is advisory: a bad network day won't take the panel down.
+
+## Use-case → top-ranked model
+
+Snapshot from `leaderboard.json` on 2026-04-24. The live data updates continuously — consult the CLI flag or [synthbench.org](https://synthbench.org) for current picks.
+
+| Use case | Dataset | Top SynthBench pick |
+|---|---|---|
+| General attitudes research | `globalopinionqa` | `claude-haiku-4-5-20251001` |
+| Economic / workplace surveys | `globalopinionqa` | `claude-haiku-4-5-20251001` |
+| Tech product discovery | `globalopinionqa` | `gemini-2.5-flash` |
+| Health & science messaging | `globalopinionqa` | see `--best-model-for "Health & Science"` |
+| International affairs / policy | `globalopinionqa` | see CLI |
+| Trust & wellbeing | `globalopinionqa` | see CLI |
+
+## Caveats
+
+- **Ensembles & product configs.** Some leaderboard entries are SynthPanel product configs (`framework=product`, `is_ensemble=true`). These aren't runnable as a plain `--model` value, so SynthPanel falls back to the underlying base model inferred from the entry's `config_id`. A stderr note records the substitution.
+
+- **Sparse topics.** When the top entry's `run_count < 3`, a low-confidence warning is emitted. Treat those recommendations as suggestive rather than authoritative.
+
+- **Provider/model strings vary.** The leaderboard publishes the raw `model` string the run used — sometimes a canonical id, sometimes a short alias. SynthPanel passes the string through the alias resolver so either shape works, but the raw value is preserved in the recommendation line as `raw_model`.
+
+## Scoping
+
+`--best-model-for` picks a single model for the whole panel. It is mutually exclusive with `--models` (which splits the panel across multiple models) — mixing the two is rejected at parse time.
+
+## See also
+
+### [SynthBench leaderboard](https://synthbench.org)
+
+→
+
+Live model rankings at synthbench.org — updated continuously.
+
+### [MCP Server](/mcp)
+
+→
+
+Use `run_panel` from your AI editor with the top-ranked model.
+
+### [Source docs](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/recommended-models.md)
+
+→
+
+The canonical `docs/recommended-models.md` in the GitHub repo.
+
+### [Report an issue](https://github.com/DataViking-Tech/SynthPanel)
+
+→
+
+Open an issue on GitHub if something looks wrong.

--- a/tests/test_site_markdown.py
+++ b/tests/test_site_markdown.py
@@ -1,0 +1,277 @@
+"""Verify the ``Accept: text/markdown`` content-negotiation surface.
+
+Two surfaces under test:
+
+1. ``scripts/render_site_markdown.py`` — the converter that produces
+   ``site/**/*.md`` from each HTML page. Asserts (a) the converter
+   produces non-empty output for every page, (b) the committed ``.md``
+   matches a fresh render so contributors don't drift, and (c) basic
+   content checks (the install command, version-independent content).
+
+2. ``site/_worker.js`` — the Cloudflare Pages Advanced Mode worker.
+   Verified by re-implementing its routing logic in Python and checking
+   the JS file exposes the expected exports / handlers.
+
+The worker is JS, but the project has no JS toolchain. We treat the
+worker as a black-box file and assert structural properties that would
+break if a refactor lost the contract.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SITE_ROOT = REPO_ROOT / "site"
+WORKER_PATH = SITE_ROOT / "_worker.js"
+
+
+def _load_renderer():
+    spec = importlib.util.spec_from_file_location(
+        "render_site_markdown",
+        REPO_ROOT / "scripts" / "render_site_markdown.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["render_site_markdown"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _site_html_pages() -> list[Path]:
+    return [p for p in sorted(SITE_ROOT.rglob("*.html")) if not p.name.endswith(".j2")]
+
+
+# ---------------------------------------------------------------------------
+# Coverage: every HTML page has a markdown sibling
+# ---------------------------------------------------------------------------
+
+
+def test_every_html_page_has_markdown_rendition() -> None:
+    pages = _site_html_pages()
+    assert pages, "site/ has no HTML pages — has the layout changed?"
+    missing = [p for p in pages if not p.with_suffix(".md").exists()]
+    assert not missing, (
+        "Missing .md rendition for: "
+        + ", ".join(str(p.relative_to(REPO_ROOT)) for p in missing)
+        + "\nRun: python scripts/render_site_markdown.py"
+    )
+
+
+def test_committed_markdown_matches_fresh_render() -> None:
+    """Catch drift: edit HTML without re-running the markdown renderer."""
+    renderer = _load_renderer()
+    pages = _site_html_pages()
+    drifted: list[str] = []
+    for html_path in pages:
+        md_path = html_path.with_suffix(".md")
+        committed = md_path.read_text(encoding="utf-8")
+        title = renderer._extract_title(html_path.read_text(encoding="utf-8"))
+        fresh = renderer.html_to_markdown(html_path.read_text(encoding="utf-8"), title=title)
+        if committed != fresh:
+            drifted.append(str(md_path.relative_to(REPO_ROOT)))
+    assert not drifted, (
+        "Markdown renditions are out of sync with their HTML sources: "
+        + ", ".join(drifted)
+        + "\nRun: python scripts/render_site_markdown.py"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Converter unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_converter_strips_chrome() -> None:
+    renderer = _load_renderer()
+    html = """
+    <html><head><title>Page</title><script>alert(1)</script>
+    <style>body{color:red}</style></head><body>
+    <nav>nav text</nav>
+    <main><h1>Hello</h1><p>World.</p></main>
+    <footer>foot text</footer>
+    <script>noisy()</script>
+    </body></html>
+    """
+    md = renderer.html_to_markdown(html, title="Page")
+    assert "alert(1)" not in md
+    assert "body{color:red}" not in md
+    assert "nav text" not in md
+    assert "foot text" not in md
+    assert "# Hello" in md
+    assert "World." in md
+
+
+def test_converter_preserves_code_blocks() -> None:
+    renderer = _load_renderer()
+    html = "<main><pre><code>pip install synthpanel</code></pre></main>"
+    md = renderer.html_to_markdown(html)
+    assert "```" in md
+    assert "pip install synthpanel" in md
+
+
+def test_converter_renders_tables() -> None:
+    renderer = _load_renderer()
+    html = """
+    <main>
+    <table>
+      <tr><th>Var</th><th>Effect</th></tr>
+      <tr><td>FOO</td><td>does foo</td></tr>
+      <tr><td>BAR</td><td>does bar</td></tr>
+    </table>
+    </main>
+    """
+    md = renderer.html_to_markdown(html)
+    assert "| Var | Effect |" in md
+    assert "|---|---|" in md
+    assert "| FOO | does foo |" in md
+
+
+def test_converter_skips_aria_hidden() -> None:
+    renderer = _load_renderer()
+    html = '<main><p>Open <span aria-hidden="true">→</span> link</p></main>'
+    md = renderer.html_to_markdown(html)
+    assert "→" not in md
+    assert "Open" in md and "link" in md
+
+
+def test_converter_attaches_link_to_card_heading() -> None:
+    """Card pattern: <a href><h3>title</h3><p>desc</p></a> renders as
+    a markdown heading whose text is the link."""
+    renderer = _load_renderer()
+    html = (
+        '<main><a href="/mcp"><div><h3>MCP server</h3>'
+        '<span aria-hidden="true">→</span></div>'
+        "<p>Drop-in config.</p></a></main>"
+    )
+    md = renderer.html_to_markdown(html)
+    assert "### [MCP server](/mcp)" in md
+    assert "Drop-in config." in md
+
+
+def test_landing_page_markdown_has_install_command() -> None:
+    """Smoke check: the most important content survives conversion."""
+    md = (SITE_ROOT / "index.md").read_text(encoding="utf-8")
+    assert "pip install synthpanel" in md
+    assert "synthpanel" in md
+    assert "MCP" in md or "mcp" in md
+
+
+def test_landing_page_markdown_drops_chrome() -> None:
+    md = (SITE_ROOT / "index.md").read_text(encoding="utf-8")
+    # No leaked CSS / JS.
+    assert "<script" not in md
+    assert "tailwind" not in md.lower()
+    # No unprocessed HTML attributes.
+    assert "class=" not in md
+    assert "data-copy" not in md
+
+
+# ---------------------------------------------------------------------------
+# Worker contract — port the routing logic to Python and assert
+# behaviour on representative inputs.
+# ---------------------------------------------------------------------------
+
+
+def _prefers_markdown(accept: str) -> bool:
+    """Python port of ``prefersMarkdown`` in site/_worker.js."""
+    if not accept:
+        return False
+    md_q = -1.0
+    best_other_q = -1.0
+    for raw in accept.split(","):
+        part = raw.strip()
+        if not part:
+            continue
+        segments = [s.strip() for s in part.split(";")]
+        type_ = segments[0].lower()
+        q = 1.0
+        for seg in segments[1:]:
+            if seg.startswith("q="):
+                with contextlib.suppress(ValueError):
+                    q = float(seg[2:])
+        if q <= 0:
+            continue
+        if type_ == "text/markdown":
+            md_q = max(md_q, q)
+        elif type_ not in ("*/*", "text/*"):
+            best_other_q = max(best_other_q, q)
+    if md_q < 0:
+        return False
+    return md_q >= best_other_q
+
+
+def _html_path_to_markdown(path: str) -> str | None:
+    """Python port of ``htmlPathToMarkdown`` in site/_worker.js."""
+    if not path:
+        return None
+    if path.endswith("/"):
+        return path + "index.md"
+    if path.endswith(".html"):
+        return path[:-5] + ".md"
+    last = path.split("/")[-1]
+    if "." in last:
+        return None
+    return path + "/index.md"
+
+
+def test_prefers_markdown_explicit() -> None:
+    assert _prefers_markdown("text/markdown")
+    assert _prefers_markdown("text/markdown, */*; q=0.1")
+    assert _prefers_markdown("text/html;q=0.5, text/markdown;q=1.0")
+
+
+def test_prefers_markdown_rejects_browsers() -> None:
+    # Default browser Accept header — must NOT trigger markdown.
+    assert not _prefers_markdown("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+    assert not _prefers_markdown("*/*")
+    assert not _prefers_markdown("")
+
+
+def test_prefers_markdown_zero_q() -> None:
+    # ``q=0`` is a refusal; explicit refusal of markdown means false.
+    assert not _prefers_markdown("text/markdown;q=0, text/html")
+
+
+def test_html_path_to_markdown_mappings() -> None:
+    assert _html_path_to_markdown("/") == "/index.md"
+    assert _html_path_to_markdown("/recommended-models/") == "/recommended-models/index.md"
+    assert _html_path_to_markdown("/recommended-models") == "/recommended-models/index.md"
+    assert _html_path_to_markdown("/blog/post.html") == "/blog/post.md"
+    assert _html_path_to_markdown("/og-image.png") is None
+    assert _html_path_to_markdown("/sitemap.xml") is None
+
+
+# ---------------------------------------------------------------------------
+# Worker file shape
+# ---------------------------------------------------------------------------
+
+
+def test_worker_file_exists_and_exports_default() -> None:
+    assert WORKER_PATH.exists(), "site/_worker.js missing"
+    src = WORKER_PATH.read_text(encoding="utf-8")
+    assert re.search(r"export\s+default\s*\{", src), (
+        "site/_worker.js must export a default object with a fetch() handler"
+    )
+    assert "async fetch(" in src or "fetch:" in src, "site/_worker.js default export must define fetch()"
+
+
+def test_worker_sets_required_response_headers() -> None:
+    src = WORKER_PATH.read_text(encoding="utf-8")
+    # The 200-path must set these three headers — they are the
+    # contract the bead specifies (content-type + token count) plus the
+    # cache directive that prevents misnegotiated responses.
+    assert "text/markdown; charset=utf-8" in src, "Content-Type not set"
+    assert '"vary"' in src.lower() or '"Vary"' in src, "Vary header not set"
+    assert "x-markdown-tokens" in src, "x-markdown-tokens header not set"
+
+
+def test_worker_returns_406_when_no_markdown_rendition() -> None:
+    """Encode the contract: missing .md -> 406 Not Acceptable."""
+    src = WORKER_PATH.read_text(encoding="utf-8")
+    assert "406" in src, "Worker must return 406 when no rendition exists"
+    assert "not_acceptable" in src or "Not Acceptable" in src


### PR DESCRIPTION
## Summary

Implements AR-2 (Markdown for Agents) by honoring `Accept: text/markdown` on synthpanel.dev. AI agents that prefer structured markdown over rendered HTML now receive a token-efficient rendition; browsers continue to receive HTML unchanged. Negotiation is strict opt-in — only an explicit `text/markdown` Accept value triggers it, never `*/*` or `text/*` — and responses include `Vary: Accept` so caches respect the negotiation. Paths without a markdown rendition return 406.

## Changes

- `site/_worker.js`: Cloudflare Pages Advanced-Mode worker. Parses Accept, routes negotiated requests to `.md` siblings, sets `Content-Type: text/markdown; charset=utf-8`, `Vary: Accept`, and `x-markdown-tokens` (chars/4 approximation); falls through to static HTML otherwise.
- `scripts/render_site_markdown.py`: stdlib-only Python converter that walks `site/**/*.html` and emits matching `.md` files. Strips chrome (head/script/style/nav/footer/aria-hidden), preserves headings, lists, tables, code blocks, and links, and attaches link hrefs to card-grid headings.
- `site/index.md`, `site/mcp/index.md`, `site/recommended-models/index.md`, `site/docs/calibration/index.md`, `site/docs/panel-run/index.md`, `site/blog/synthpanel-vs-commercial-alternatives.md`: committed renditions for every public HTML page.
- `site/_headers`: adds `Vary: Accept` and pins `text/markdown` content-type for direct `.md` fetches.
- `docs/cloudflare-pages-setup.md`: operational notes including curl verification and the editing checklist (re-run renderer when HTML changes).

## Test plan

- `tests/test_site_markdown.py`: coverage check that every HTML page has a markdown sibling; drift guard that committed `.md` matches a fresh render; converter unit tests; and a Python port of the worker's routing/Accept-parsing logic so the contract is testable without a JS toolchain.

## References

- Spec: build-plan.md (sp-v1-0-0-contract) / agentready_feedback.md
- Cloudflare "Markdown for Agents"; SKILL: https://isitagentready.com/.well-known/agent-skills/markdown-negotiation/SKILL.md
- Bead: sy-ifw

Closes #413
