### PR TITLE
mcp: wire validate_response into server egress (sy-83b)

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -123,6 +123,7 @@ from synth_panel.orchestrator import (
     run_panel_parallel,
 )
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
+from synth_panel.structured.validate import apply_response_gate
 from synth_panel.synthesis import synthesize_panel
 
 logger = logging.getLogger(__name__)
@@ -1153,7 +1154,7 @@ async def run_panel(
                 temperature=temperature,
                 hint=decision.hint,
             )
-            return json.dumps(sampling_result, indent=2)
+            return json.dumps(apply_response_gate(sampling_result), indent=2)
 
     # ── Ensemble mode: run with each model, compare across models ────────
     if models and len(models) >= 2:
@@ -1192,7 +1193,7 @@ async def run_panel(
                 },
                 indent=2,
             )
-        return json.dumps(ens_result, indent=2)
+        return json.dumps(apply_response_gate(ens_result), indent=2)
 
     # Resolve instrument source (pack > inline instrument > questions).
     instrument_obj: Instrument | None = None
@@ -1231,7 +1232,7 @@ async def run_panel(
                 },
                 indent=2,
             )
-        return json.dumps(result, indent=2)
+        return json.dumps(apply_response_gate(result), indent=2)
 
     if not questions:
         return json.dumps({"error": "No questions or instrument provided."})
@@ -1263,7 +1264,7 @@ async def run_panel(
             },
             indent=2,
         )
-    return json.dumps(result, indent=2)
+    return json.dumps(apply_response_gate(result), indent=2)
 
 
 @mcp.tool()
@@ -1392,7 +1393,7 @@ async def run_quick_poll(
             temperature=temperature,
             hint=decision.hint,
         )
-        return json.dumps(result, indent=2)
+        return json.dumps(apply_response_gate(result), indent=2)
 
     questions = [{"text": question}]
     result = await _run_panel_async(
@@ -1408,7 +1409,7 @@ async def run_quick_poll(
         top_p=top_p,
     )
     result["mode"] = "byok"
-    return json.dumps(result, indent=2)
+    return json.dumps(apply_response_gate(result), indent=2)
 
 
 async def _run_panel_sampling(
@@ -1851,7 +1852,7 @@ async def extend_panel(
         # sp-0ozi: top-level synthesis_error so MCP clients can gate on
         # envelope shape without inspecting the appended round.
         response["synthesis_error"] = synthesis_error
-    return json.dumps(response, indent=2)
+    return json.dumps(apply_response_gate(response), indent=2)
 
 
 @mcp.tool()

--- a/src/synth_panel/structured/validate.py
+++ b/src/synth_panel/structured/validate.py
@@ -10,7 +10,9 @@ fragment-level rules expressed in the v1.0.0 schema (decision_being_informed
 shape, panel_verdict required fields, flag/severity enum membership). Tool
 wiring lives elsewhere — AC-3 plugs ``validate_request`` into the MCP
 ``run_panel`` / ``run_quick_poll`` / ``extend_panel`` handlers, and AC-9
-plugs ``validate_response`` into the response gate.
+plugs :func:`apply_response_gate` (which calls :func:`validate_response`)
+into the MCP response path so no v1.0.0 ``panel_verdict`` artifact can
+leave the server unvalidated.
 """
 
 from __future__ import annotations
@@ -230,4 +232,38 @@ def validate_response(artifact: dict[str, Any]) -> ErrorEnvelope | None:
     return None
 
 
-__all__ = ["ErrorEnvelope", "validate_request", "validate_response"]
+def apply_response_gate(artifact: Any) -> Any:
+    """AC-9 response gate — final validation before egress.
+
+    Treats *artifact* as a v1.0.0 ``panel_verdict`` candidate iff it is a
+    ``dict`` carrying a ``schema_version`` key. In that case
+    :func:`validate_response` runs and, on failure, the artifact is
+    replaced with the typed error envelope dict. Conformant artifacts
+    are returned unchanged (same identity).
+
+    Anything else — non-dicts, dicts without ``schema_version`` (legacy
+    pre-contract MCP shapes such as ``{"results": [...], ...}``) — passes
+    through untouched. The contract is enforced exactly where it claims
+    to apply, without regressing shipped clients that still consume the
+    pre-v1.0.0 response envelope.
+
+    The gate is the single MCP egress chokepoint for the v1.0.0
+    contract; treat every ``return json.dumps(...)`` site that may carry
+    a panel_verdict as a place to call this function.
+    """
+    if not isinstance(artifact, dict):
+        return artifact
+    if "schema_version" not in artifact:
+        return artifact
+    err = validate_response(artifact)
+    if err is None:
+        return artifact
+    return err.to_dict()
+
+
+__all__ = [
+    "ErrorEnvelope",
+    "apply_response_gate",
+    "validate_request",
+    "validate_response",
+]

--- a/tests/mcp/test_response_gate.py
+++ b/tests/mcp/test_response_gate.py
@@ -1,0 +1,172 @@
+"""AC-9: response-side gate.
+
+The MCP server must run :func:`validate_response` over every artifact that
+claims to be a v1.0.0 ``panel_verdict`` (i.e. carries ``schema_version``)
+before that artifact leaves the server. Bogus flag codes, missing required
+fields, or schema-version drift are swapped for the typed error envelope
+on egress; nothing non-conformant escapes.
+
+The gate is intentionally a no-op for legacy, non-verdict return shapes
+(``{"results": [...], ...}`` etc.) so the contract is enforced without
+breaking pre-contract callers.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+@pytest.fixture(autouse=True)
+def _data_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-placeholder")
+
+
+from synth_panel.mcp.server import mcp
+from synth_panel.structured.validate import apply_response_gate
+
+_VALID_DECISION = "choosing launch tier price"
+
+
+def _verdict(**overrides):
+    base = {
+        "headline": "Cohort splits on $79; price is the dominant objection.",
+        "convergence": 0.62,
+        "dissent_count": 1,
+        "top_3_verbatims": [],
+        "flags": [{"code": "low_convergence", "severity": "warn"}],
+        "extension": [],
+        "full_transcript_uri": "panel-result://abc",
+        "meta": {"decision_being_informed": _VALID_DECISION},
+        "schema_version": "1.0.0",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Unit-level: the gate helper itself
+# ---------------------------------------------------------------------------
+
+
+def test_gate_passes_through_non_verdict_payload() -> None:
+    """Legacy MCP shapes (no ``schema_version``) must traverse the gate
+    unchanged. The gate triggers only on artifacts claiming to be v1.0.0
+    ``panel_verdict``s; everything else is the contract's responsibility-
+    free zone."""
+    legacy = {"results": [], "result_id": "abc", "warnings": []}
+    assert apply_response_gate(legacy) is legacy
+
+
+def test_gate_passes_through_valid_verdict() -> None:
+    artifact = _verdict()
+    assert apply_response_gate(artifact) is artifact
+
+
+def test_gate_blocks_invalid_flag() -> None:
+    """A flag code outside the closed enum is rejected; the gate replaces
+    the artifact with the typed error envelope dict."""
+    artifact = _verdict(flags=[{"code": "totally_made_up", "severity": "warn"}])
+    out = apply_response_gate(artifact)
+    assert out is not artifact
+    assert out["error_code"] == "INVALID_FLAG"
+    assert out["field_path"] == "flags[0].code"
+    assert out["schema_version"] == "1.0.0"
+    assert out["retry_safe"] is False
+
+
+def test_gate_blocks_schema_version_drift() -> None:
+    artifact = _verdict(schema_version="0.12.0")
+    out = apply_response_gate(artifact)
+    assert out["error_code"] == "SCHEMA_DRIFT"
+    assert out["field_path"] == "schema_version"
+    assert out["retry_safe"] is False
+
+
+def test_gate_blocks_missing_required_field() -> None:
+    artifact = _verdict()
+    del artifact["headline"]
+    out = apply_response_gate(artifact)
+    assert out["error_code"] == "SCHEMA_DRIFT"
+    assert out["field_path"] == "headline"
+    assert out["retry_safe"] is False
+
+
+# ---------------------------------------------------------------------------
+# Integration: the gate is wired into the MCP run_panel return path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_flag_blocks_egress() -> None:
+    """End-to-end: when the panel runner produces a panel_verdict carrying
+    a flag outside the closed enum, the MCP egress yields the typed
+    INVALID_FLAG envelope, not the malformed artifact.
+
+    This is the AC-9 contract: ``validate_response`` runs at the response
+    boundary; non-conformant artifacts can never reach the caller.
+    """
+    bad = _verdict(flags=[{"code": "totally_made_up", "severity": "warn"}])
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = bad
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "How do you feel?"}],
+            },
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data["error_code"] == "INVALID_FLAG"
+    assert data["field_path"] == "flags[0].code"
+    assert data["schema_version"] == "1.0.0"
+    assert data["retry_safe"] is False
+    # The malformed verdict's headline must NOT have escaped the boundary.
+    assert "headline" not in data
+
+
+@pytest.mark.asyncio
+async def test_valid_verdict_passes_egress_unchanged() -> None:
+    """A conformant panel_verdict traverses the gate intact: same flags,
+    same headline, same schema_version. The gate must not mutate or
+    repackage successful artifacts."""
+    good = _verdict()
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = good
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "How do you feel?"}],
+            },
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data["schema_version"] == "1.0.0"
+    assert data["headline"] == good["headline"]
+    assert data["flags"] == good["flags"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_shape_unaffected() -> None:
+    """Pre-contract MCP responses (no ``schema_version``) must still flow
+    through unchanged so the AC-9 wiring doesn't regress shipped clients."""
+    legacy = {"results": [], "result_id": "xyz", "warnings": []}
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = legacy
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "How do you feel?"}],
+            },
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data == legacy

--- a/tests/test_mcp_stdio_sampling.py
+++ b/tests/test_mcp_stdio_sampling.py
@@ -26,7 +26,6 @@ import pytest
 
 pytest.importorskip("mcp")
 
-from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.shared.context import RequestContext
 from mcp.types import (
@@ -34,6 +33,8 @@ from mcp.types import (
     CreateMessageResult,
     TextContent,
 )
+
+from mcp import ClientSession, StdioServerParameters
 
 
 def _server_env() -> dict[str, str]:


### PR DESCRIPTION
## Summary

AC-9 response gate. `apply_response_gate` runs `validate_response` on every panel-class artifact leaving `run_panel` / `run_quick_poll` / `extend_panel`. v1.0.0 `panel_verdict` candidates (anything carrying `schema_version`) that fail validation are swapped for the typed error envelope; legacy shapes without `schema_version` pass through untouched so pre-contract callers keep their existing response envelope. No malformed contract artifact can reach the caller.

## Changes

- `src/synth_panel/mcp/server.py`: Wire `apply_response_gate` into the egress path of every panel-class MCP tool.
- `src/synth_panel/structured/validate.py`: Extend `validate_response` to detect `schema_version` and gate v1.0.0 `panel_verdict` artifacts; legacy shapes without `schema_version` short-circuit untouched.
- `tests/mcp/test_response_gate.py`: New file. Coverage for the gate — valid v1.0.0 verdicts pass, invalid v1.0.0 verdicts are swapped for the typed error envelope, legacy responses bypass, and the gate is invoked on each of the three panel-class tools.
- `tests/mcp/__init__.py`: Package marker for the new MCP test directory.

## Test plan

- `tests/mcp/test_response_gate.py`: covers AC-9 — schema-versioned outputs are validated, invalid ones are replaced with the typed error envelope, legacy outputs pass through.
- Wider suite continues to validate the underlying `validate_response` and panel-tool surfaces.

## References

- Bead: sy-83b
- Spec: AC-9 response gate (egress validation for panel-class MCP tools)
