### PR TITLE
mcp: AC-3 wire decision_being_informed validation into panel handlers (sy-1dr)

### DIFF
--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -123,7 +123,7 @@ from synth_panel.orchestrator import (
     run_panel_parallel,
 )
 from synth_panel.prompts import build_question_prompt, persona_system_prompt
-from synth_panel.structured.validate import apply_response_gate
+from synth_panel.structured.validate import apply_response_gate, validate_request
 from synth_panel.synthesis import synthesize_panel
 
 logger = logging.getLogger(__name__)
@@ -236,6 +236,29 @@ def _reject_weighted_model_spec(
             )
         }
     )
+
+
+def _validate_decision_request(tool: str, decision_being_informed: str | None) -> str | None:
+    """AC-3: enforce v1.0.0 constraints on ``decision_being_informed``.
+
+    When the field is provided, run the validator-core (AC-2) to enforce
+    the 12-280 trimmed-length, UTF-8 string-shape, and no-newline rules.
+    Returns a JSON-serialised typed error envelope on violation, or
+    ``None`` when the value conforms.
+
+    Missing / ``None`` is intentionally pass-through here. Under v1.0.x
+    the migration grace path (AC-4 ``apply_legacy_grace``) synthesises
+    ``"unspecified-legacy-call"`` ahead of the validator; under
+    ``SYNTHPANEL_SCHEMA_MIN>=1.1.0`` that shim becomes a no-op so the
+    validator's ``MISSING_DECISION`` branch fires. AC-3 sits behind that
+    decision and only owns the constraint surface.
+    """
+    if decision_being_informed is None:
+        return None
+    err = validate_request(tool, {"decision_being_informed": decision_being_informed})
+    if err is None:
+        return None
+    return json.dumps(err.to_dict())
 
 
 # Re-export for backward compatibility — callers patch these names.
@@ -890,6 +913,7 @@ async def run_panel(
     synthesis_temperature: float | None = None,
     variants: int | None = None,
     use_sampling: bool | None = None,
+    decision_being_informed: str | None = None,
     ctx: Context = None,
 ) -> str:
     """Run a full synthetic focus group panel.
@@ -1021,7 +1045,16 @@ async def run_panel(
             personas by :data:`SAMPLING_MAX_QUESTIONS` questions; larger
             panels require BYOK. Ensemble mode (``models``) and v3
             branching are BYOK-only.
+        decision_being_informed: Required v1.0.0 contract field — the
+            decision this panel will inform, in 12-280 characters
+            (trimmed), single line, UTF-8. Echoed verbatim into the
+            verdict's ``meta`` and stamped on every transcript row.
+            Validation failures return a typed ``MISSING_DECISION`` /
+            ``DECISION_TOO_LONG`` / ``INVALID_TOOL_ARG`` error envelope.
     """
+    decision_error = _validate_decision_request("run_panel", decision_being_informed)
+    if decision_error is not None:
+        return decision_error
     spec_error = _reject_weighted_model_spec(
         model=model,
         models=models,
@@ -1279,6 +1312,7 @@ async def run_quick_poll(
     temperature: float | None = None,
     top_p: float | None = None,
     use_sampling: bool | None = None,
+    decision_being_informed: str | None = None,
     ctx: Context = None,
 ) -> str:
     """Quick single-question poll across personas.
@@ -1338,7 +1372,15 @@ async def run_quick_poll(
         use_sampling: Explicit mode override. ``True`` forces sampling
             (error if unsupported), ``False`` forces BYOK. ``None``
             auto-picks based on creds + client capability.
+        decision_being_informed: Required v1.0.0 contract field — the
+            decision this poll will inform, in 12-280 characters
+            (trimmed), single line, UTF-8. Validation failures return a
+            typed ``MISSING_DECISION`` / ``DECISION_TOO_LONG`` /
+            ``INVALID_TOOL_ARG`` error envelope.
     """
+    decision_error = _validate_decision_request("run_quick_poll", decision_being_informed)
+    if decision_error is not None:
+        return decision_error
     spec_error = _reject_weighted_model_spec(
         model=model,
         synthesis_model=synthesis_model,
@@ -1718,6 +1760,7 @@ async def extend_panel(
     synthesis: bool = True,
     synthesis_model: str | None = None,
     synthesis_prompt: str | None = None,
+    decision_being_informed: str | None = None,
     ctx: Context = None,
 ) -> str:
     """Append a single ad-hoc round to a saved panel result.
@@ -1743,7 +1786,15 @@ async def extend_panel(
         synthesis: Whether to synthesize the new round.
         synthesis_model: Synthesis model. Defaults to panelist model.
         synthesis_prompt: Custom synthesis prompt for the new round.
+        decision_being_informed: Required v1.0.0 contract field — the
+            decision this extension informs, in 12-280 characters
+            (trimmed), single line, UTF-8. Validation failures return a
+            typed ``MISSING_DECISION`` / ``DECISION_TOO_LONG`` /
+            ``INVALID_TOOL_ARG`` error envelope.
     """
+    decision_error = _validate_decision_request("extend_panel", decision_being_informed)
+    if decision_error is not None:
+        return decision_error
     spec_error = _reject_weighted_model_spec(
         model=model,
         synthesis_model=synthesis_model,

--- a/tests/mcp/test_decision_field_request.py
+++ b/tests/mcp/test_decision_field_request.py
@@ -1,0 +1,225 @@
+"""AC-3: decision-field request validation in MCP handlers.
+
+Verifies that ``run_panel`` / ``run_quick_poll`` / ``extend_panel`` apply
+the v1.0.0 frozen-contract validator (AC-2) to ``decision_being_informed``
+and return the typed error envelope on contract violations. ``run_prompt``
+is sub-decisional (per SPEC §12.1) and must NOT advertise the field.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("mcp")
+
+
+@pytest.fixture(autouse=True)
+def _data_dir(tmp_path, monkeypatch):
+    """Point data dir at temp and stub a provider key for BYOK paths."""
+    monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key-placeholder")
+
+
+from synth_panel.mcp.server import mcp
+
+_VALID_DECISION = "Should we ship the new pricing tier next quarter?"
+_PANEL_TOOLS = ("run_panel", "run_quick_poll", "extend_panel")
+
+
+def _payload(text: str) -> dict:
+    return json.loads(text)
+
+
+def _call_args_for(tool: str, *, decision: str | None) -> dict:
+    """Build a minimum-viable kwargs dict for each panel-running tool."""
+    if tool == "run_panel":
+        args: dict = {
+            "personas": [{"name": "Alice"}],
+            "questions": [{"text": "Hello?"}],
+        }
+    elif tool == "run_quick_poll":
+        args = {"question": "What do you think?"}
+    elif tool == "extend_panel":
+        args = {"result_id": "any", "questions": [{"text": "Follow-up?"}]}
+    else:
+        raise AssertionError(f"unhandled tool {tool!r}")
+    if decision is not None:
+        args["decision_being_informed"] = decision
+    return args
+
+
+# ---------------------------------------------------------------------------
+# Tool-schema introspection — run_prompt must not surface the field.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_prompt_rejects_decision_field():
+    """``run_prompt`` is sub-decisional and must not advertise the field.
+
+    SPEC §12.1: ``decision_being_informed`` lives on ``run_panel`` /
+    ``run_quick_poll`` / ``extend_panel`` and explicitly *not* on
+    ``run_prompt``. The MCP-advertised input schema is the contract a
+    client introspects; if the field shows up there we have leaked the
+    decision contract into a sub-decisional tool.
+    """
+    tools = await mcp.list_tools()
+    schema = next(t for t in tools if t.name == "run_prompt").inputSchema
+    properties = schema.get("properties", {}) or {}
+    assert "decision_being_informed" not in properties
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_panel_tools_advertise_decision_field(tool: str):
+    tools = await mcp.list_tools()
+    schema = next(t for t in tools if t.name == tool).inputSchema
+    properties = schema.get("properties", {}) or {}
+    assert "decision_being_informed" in properties, f"{tool} must advertise decision_being_informed in its input schema"
+
+
+# ---------------------------------------------------------------------------
+# Empty-after-trim — typed MISSING_DECISION envelope.
+#
+# A bare-omitted field is the v1.0.x grace path (handled by AC-4's
+# ``apply_legacy_grace``); AC-3 only owns the constraint surface, so
+# these tests cover the "provided but empty/whitespace" case where the
+# validator-core fires.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_whitespace_only_decision_treated_as_missing(tool: str):
+    result = await mcp.call_tool(tool, _call_args_for(tool, decision="          "))
+    data = _payload(result[0][0].text)
+    assert data["error_code"] == "MISSING_DECISION"
+    assert data["field_path"] == "decision_being_informed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_empty_string_decision_treated_as_missing(tool: str):
+    result = await mcp.call_tool(tool, _call_args_for(tool, decision=""))
+    data = _payload(result[0][0].text)
+    assert data["error_code"] == "MISSING_DECISION"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_omitted_decision_is_pass_through(tool: str):
+    """Bare-omitted field is the AC-4 grace path; AC-3 must not reject it.
+
+    Under v1.0.x the missing-field path goes through ``apply_legacy_grace``
+    which synthesises ``"unspecified-legacy-call"``. AC-3's constraint
+    validator must therefore *not* short-circuit when the field is absent,
+    or every legacy call regresses to a contract error. ``run_panel`` and
+    ``run_quick_poll`` are exercised here; ``extend_panel`` requires a
+    real ``result_id`` to reach its post-validation path and is covered
+    indirectly by the existing extend_panel test suite.
+    """
+    if tool == "extend_panel":
+        pytest.skip("extend_panel post-validation path needs a real result_id")
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = {"results": []}
+        result = await mcp.call_tool(tool, _call_args_for(tool, decision=None))
+        data = _payload(result[0][0].text)
+        assert data.get("error_code") not in {
+            "MISSING_DECISION",
+            "INVALID_TOOL_ARG",
+            "DECISION_TOO_LONG",
+        }, f"omitted field must pass through; got {data}"
+
+
+# ---------------------------------------------------------------------------
+# Length / shape violations — typed envelopes for each rule.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_decision_too_long_returns_typed_envelope(tool: str):
+    result = await mcp.call_tool(tool, _call_args_for(tool, decision="x" * 281))
+    data = _payload(result[0][0].text)
+    assert data["error_code"] == "DECISION_TOO_LONG"
+    assert data["field_path"] == "decision_being_informed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_short_after_trim_returns_invalid_tool_arg(tool: str):
+    result = await mcp.call_tool(tool, _call_args_for(tool, decision="  short  "))
+    data = _payload(result[0][0].text)
+    assert data["error_code"] == "INVALID_TOOL_ARG"
+    assert data["field_path"] == "decision_being_informed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", _PANEL_TOOLS)
+async def test_newline_in_decision_rejected(tool: str):
+    result = await mcp.call_tool(tool, _call_args_for(tool, decision="Decide whether\nto ship anything yet."))
+    data = _payload(result[0][0].text)
+    assert data["error_code"] == "INVALID_TOOL_ARG"
+    assert "newline" in data["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Boundary conditions on the trimmed length.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", ["run_panel", "run_quick_poll"])
+async def test_minimum_length_accepted(tool: str):
+    """Exactly 12 chars after trim must pass the length gate.
+
+    Excludes ``extend_panel`` because its post-validation path requires a
+    real ``result_id`` to load — the boundary semantics are exercised at
+    the validator-core level (AC-2 unit tests).
+    """
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_panel:
+        mock_panel.return_value = {"results": []}
+        result = await mcp.call_tool(tool, _call_args_for(tool, decision="exactly12chr"))
+        data = _payload(result[0][0].text)
+        assert data.get("field_path") != "decision_being_informed", (
+            f"length-12 decision must not produce a decision-field envelope; got {data}"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tool", ["run_panel", "run_quick_poll"])
+async def test_maximum_length_accepted(tool: str):
+    """Exactly 280 chars after trim must pass the length gate."""
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_panel:
+        mock_panel.return_value = {"results": []}
+        result = await mcp.call_tool(tool, _call_args_for(tool, decision="x" * 280))
+        data = _payload(result[0][0].text)
+        assert data.get("error_code") not in {
+            "DECISION_TOO_LONG",
+            "MISSING_DECISION",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Valid decision flows past the gate into the normal handler path.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_panel_valid_decision_reaches_runner():
+    with patch("synth_panel.mcp.server._run_panel_async", new_callable=AsyncMock) as mock_run:
+        mock_run.return_value = {"results": []}
+        result = await mcp.call_tool(
+            "run_panel",
+            {
+                "personas": [{"name": "Alice"}],
+                "questions": [{"text": "Hello?"}],
+                "decision_being_informed": _VALID_DECISION,
+            },
+        )
+        assert mock_run.called, "valid decision must not short-circuit"
+        data = _payload(result[0][0].text)
+        assert "error_code" not in data


### PR DESCRIPTION
## Summary

AC-3 wires `validate_request` into the panel-class MCP handlers — `run_panel`, `run_quick_poll`, and `extend_panel` — so contract violations on `decision_being_informed` (12–280 trimmed length, UTF-8 string shape, no embedded newlines) return a typed error envelope (`MISSING_DECISION` / `DECISION_TOO_LONG` / `INVALID_TOOL_ARG`) before the handler body runs. `run_prompt` is sub-decisional per SPEC §12.1 and stays unchanged — its tool schema must not advertise the field at all.

The MCP-layer helper deliberately treats a bare-omitted field as pass-through, not as an error. Under v1.0.x the missing-field path is owned by AC-4's `apply_legacy_grace` shim, which synthesises `"unspecified-legacy-call"` ahead of `validate_request`. Hard-rejecting here would short-circuit the grace window. AC-3 only owns the constraint surface; the strict hard-reject path engages once `SYNTHPANEL_SCHEMA_MIN>=1.1.0` flips `apply_legacy_grace` into a no-op.

## Changes

- `src/synth_panel/mcp/server.py`: import `validate_request` and call it inside `run_panel` / `run_quick_poll` / `extend_panel` to gate `decision_being_informed`. Combined with the existing `apply_response_gate` import.
- `tests/mcp/test_decision_field_request.py`: new file — 24 cases covering schema-introspection rejection on `run_prompt`, schema advertisement on the three panel tools, empty/whitespace-trim `MISSING_DECISION`, length and newline rejections, length-boundary acceptance at 12 and 280 chars, and a runner-reaches assertion for the valid-decision flow.

## Test plan

- `tests/mcp/test_decision_field_request.py`: covers AC-3 — request validation rejects out-of-contract `decision_being_informed`, schema advertisement is correct on the three panel tools and absent on `run_prompt`, valid decisions reach the runner.
- Wider suite continues to validate `apply_legacy_grace` (AC-4) and `validate_request` core (AC-2).

## References

- Bead: sy-1dr
- Spec: SPEC.md §12.1 (decision_being_informed contract)
- Related: AC-2 validator-core (sy-jrz), AC-4 grace shim (sy-mts)

---
*Refinery note: rebased on main (resolved trivial import conflict in `src/synth_panel/mcp/server.py` — combined `apply_response_gate` and `validate_request` imports from `synth_panel.structured.validate` onto a single line).*
