### PR TITLE
docs: integrate Ko-fi sponsorship link (sy-kofi-1)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: dataviking

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/synthpanel.svg)](https://pypi.org/project/synthpanel/)
 [![MCP](https://img.shields.io/badge/MCP-enabled-brightgreen.svg)](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md)
 [![GHCR](https://img.shields.io/badge/ghcr.io-dataviking--tech%2Fsynthpanel-2496ED?logo=docker&logoColor=white)](https://github.com/DataViking-Tech/SynthPanel/pkgs/container/synthpanel)
+[![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-FF5E5B?logo=ko-fi)](https://ko-fi.com/dataviking)
 
 Site: <https://synthpanel.dev> · Benchmark: <https://synthbench.org>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ Repository = "https://github.com/DataViking-Tech/SynthPanel"
 Issues = "https://github.com/DataViking-Tech/SynthPanel/issues"
 Changelog = "https://github.com/DataViking-Tech/SynthPanel/releases"
 "MCP Reference" = "https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md"
+Funding = "https://ko-fi.com/dataviking"
 
 [project.optional-dependencies]
 mcp = [

--- a/site/blog/synthpanel-vs-commercial-alternatives.html
+++ b/site/blog/synthpanel-vs-commercial-alternatives.html
@@ -540,6 +540,13 @@ synthpanel mcp-serve</pre>
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by

--- a/site/docs/calibration/index.html
+++ b/site/docs/calibration/index.html
@@ -514,6 +514,13 @@
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by

--- a/site/docs/panel-run/index.html
+++ b/site/docs/panel-run/index.html
@@ -912,6 +912,13 @@ synthpanel panel run \
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by

--- a/site/index.html
+++ b/site/index.html
@@ -564,6 +564,13 @@ synthpanel report &lt;result-id&gt; -o report.md</pre>
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by

--- a/site/index.html.j2
+++ b/site/index.html.j2
@@ -564,6 +564,13 @@ synthpanel report &lt;result-id&gt; -o report.md</pre>
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -1000,6 +1000,13 @@
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by

--- a/site/recommended-models/index.html
+++ b/site/recommended-models/index.html
@@ -469,6 +469,13 @@ synthpanel panel run ... --best-model-for <span class="text-amber-300">"Technolo
               class="hover:text-slate-300"
               >DataViking-Tech/SynthPanel</a
             >
+            ·
+            <a
+              href="https://ko-fi.com/dataviking"
+              class="hover:text-slate-300"
+              rel="noopener"
+              >Support on Ko-fi</a
+            >
           </span>
           <span>
             Built by


### PR DESCRIPTION
Adds Ko-fi sponsorship integration in 4 spots: .github/FUNDING.yml, README badge, pyproject.toml [project.urls] Funding, site footer. Branch by polecat obsidian; PR opened manually after gt done flow stalled.