### PR TITLE
feat: add `synthpanel plugin lint <path>` for plugin authors (sy-0rr)

### DIFF
--- a/site/cli-coverage.txt
+++ b/site/cli-coverage.txt
@@ -21,6 +21,7 @@ logout
 mcp-serve
 pack
 panel
+plugin
 prompt
 report
 runs

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -13,7 +13,10 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from synth_panel.plugins.lint import LintReport
 
 import yaml
 
@@ -5828,3 +5831,97 @@ def _print_text_diff(q: TextQuestionDiff) -> None:
         print(f"    New in B: {', '.join(q.new_themes)}")
     if q.dropped_themes:
         print(f"    Gone in B: {', '.join(q.dropped_themes)}")
+
+
+# ---------------------------------------------------------------------------
+# plugin lint (sy-0rr)
+# ---------------------------------------------------------------------------
+
+
+def handle_plugin_lint(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Lint one plugin directory or every installed plugin (--all)."""
+    from synth_panel.plugins.lint import lint_plugin
+
+    strict = bool(getattr(args, "strict", False))
+    lint_all = bool(getattr(args, "lint_all", False))
+    path = getattr(args, "path", None)
+
+    if lint_all and path:
+        print(
+            "Error: pass either a plugin path or --all, not both.",
+            file=sys.stderr,
+        )
+        return 1
+    if not lint_all and not path:
+        print(
+            "Error: provide a plugin path or pass --all.",
+            file=sys.stderr,
+        )
+        return 1
+
+    targets: list[Path] = []
+    if lint_all:
+        config_dir = Path(getattr(args, "plugin_config_dir", None) or Path.home() / ".synthpanel").expanduser()
+        plugins_dir = config_dir / "plugins"
+        if not plugins_dir.exists():
+            if fmt is OutputFormat.TEXT:
+                print(f"No plugins installed under {plugins_dir}.")
+            else:
+                emit(
+                    fmt,
+                    message="no plugins installed",
+                    extra={"plugins_dir": str(plugins_dir), "reports": []},
+                )
+            return 0
+        targets = sorted(p for p in plugins_dir.iterdir() if p.is_dir())
+        if not targets:
+            if fmt is OutputFormat.TEXT:
+                print(f"No plugins installed under {plugins_dir}.")
+            else:
+                emit(
+                    fmt,
+                    message="no plugins installed",
+                    extra={"plugins_dir": str(plugins_dir), "reports": []},
+                )
+            return 0
+    else:
+        targets = [Path(path)]
+
+    reports: list[LintReport] = [lint_plugin(t) for t in targets]
+    failed = [r for r in reports if not r.passed(strict=strict)]
+
+    if fmt is OutputFormat.TEXT:
+        for report in reports:
+            _print_lint_report(report, strict=strict)
+        _print_lint_summary(reports, strict=strict)
+    else:
+        payload = {
+            "strict": strict,
+            "reports": [r.to_dict() for r in reports],
+            "failed": len(failed),
+            "passed": len(reports) - len(failed),
+        }
+        message = "plugin lint passed" if not failed else "plugin lint failed"
+        emit(fmt, message=message, extra=payload)
+
+    return 1 if failed else 0
+
+
+def _print_lint_report(report: LintReport, *, strict: bool) -> None:
+    label = report.plugin_name or report.plugin_path
+    status = "ok" if report.passed(strict=strict) else "fail"
+    print(f"--- {label} [{status}]")
+    if not report.issues:
+        print("  ✓ no issues")
+        return
+    for issue in report.issues:
+        print(f"  {issue.format()}")
+
+
+def _print_lint_summary(reports: list[LintReport], *, strict: bool) -> None:
+    failed = sum(1 for r in reports if not r.passed(strict=strict))
+    if failed == 0:
+        suffix = "" if len(reports) == 1 else "s"
+        print(f"\n{len(reports)} plugin{suffix} lint OK.")
+    else:
+        print(f"\n{failed} plugin lint failed.")

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1145,6 +1145,45 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start the MCP server (stdio transport).",
     )
 
+    # plugin (sy-0rr): author-time tooling for plugin manifests
+    plugin_parser = subparsers.add_parser(
+        "plugin",
+        help="Plugin author tooling: lint a plugin source directory.",
+    )
+    plugin_subparsers = plugin_parser.add_subparsers(dest="plugin_command")
+
+    plugin_lint_parser = plugin_subparsers.add_parser(
+        "lint",
+        help="Validate a plugin manifest and surface schema problems before install.",
+    )
+    plugin_lint_parser.add_argument(
+        "path",
+        nargs="?",
+        default=None,
+        metavar="PATH",
+        help="Plugin source directory (containing plugin.yaml). Required unless --all is given.",
+    )
+    plugin_lint_parser.add_argument(
+        "--all",
+        action="store_true",
+        default=False,
+        dest="lint_all",
+        help="Lint every plugin currently installed under ~/.synthpanel/plugins/.",
+    )
+    plugin_lint_parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help="Treat warnings as failures (non-zero exit if any warning is reported).",
+    )
+    plugin_lint_parser.add_argument(
+        "--config-dir",
+        default=None,
+        metavar="DIR",
+        dest="plugin_config_dir",
+        help="Override the plugin install root used by --all (default: ~/.synthpanel).",
+    )
+
     # install-skills (sy-65k74)
     install_skills_parser = subparsers.add_parser(
         "install-skills",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -35,6 +35,7 @@ from synth_panel.cli.commands import (
     handle_panel_inspect,
     handle_panel_run,
     handle_panel_synthesize,
+    handle_plugin_lint,
     handle_prompt,
     handle_report,
     handle_runs_diff,
@@ -132,6 +133,13 @@ def main(argv: list[str] | None = None) -> int:
         return handle_report(args, output_format)
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
+    elif args.command == "plugin":
+        sub = getattr(args, "plugin_command", None)
+        if sub == "lint":
+            return handle_plugin_lint(args, output_format)
+        else:
+            parser.parse_args(["plugin", "--help"])
+            return 1
     elif args.command == "install-skills":
         return handle_install_skills(args, output_format)
     elif args.command == "login":

--- a/src/synth_panel/plugins/__init__.py
+++ b/src/synth_panel/plugins/__init__.py
@@ -8,6 +8,7 @@ and lifecycle commands (init/shutdown).
 from __future__ import annotations
 
 from synth_panel.plugins.hooks import ShellHookRunner
+from synth_panel.plugins.lint import LintIssue, LintReport, lint_plugin
 from synth_panel.plugins.manager import PluginManager
 from synth_panel.plugins.manifest import (
     PluginHooks,
@@ -19,6 +20,8 @@ from synth_panel.plugins.manifest import (
 from synth_panel.plugins.registry import PluginRegistry
 
 __all__ = [
+    "LintIssue",
+    "LintReport",
     "PluginHooks",
     "PluginKind",
     "PluginLifecycle",
@@ -27,4 +30,5 @@ __all__ = [
     "PluginMetadata",
     "PluginRegistry",
     "ShellHookRunner",
+    "lint_plugin",
 ]

--- a/src/synth_panel/plugins/lint.py
+++ b/src/synth_panel/plugins/lint.py
@@ -1,0 +1,352 @@
+"""Plugin manifest linter (sy-0rr).
+
+Author-time validation for synthpanel plugins. Surfaces structural
+problems in ``plugin.yaml`` before the plugin is installed and loaded
+at runtime, where the same problems would otherwise present as opaque
+load failures.
+
+The linter validates the on-disk shape that ``PluginManifest.from_file``
+expects, plus the keys (`pre_tool_use`, `post_tool_use`,
+`post_tool_use_failure`) and lifecycle commands the rest of the plugin
+system actually consumes. Hook *commands* are shell strings, not Python
+callables, so the linter only validates their type and emptiness — not
+their semantics.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from synth_panel.plugins.manifest import MANIFEST_FILENAME
+
+VALID_HOOK_NAMES = ("pre_tool_use", "post_tool_use", "post_tool_use_failure")
+VALID_LIFECYCLE_NAMES = ("init", "shutdown")
+REQUIRED_FIELDS = ("name", "version")
+
+
+@dataclass
+class LintIssue:
+    """A single lint finding against a plugin manifest."""
+
+    severity: str  # "error" | "warning"
+    code: str
+    message: str
+
+    def format(self) -> str:
+        marker = "✗" if self.severity == "error" else "!"
+        return f"{marker} [{self.code}] {self.message}"
+
+
+@dataclass
+class LintReport:
+    """Result of linting one plugin directory."""
+
+    plugin_path: str
+    plugin_name: str | None
+    issues: list[LintIssue] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[LintIssue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> list[LintIssue]:
+        return [i for i in self.issues if i.severity == "warning"]
+
+    def passed(self, *, strict: bool = False) -> bool:
+        if self.errors:
+            return False
+        return not (strict and self.warnings)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "plugin_path": self.plugin_path,
+            "plugin_name": self.plugin_name,
+            "errors": [{"code": i.code, "message": i.message} for i in self.errors],
+            "warnings": [{"code": i.code, "message": i.message} for i in self.warnings],
+        }
+
+
+def lint_plugin(path: str | Path) -> LintReport:
+    """Lint a plugin source directory and return a structured report.
+
+    The path may be a directory containing ``plugin.yaml`` or a direct
+    path to the manifest file itself. The function never raises for
+    malformed manifests — every problem becomes a `LintIssue` so callers
+    can render a complete report in one pass.
+    """
+    raw_path = Path(path)
+    report = LintReport(plugin_path=str(raw_path), plugin_name=None)
+
+    manifest_path = _resolve_manifest_path(raw_path, report)
+    if manifest_path is None:
+        return report
+
+    data = _load_manifest_yaml(manifest_path, report)
+    if data is None:
+        return report
+
+    if not isinstance(data, dict):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="manifest-shape",
+                message=(f"plugin.yaml must be a YAML mapping, got {type(data).__name__}"),
+            )
+        )
+        return report
+
+    name = data.get("name")
+    if isinstance(name, str) and name:
+        report.plugin_name = name
+
+    _check_required_fields(data, report)
+    _check_scalar_types(data, report)
+    _check_permissions(data, report)
+    _check_hooks(data, report)
+    _check_lifecycle(data, report)
+    _check_tools_commands(data, report)
+
+    return report
+
+
+def _resolve_manifest_path(path: Path, report: LintReport) -> Path | None:
+    if not path.exists():
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="path-missing",
+                message=f"plugin path does not exist: {path}",
+            )
+        )
+        return None
+
+    if path.is_file():
+        return path
+
+    manifest = path / MANIFEST_FILENAME
+    if not manifest.exists():
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="manifest-missing",
+                message=f"{MANIFEST_FILENAME} not found in {path}",
+            )
+        )
+        return None
+    return manifest
+
+
+def _load_manifest_yaml(manifest_path: Path, report: LintReport) -> Any:
+    try:
+        text = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="manifest-unreadable",
+                message=f"cannot read {manifest_path}: {exc}",
+            )
+        )
+        return None
+
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="manifest-yaml",
+                message=f"plugin.yaml is not valid YAML: {exc}",
+            )
+        )
+        return None
+
+
+def _check_required_fields(data: dict[str, Any], report: LintReport) -> None:
+    for field_name in REQUIRED_FIELDS:
+        value = data.get(field_name)
+        if value is None or value == "":
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="missing-field",
+                    message=f"required field '{field_name}' is missing or empty",
+                )
+            )
+        elif not isinstance(value, str):
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="field-type",
+                    message=(f"field '{field_name}' must be a string, got {type(value).__name__}"),
+                )
+            )
+
+
+def _check_scalar_types(data: dict[str, Any], report: LintReport) -> None:
+    description = data.get("description", "")
+    if not isinstance(description, str):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="field-type",
+                message=(f"field 'description' must be a string, got {type(description).__name__}"),
+            )
+        )
+
+    if "default_enabled" in data and not isinstance(data["default_enabled"], bool):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="field-type",
+                message=(f"field 'default_enabled' must be a boolean, got {type(data['default_enabled']).__name__}"),
+            )
+        )
+
+
+def _check_permissions(data: dict[str, Any], report: LintReport) -> None:
+    if "permissions" not in data:
+        return
+    perms = data["permissions"]
+    if not isinstance(perms, list):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="field-type",
+                message=(f"field 'permissions' must be a list of strings, got {type(perms).__name__}"),
+            )
+        )
+        return
+    for i, p in enumerate(perms):
+        if not isinstance(p, str):
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="field-type",
+                    message=(f"permissions[{i}] must be a string, got {type(p).__name__}"),
+                )
+            )
+
+
+def _check_hooks(data: dict[str, Any], report: LintReport) -> None:
+    if "hooks" not in data:
+        return
+    hooks = data["hooks"]
+    if not isinstance(hooks, dict):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="field-type",
+                message=(f"field 'hooks' must be a mapping, got {type(hooks).__name__}"),
+            )
+        )
+        return
+
+    for key, value in hooks.items():
+        if key not in VALID_HOOK_NAMES:
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="unknown-hook",
+                    message=(f"unknown hook name '{key}' (valid: {', '.join(VALID_HOOK_NAMES)})"),
+                )
+            )
+            continue
+        _check_command_list(f"hooks.{key}", value, report)
+
+
+def _check_lifecycle(data: dict[str, Any], report: LintReport) -> None:
+    if "lifecycle" not in data:
+        return
+    lifecycle = data["lifecycle"]
+    if not isinstance(lifecycle, dict):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="field-type",
+                message=(f"field 'lifecycle' must be a mapping, got {type(lifecycle).__name__}"),
+            )
+        )
+        return
+
+    for key, value in lifecycle.items():
+        if key not in VALID_LIFECYCLE_NAMES:
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="unknown-lifecycle",
+                    message=(f"unknown lifecycle stage '{key}' (valid: {', '.join(VALID_LIFECYCLE_NAMES)})"),
+                )
+            )
+            continue
+        _check_command_list(f"lifecycle.{key}", value, report)
+
+
+def _check_command_list(label: str, value: Any, report: LintReport) -> None:
+    if not isinstance(value, list):
+        report.issues.append(
+            LintIssue(
+                severity="error",
+                code="field-type",
+                message=(f"{label} must be a list of shell command strings, got {type(value).__name__}"),
+            )
+        )
+        return
+
+    if not value:
+        report.issues.append(
+            LintIssue(
+                severity="warning",
+                code="empty-hook",
+                message=f"{label} is an empty list — declare it only if you have commands",
+            )
+        )
+        return
+
+    for i, cmd in enumerate(value):
+        if not isinstance(cmd, str):
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="field-type",
+                    message=(f"{label}[{i}] must be a string, got {type(cmd).__name__}"),
+                )
+            )
+        elif not cmd.strip():
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="empty-command",
+                    message=f"{label}[{i}] is an empty command",
+                )
+            )
+
+
+def _check_tools_commands(data: dict[str, Any], report: LintReport) -> None:
+    for key in ("tools", "commands"):
+        if key not in data:
+            continue
+        value = data[key]
+        if not isinstance(value, list):
+            report.issues.append(
+                LintIssue(
+                    severity="error",
+                    code="field-type",
+                    message=(f"field '{key}' must be a list of mappings, got {type(value).__name__}"),
+                )
+            )
+            continue
+        for i, entry in enumerate(value):
+            if not isinstance(entry, dict):
+                report.issues.append(
+                    LintIssue(
+                        severity="error",
+                        code="field-type",
+                        message=(f"{key}[{i}] must be a mapping, got {type(entry).__name__}"),
+                    )
+                )

--- a/tests/fixtures/plugins/bad-entrypoint/plugin.yaml
+++ b/tests/fixtures/plugins/bad-entrypoint/plugin.yaml
@@ -1,0 +1,1 @@
+just a string, not a mapping

--- a/tests/fixtures/plugins/bad-hooks/plugin.yaml
+++ b/tests/fixtures/plugins/bad-hooks/plugin.yaml
@@ -1,0 +1,7 @@
+name: bad-hooks-plugin
+version: 0.1.0
+description: Declares an unknown hook name and a malformed hook value.
+hooks:
+  pre_tool_use: "echo not-a-list"
+  on_persona_load:
+    - "echo wrong-name"

--- a/tests/fixtures/plugins/bad-manifest/plugin.yaml
+++ b/tests/fixtures/plugins/bad-manifest/plugin.yaml
@@ -1,0 +1,2 @@
+name: bad-manifest-plugin
+description: Missing the required 'version' field.

--- a/tests/fixtures/plugins/good/plugin.yaml
+++ b/tests/fixtures/plugins/good/plugin.yaml
@@ -1,0 +1,22 @@
+name: good-plugin
+version: 1.0.0
+description: A clean plugin manifest used by the lint test suite.
+default_enabled: true
+permissions:
+  - read
+  - write
+hooks:
+  pre_tool_use:
+    - "echo pre"
+  post_tool_use:
+    - "echo post"
+lifecycle:
+  init:
+    - "echo init"
+  shutdown:
+    - "echo shutdown"
+tools:
+  - name: example_tool
+    description: A demo tool.
+commands:
+  - name: example_cmd

--- a/tests/test_plugin_lint.py
+++ b/tests/test_plugin_lint.py
@@ -1,0 +1,260 @@
+"""Tests for `synthpanel plugin lint` (sy-0rr)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from synth_panel.cli.commands import handle_plugin_lint
+from synth_panel.cli.output import OutputFormat
+from synth_panel.cli.parser import build_parser
+from synth_panel.plugins.lint import lint_plugin
+
+FIXTURES = Path(__file__).parent / "fixtures" / "plugins"
+
+
+# ---------------------------------------------------------------------------
+# Core linter
+# ---------------------------------------------------------------------------
+
+
+class TestLintPlugin:
+    def test_good_fixture_passes(self) -> None:
+        report = lint_plugin(FIXTURES / "good")
+        assert report.errors == []
+        assert report.warnings == []
+        assert report.passed()
+        assert report.passed(strict=True)
+        assert report.plugin_name == "good-plugin"
+
+    def test_bad_manifest_missing_version(self) -> None:
+        report = lint_plugin(FIXTURES / "bad-manifest")
+        assert not report.passed()
+        codes = [i.code for i in report.errors]
+        assert "missing-field" in codes
+        assert any("version" in i.message for i in report.errors)
+
+    def test_bad_hooks_unknown_name_and_wrong_type(self) -> None:
+        report = lint_plugin(FIXTURES / "bad-hooks")
+        assert not report.passed()
+        codes = [i.code for i in report.errors]
+        assert "unknown-hook" in codes
+        assert "field-type" in codes
+        assert any("on_persona_load" in i.message for i in report.errors)
+
+    def test_bad_entrypoint_non_mapping_manifest(self) -> None:
+        report = lint_plugin(FIXTURES / "bad-entrypoint")
+        assert not report.passed()
+        assert any(i.code == "manifest-shape" for i in report.errors)
+
+    def test_missing_path(self, tmp_path: Path) -> None:
+        report = lint_plugin(tmp_path / "does-not-exist")
+        assert not report.passed()
+        assert any(i.code == "path-missing" for i in report.errors)
+
+    def test_directory_without_manifest(self, tmp_path: Path) -> None:
+        report = lint_plugin(tmp_path)
+        assert not report.passed()
+        assert any(i.code == "manifest-missing" for i in report.errors)
+
+    def test_yaml_syntax_error(self, tmp_path: Path) -> None:
+        (tmp_path / "plugin.yaml").write_text("not: [valid", encoding="utf-8")
+        report = lint_plugin(tmp_path)
+        assert not report.passed()
+        assert any(i.code == "manifest-yaml" for i in report.errors)
+
+    def test_accepts_manifest_file_path_directly(self) -> None:
+        report = lint_plugin(FIXTURES / "good" / "plugin.yaml")
+        assert report.passed()
+        assert report.plugin_name == "good-plugin"
+
+    def test_empty_hook_list_is_warning_not_error(self, tmp_path: Path) -> None:
+        manifest = {
+            "name": "warn-plugin",
+            "version": "1.0.0",
+            "hooks": {"pre_tool_use": []},
+        }
+        (tmp_path / "plugin.yaml").write_text(yaml.dump(manifest), encoding="utf-8")
+        report = lint_plugin(tmp_path)
+        assert report.errors == []
+        assert any(i.code == "empty-hook" for i in report.warnings)
+        assert report.passed()
+        assert not report.passed(strict=True)
+
+    def test_default_enabled_must_be_bool(self, tmp_path: Path) -> None:
+        manifest = {
+            "name": "p",
+            "version": "1.0.0",
+            "default_enabled": "yes",
+        }
+        (tmp_path / "plugin.yaml").write_text(yaml.dump(manifest), encoding="utf-8")
+        report = lint_plugin(tmp_path)
+        assert any("default_enabled" in i.message and i.severity == "error" for i in report.issues)
+
+    def test_unknown_lifecycle_stage(self, tmp_path: Path) -> None:
+        manifest = {
+            "name": "p",
+            "version": "1.0.0",
+            "lifecycle": {"on_load": ["echo nope"]},
+        }
+        (tmp_path / "plugin.yaml").write_text(yaml.dump(manifest), encoding="utf-8")
+        report = lint_plugin(tmp_path)
+        assert any(i.code == "unknown-lifecycle" for i in report.errors)
+
+    def test_empty_command_string_is_error(self, tmp_path: Path) -> None:
+        manifest = {
+            "name": "p",
+            "version": "1.0.0",
+            "hooks": {"pre_tool_use": ["   "]},
+        }
+        (tmp_path / "plugin.yaml").write_text(yaml.dump(manifest), encoding="utf-8")
+        report = lint_plugin(tmp_path)
+        assert any(i.code == "empty-command" for i in report.errors)
+
+    def test_to_dict_shape(self) -> None:
+        report = lint_plugin(FIXTURES / "bad-hooks")
+        d = report.to_dict()
+        assert d["plugin_path"]
+        assert d["plugin_name"] == "bad-hooks-plugin"
+        assert isinstance(d["errors"], list)
+        assert isinstance(d["warnings"], list)
+        assert all("code" in e and "message" in e for e in d["errors"])
+
+
+# ---------------------------------------------------------------------------
+# CLI handler
+# ---------------------------------------------------------------------------
+
+
+class TestHandlePluginLint:
+    def _parse(self, *argv: str):
+        return build_parser().parse_args(["plugin", "lint", *argv])
+
+    def test_good_fixture_returns_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = self._parse(str(FIXTURES / "good"))
+        rc = handle_plugin_lint(args, OutputFormat.TEXT)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "ok" in out
+        assert "lint OK" in out
+
+    def test_bad_fixture_returns_nonzero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = self._parse(str(FIXTURES / "bad-manifest"))
+        rc = handle_plugin_lint(args, OutputFormat.TEXT)
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "fail" in out
+        assert "lint failed" in out
+
+    def test_json_output(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = self._parse(str(FIXTURES / "bad-hooks"))
+        rc = handle_plugin_lint(args, OutputFormat.JSON)
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+        assert rc == 1
+        assert payload["failed"] == 1
+        assert payload["passed"] == 0
+        assert payload["reports"][0]["plugin_name"] == "bad-hooks-plugin"
+
+    def test_strict_promotes_warnings(self, tmp_path: Path) -> None:
+        manifest = {
+            "name": "p",
+            "version": "1.0.0",
+            "hooks": {"pre_tool_use": []},
+        }
+        (tmp_path / "plugin.yaml").write_text(yaml.dump(manifest), encoding="utf-8")
+
+        relaxed = handle_plugin_lint(self._parse(str(tmp_path)), OutputFormat.JSON)
+        assert relaxed == 0
+
+        strict = handle_plugin_lint(self._parse(str(tmp_path), "--strict"), OutputFormat.JSON)
+        assert strict == 1
+
+    def test_no_args_errors(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = self._parse()
+        rc = handle_plugin_lint(args, OutputFormat.TEXT)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "plugin path" in err
+
+    def test_path_and_all_conflict(self, capsys: pytest.CaptureFixture[str]) -> None:
+        args = self._parse(str(FIXTURES / "good"), "--all")
+        rc = handle_plugin_lint(args, OutputFormat.TEXT)
+        err = capsys.readouterr().err
+        assert rc == 1
+        assert "either" in err
+
+    def test_all_with_empty_config_dir(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        args = self._parse("--all", "--config-dir", str(tmp_path))
+        rc = handle_plugin_lint(args, OutputFormat.TEXT)
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "No plugins installed" in out
+
+    def test_all_walks_installed_plugins(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        plugins_root = tmp_path / "plugins"
+        plugins_root.mkdir()
+
+        good = plugins_root / "good"
+        good.mkdir()
+        (good / "plugin.yaml").write_text(yaml.dump({"name": "good", "version": "1.0.0"}), encoding="utf-8")
+
+        bad = plugins_root / "bad"
+        bad.mkdir()
+        (bad / "plugin.yaml").write_text(yaml.dump({"name": "bad"}), encoding="utf-8")
+
+        args = self._parse("--all", "--config-dir", str(tmp_path))
+        rc = handle_plugin_lint(args, OutputFormat.JSON)
+        out = capsys.readouterr().out
+        payload = json.loads(out)
+
+        assert rc == 1
+        assert payload["passed"] == 1
+        assert payload["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end CLI smoke test
+# ---------------------------------------------------------------------------
+
+
+def test_cli_smoke_good_fixture() -> None:
+    """Invoke the real CLI module and check the exit code is zero."""
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "synth_panel",
+            "plugin",
+            "lint",
+            str(FIXTURES / "good"),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "ok" in proc.stdout
+
+
+def test_cli_smoke_bad_fixture_nonzero() -> None:
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "synth_panel",
+            "plugin",
+            "lint",
+            str(FIXTURES / "bad-hooks"),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    assert "fail" in proc.stdout


### PR DESCRIPTION
Adds `synthpanel plugin lint <path>` CLI command for plugin authors to validate their plugins before publishing.

**Source bead:** sy-0rr (yggdrasil rig: synthpanel)
**Stranded recovery:** Polecat topaz pushed this work but `gt done` deadlocked on missing tracking bead. Yggdrasil rebuilt bd to server mode; PR opened manually by mayor to recover.

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)