### PR TITLE
feat(cli): add --seed flag with provider-aware fallback (sy-cxp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 Work in progress for the next release after v1.0.0 lands.
 
+### Added
+
+- `--seed N` flag on `panel run` (sy-cxp) for reproducible sampling.
+  Forwarded to providers that support it (OpenAI, Gemini, xAI, OpenRouter)
+  and recorded in `metadata.parameters.seed` plus the resume fingerprint.
+  Anthropic and other non-supporting providers log a single warning per
+  run and proceed without determinism. See `docs/reproducibility.md` for
+  the boundary between `--seed` (new runs) and `--resume` (replay).
+
 ### Documentation
 
 - `docs/oauth-discovery.md` — records the AR-5 (sy-iaf) determination that

--- a/README.md
+++ b/README.md
@@ -876,6 +876,38 @@ synthpanel panel run --personas personas.yaml --instrument survey.yaml --prompt-
 
 Templates use Python format-string syntax (`{field_name}`). Missing persona fields are left as literal `{field_name}` in the output.
 
+## Reproducibility (`--seed`)
+
+Pass `--seed N` to `panel run` for reproducible sampling on providers that
+honor the seed parameter (OpenAI, Gemini, xAI, OpenRouter):
+
+```bash
+synthpanel panel run --seed 42 --personas p.yaml --instrument s.yaml
+```
+
+What synthpanel **can** promise:
+
+- Forwards the seed to providers that support it.
+- Records the seed in the run's `metadata.parameters.seed` and in the
+  checkpoint fingerprint, so a `--resume` run with a different seed
+  fails loudly instead of silently mixing samples.
+
+What synthpanel **cannot** promise:
+
+- Anthropic's Messages API has no `seed` parameter. When `--seed` is set
+  on a Claude model, synthpanel logs a single warning per provider and
+  proceeds without determinism. Use `--temperature 0` for closer-to-
+  deterministic Claude output, but expect drift across model versions.
+- Even on supporting providers, "seeded" sampling is best-effort: model
+  serving infrastructure and silent server-side updates can still shift
+  outputs between runs.
+
+`--seed` is for *new* runs you want to be reproducible. To replay a
+previously-cached run exactly, use `synthpanel panel run --resume <run-id>`
+— that path serves cached responses verbatim and is independent of
+`--seed`. See [docs/reproducibility.md](docs/reproducibility.md) for
+the full picture.
+
 ## Methodology Notes
 
 Synthetic research is useful for exploration, hypothesis generation, and rapid iteration. It is **not** a replacement for talking to real humans.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,134 @@
+# Reproducibility — what synthpanel can and can't promise
+
+LLM-driven research lives or dies on whether you can rerun a panel and get
+the same answers. This page lays out the two reproducibility tools in
+synthpanel, what each one actually guarantees, and where the joints are.
+
+## TL;DR
+
+| Goal | Use | Determinism |
+|---|---|---|
+| Replay a *previously executed* run exactly | `panel run --resume <run-id>` | Strong: cached responses are served verbatim |
+| Constrain a *new* run for repeatability | `panel run --seed N` | Best-effort, provider-dependent |
+
+These solve different problems. `--resume` lets you pick up where a crashed
+or interrupted run left off, with byte-identical answers for every
+already-completed panelist. `--seed` lets you start a fresh run that you
+*want* to be repeatable — useful for instrument validation, paper
+supplementary materials, or debugging an unexpected synthesis output.
+
+## `--seed` — provider-aware sampling
+
+```bash
+synthpanel panel run --seed 42 --personas p.yaml --instrument s.yaml
+```
+
+The seed is forwarded to the provider's sampling parameter on every
+panelist call (and every synthesis call) for the duration of the run.
+
+### Provider support
+
+| Provider | `--seed` behavior |
+|---|---|
+| OpenAI / OpenRouter | Forwarded as `seed` on the chat-completions request |
+| Gemini (Google) | Forwarded as `seed` on the OpenAI-compatible endpoint |
+| xAI (Grok) | Forwarded as `seed` |
+| Anthropic (Claude) | **Not supported.** synthpanel logs a single warning per provider per run and proceeds without determinism |
+| Local / unknown OpenAI-compatible | Forwarded; whether it's honored depends on the runtime |
+
+### Why Claude isn't reproducible via `--seed`
+
+Anthropic's Messages API has no `seed` parameter at the time of writing.
+Setting one would mislead users into thinking determinism holds. Instead,
+synthpanel:
+
+1. Logs **one** warning per provider per run, naming the provider:
+   ```
+   --seed=42 is not supported by Anthropic models; runs against this
+   provider will not be deterministic. Use temperature=0 for closer-to-
+   deterministic output.
+   ```
+2. Drops the seed from the Anthropic request body (so the API doesn't
+   reject the call).
+3. Keeps the seed on every other provider's request as normal.
+
+For Claude, the closest you can get to reproducibility is
+`--temperature 0`, but expect drift when Anthropic ships model updates.
+
+### Mixed-provider runs
+
+`--models claude-sonnet-4-6:0.5,gpt-4o-mini:0.5` (or per-persona model
+overrides) splits the panel across providers. With `--seed N`:
+
+- The OpenAI-routed panelists get `seed=N`.
+- The Anthropic-routed panelists do not.
+- You see exactly **one** "seed not supported" warning for Anthropic,
+  and exactly zero for OpenAI.
+
+The warning is one-shot per (LLMClient instance, provider) so a 1000-
+panelist mixed run does not produce 500 duplicate warnings.
+
+### What gets recorded
+
+When `--seed` is set, the value lands in two places in the output JSON:
+
+- `metadata.parameters.seed` — surfaced for downstream auditors.
+- The checkpoint's `config` fingerprint — so `--resume` of a checkpointed
+  run rejects mismatched seeds with a `CheckpointDriftError` rather than
+  silently splicing two different seeded slices together.
+
+### What `--seed` does **not** promise
+
+- **Cross-version stability.** A new model release on the provider side
+  will change outputs even with the same seed. The seed only constrains
+  sampling *given a fixed model*.
+- **Cross-provider stability.** Two providers with the same seed will
+  emit different text. Seeds are local to one provider's RNG.
+- **Determinism on every single token.** Many providers describe seeded
+  sampling as best-effort; backend load balancing, batching, and
+  numerical drift can still nudge outputs. Treat `--seed` as "very
+  similar most of the time," not "byte-identical always."
+
+## `--resume` — replay an existing run
+
+```bash
+synthpanel panel run --resume <run-id>
+```
+
+`--resume` operates on a checkpoint written by a prior `panel run` (with
+`--checkpoint-dir`, or via the default checkpoint root). Every panelist
+that completed before the crash / SIGINT is reloaded from disk; only the
+remaining panelists are dispatched to the provider.
+
+This **is** byte-deterministic for the already-completed slice — the
+responses are served from the checkpoint, not regenerated. Combined with
+`--seed N` on the resumed slice, you get the closest synthpanel offers
+to a fully deterministic run on supporting providers.
+
+### Drift detection
+
+`--resume` rejects a run when the saved fingerprint disagrees with the
+current invocation on any of:
+
+- persona names / count / identities
+- question texts / count
+- model (or `persona_models` map)
+- temperature, top_p, **seed**
+- response/extract schemas
+- prompt template variables
+
+Pass `--allow-drift` to override (with a loud warning that the
+resumed run is statistically inconsistent).
+
+## Best practices
+
+- **Always print or capture the seed** if you intend to publish or audit
+  the run. It is in the JSON output but easy to miss in text mode.
+- **Pin the model** (`--model claude-sonnet-4-6` rather than `--model sonnet`).
+  Aliases resolve to whatever the latest version is, which defeats the
+  purpose of seeding.
+- **Pair with `--temperature 0`** on Anthropic if you need
+  near-deterministic Claude output. It's not a true seed, but it removes
+  most sampling variance.
+- **Use `--resume` for replay, `--seed` for repeatability.** They're
+  complementary, not interchangeable.

--- a/src/synth_panel/_runners.py
+++ b/src/synth_panel/_runners.py
@@ -634,6 +634,7 @@ def run_panel_sync(
     synthesis_prompt: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     persona_models: dict[str, str] | None = None,
     extract_schema: dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
@@ -678,6 +679,7 @@ def run_panel_sync(
         response_schema=response_schema,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
         persona_models=persona_models,
         extract_schema=extract_schema,
     )
@@ -742,6 +744,7 @@ def run_panel_sync(
                     custom_prompt=synthesis_prompt,
                     panelist_cost=panelist_cost,
                     temperature=synthesis_temperature,
+                    seed=seed,
                 )
                 synthesis_dict = synthesis_result.to_dict()
             except Exception as exc:
@@ -783,6 +786,7 @@ def run_multi_round_sync(
     synthesis_prompt: str | None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     persona_models: dict[str, str] | None = None,
     extract_schema: dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
@@ -804,6 +808,7 @@ def run_multi_round_sync(
             panelist_model=model,
             custom_prompt=synthesis_prompt,
             temperature=synthesis_temperature,
+            seed=seed,
         )
 
     final_fn = _round_synth if synthesis else None
@@ -819,6 +824,7 @@ def run_multi_round_sync(
         response_schema=response_schema,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
         persona_models=persona_models,
         extract_schema=extract_schema,
     )

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -955,6 +955,7 @@ def _build_run_config_fingerprint(
     response_schema: dict[str, Any] | None,
     extract_schema: dict[str, Any] | None,
     template_vars: dict[str, str] | None,
+    seed: int | None = None,
 ) -> dict[str, Any]:
     """Build a stable-key config dict whose hash detects resume drift.
 
@@ -972,6 +973,7 @@ def _build_run_config_fingerprint(
         "persona_models": dict(persona_models) if persona_models else None,
         "temperature": temperature,
         "top_p": top_p,
+        "seed": seed,
         "response_schema": response_schema,
         "extract_schema": extract_schema,
         "template_vars": dict(template_vars) if template_vars else None,
@@ -1293,6 +1295,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
     # Generation parameters
     temperature: float | None = getattr(args, "temperature", None)
     top_p: float | None = getattr(args, "top_p", None)
+    seed: int | None = getattr(args, "seed", None)
 
     # ── sp-blend: multi-model ensemble ───────────────────────────────────
     # Parse --models spec and build per-persona model assignments.
@@ -1476,6 +1479,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             extract_schema=extract_schema,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
         )
         timer.stop()
 
@@ -1748,6 +1752,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             persona_models=persona_models,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
             response_schema=response_schema,
             extract_schema=extract_schema,
             template_vars=template_vars,
@@ -1854,6 +1859,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             extract_schema=extract_schema,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
         )
         # Build weights dict from the model spec
         blend_weights = {m: w for m, w in model_spec}
@@ -1902,6 +1908,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 extract_schema=extract_schema,
                 temperature=temperature,
                 top_p=top_p,
+                seed=seed,
                 persona_models=persona_models,
                 max_workers=max_concurrent,
                 convergence_tracker=convergence_tracker,
@@ -2126,6 +2133,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                         panelist_cost=panelist_cost_est,
                         temperature=effective_synth_temp,
                         top_p=top_p,
+                        seed=seed,
                         personas=personas,
                         auto_escalate=getattr(args, "synthesis_auto_escalate", False),
                     )
@@ -2140,6 +2148,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                         panelist_cost=panelist_cost_est,
                         temperature=effective_synth_temp,
                         top_p=top_p,
+                        seed=seed,
                     )
             except MapChunkOverflowError as exc:
                 # sp-exu6: per-map chunk overflow — distinct from the
@@ -4759,6 +4768,9 @@ def _build_params_metadata(
         params["temperature"] = temperature
     if top_p is not None:
         params["top_p"] = top_p
+    seed = getattr(args, "seed", None)
+    if seed is not None:
+        params["seed"] = seed
     synthesis_temperature = getattr(args, "synthesis_temperature", None)
     if synthesis_temperature is not None:
         params["synthesis_temperature"] = synthesis_temperature

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -265,6 +265,20 @@ def build_parser() -> argparse.ArgumentParser:
         help=("Nucleus sampling cutoff for panelist LLM calls (0.0-1.0). Default: provider default."),
     )
     panel_run_parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        metavar="INT",
+        help=(
+            "Sampling seed for reproducible panel runs (sy-cxp). Forwarded "
+            "to providers that support it (OpenAI, Gemini, xAI, OpenRouter). "
+            "Anthropic / unknown providers warn once and proceed without "
+            "determinism — use --temperature 0 for closer-to-deterministic "
+            "Claude output. Distinct from --resume, which replays a "
+            "previously-cached run; --seed only constrains a fresh run."
+        ),
+    )
+    panel_run_parser.add_argument(
         "--synthesis-temperature",
         type=float,
         default=None,

--- a/src/synth_panel/ensemble.py
+++ b/src/synth_panel/ensemble.py
@@ -184,6 +184,7 @@ def ensemble_run(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
 ) -> EnsembleResult:
     """Run a panel once per model and aggregate results.
 
@@ -235,6 +236,7 @@ def ensemble_run(
             extract_schema=extract_schema,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
         )
 
         # Aggregate usage for this model

--- a/src/synth_panel/llm/client.py
+++ b/src/synth_panel/llm/client.py
@@ -122,6 +122,10 @@ class LLMClient:
         self._bucket: _TokenBucket | None = (
             _TokenBucket(rate_limit_rps) if rate_limit_rps and rate_limit_rps > 0 else None
         )
+        # Track which providers we've already warned for unsupported seed
+        # (one-shot per LLMClient instance, per provider name).
+        self._seed_warned: set[str] = set()
+        self._seed_warned_lock = threading.Lock()
 
     def _resolve_provider(self, model: str) -> LLMProvider:
         """Resolve a provider for the given canonical model name."""
@@ -177,13 +181,44 @@ class LLMClient:
                 stream=request.stream,
                 temperature=request.temperature,
                 top_p=request.top_p,
+                seed=request.seed,
             )
         return request
+
+    def _check_seed_support(self, request: CompletionRequest, provider: LLMProvider) -> None:
+        """Emit a one-shot warning when ``seed`` is set on a provider that
+        does not honor it (sy-cxp).
+
+        Anthropic's Messages API has no equivalent of OpenAI's ``seed``
+        parameter, and local / unknown OpenAI-compatible endpoints aren't
+        guaranteed to support it either. Rather than silently dropping the
+        flag, log once per (provider) so the user knows determinism won't
+        hold for those calls — repeated per-turn warnings would be noise.
+        """
+        if request.seed is None:
+            return
+        config = getattr(provider, "config", None)
+        supports = bool(getattr(config, "supports_seed", False))
+        if supports:
+            return
+        name = _provider_name(provider)
+        with self._seed_warned_lock:
+            if name in self._seed_warned:
+                return
+            self._seed_warned.add(name)
+        logger.warning(
+            "--seed=%s is not supported by %s models; runs against this "
+            "provider will not be deterministic. Use temperature=0 for "
+            "closer-to-deterministic output.",
+            request.seed,
+            name,
+        )
 
     def send(self, request: CompletionRequest) -> CompletionResponse:
         """Send a blocking completion request with automatic retry."""
         request = self._prepare(request)
         provider = self._resolve_provider(request.model)
+        self._check_seed_support(request, provider)
         logger.debug("send model=%s max_tokens=%d", request.model, request.max_tokens)
         if self._bucket is not None:
             self._bucket.acquire()
@@ -212,6 +247,7 @@ class LLMClient:
         """Send a streaming request. Retry is NOT applied to streams."""
         request = self._prepare(request)
         provider = self._resolve_provider(request.model)
+        self._check_seed_support(request, provider)
         return provider.stream(request)
 
 

--- a/src/synth_panel/llm/models.py
+++ b/src/synth_panel/llm/models.py
@@ -179,6 +179,7 @@ class CompletionRequest:
     stream: bool = False
     temperature: float | None = None
     top_p: float | None = None
+    seed: int | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/synth_panel/llm/providers/_openai_format.py
+++ b/src/synth_panel/llm/providers/_openai_format.py
@@ -135,6 +135,8 @@ def build_openai_body(
         body["temperature"] = request.temperature
     if request.top_p is not None:
         body["top_p"] = request.top_p
+    if request.seed is not None:
+        body["seed"] = request.seed
 
     return body
 

--- a/src/synth_panel/llm/providers/anthropic.py
+++ b/src/synth_panel/llm/providers/anthropic.py
@@ -219,6 +219,9 @@ class AnthropicProvider(LLMProvider):
         )
 
     def stream(self, request: CompletionRequest) -> Iterator[StreamEvent]:
+        # Anthropic's API has no ``seed`` parameter (sy-cxp); the
+        # LLMClient warns once per provider when seed is set on a
+        # non-supporting provider, so we just drop it here.
         request_copy = CompletionRequest(
             model=request.model,
             max_tokens=request.max_tokens,

--- a/src/synth_panel/llm/providers/base.py
+++ b/src/synth_panel/llm/providers/base.py
@@ -25,6 +25,7 @@ class ProviderConfig:
     default_base_url: str
     model_prefixes: tuple[str, ...]
     name: str = ""
+    supports_seed: bool = False
 
     def get_api_key(self) -> str:
         """Return the API key from env or the on-disk credential store."""

--- a/src/synth_panel/llm/providers/gemini.py
+++ b/src/synth_panel/llm/providers/gemini.py
@@ -31,6 +31,7 @@ GEMINI_CONFIG = ProviderConfig(
     default_base_url="https://generativelanguage.googleapis.com/v1beta/openai",
     model_prefixes=("gemini-",),
     name="Gemini",
+    supports_seed=True,
 )
 
 

--- a/src/synth_panel/llm/providers/openai_compat.py
+++ b/src/synth_panel/llm/providers/openai_compat.py
@@ -29,6 +29,7 @@ OPENAI_COMPAT_CONFIG = ProviderConfig(
     default_base_url="https://api.openai.com",
     model_prefixes=(),  # No prefix — this is the fallback
     name="OpenAI",
+    supports_seed=True,
 )
 
 

--- a/src/synth_panel/llm/providers/openrouter.py
+++ b/src/synth_panel/llm/providers/openrouter.py
@@ -30,6 +30,7 @@ OPENROUTER_CONFIG = ProviderConfig(
     default_base_url="https://openrouter.ai/api",
     model_prefixes=("openrouter/",),
     name="OpenRouter",
+    supports_seed=True,
 )
 
 
@@ -131,6 +132,7 @@ class OpenRouterProvider(LLMProvider):
                 stream=request.stream,
                 temperature=request.temperature,
                 top_p=request.top_p,
+                seed=request.seed,
             )
         body = build_openai_body(request)
         # Ask OpenRouter to always return the detailed usage block (including
@@ -177,6 +179,7 @@ class OpenRouterProvider(LLMProvider):
                 stream=True,
                 temperature=request.temperature,
                 top_p=request.top_p,
+                seed=request.seed,
             )
         body = build_openai_body(request, stream=True)
         # Mirror send(): ensure OpenRouter emits usage details in the final

--- a/src/synth_panel/llm/providers/xai.py
+++ b/src/synth_panel/llm/providers/xai.py
@@ -30,6 +30,7 @@ XAI_CONFIG = ProviderConfig(
     default_base_url="https://api.x.ai",
     model_prefixes=("grok-",),
     name="xAI",
+    supports_seed=True,
 )
 
 

--- a/src/synth_panel/orchestrator.py
+++ b/src/synth_panel/orchestrator.py
@@ -599,6 +599,7 @@ def _run_panelist(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     question_budget: QuestionFailureBudget | None = None,
 ) -> tuple[PanelistResult, Session]:
     """Execute a single panelist's full interview. Runs in a worker thread.
@@ -648,6 +649,7 @@ def _run_panelist(
             max_tokens=eff_max_tokens,
             temperature=eff_temperature,
             top_p=eff_top_p,
+            seed=seed,
         )
 
         # Set up structured output engine if schema provided
@@ -699,6 +701,7 @@ def _run_panelist(
                         system=system_prompt,
                         temperature=eff_temperature,
                         top_p=eff_top_p,
+                        seed=seed,
                     )
                     tracker.record_turn(_convert_llm_usage(result.total_usage))
                     responses.append(
@@ -740,6 +743,7 @@ def _run_panelist(
                                 system=system_prompt,
                                 temperature=eff_temperature,
                                 top_p=eff_top_p,
+                                seed=seed,
                             )
                             tracker.record_turn(_convert_llm_usage(extract_result.total_usage))
                             resp_dict["extraction"] = extract_result.data
@@ -882,6 +886,7 @@ def run_panel_parallel(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     persona_models: dict[str, str] | None = None,
     convergence_tracker: ConvergenceTracker | None = None,
     on_panelist_complete: Callable[[PanelistResult], None] | None = None,
@@ -1011,6 +1016,7 @@ def run_panel_parallel(
                 extract_schema,
                 temperature,
                 top_p,
+                seed,
                 question_budget,
             )
             future_to_index[future] = idx
@@ -1160,6 +1166,7 @@ def run_multi_round_panel(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     persona_models: dict[str, str] | None = None,
 ) -> MultiRoundResult:
     """Execute a (possibly branching) multi-round panel run.
@@ -1225,6 +1232,7 @@ def run_multi_round_panel(
             extract_schema=extract_schema,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
             persona_models=persona_models,
         )
 
@@ -1366,6 +1374,7 @@ def ensemble_run(
     extract_schema: dict[str, Any] | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
 ) -> EnsembleResult:
     """Run the same panel with each model and compare results.
 
@@ -1391,6 +1400,7 @@ def ensemble_run(
             extract_schema=extract_schema,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
         )
         per_model[model_name] = results
         model_usage = ZERO_USAGE

--- a/src/synth_panel/runtime.py
+++ b/src/synth_panel/runtime.py
@@ -300,6 +300,7 @@ class AgentRuntime:
         usage_tracker: UsageTracker | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
+        seed: int | None = None,
     ) -> None:
         self._client = client
         self._session = session
@@ -316,6 +317,7 @@ class AgentRuntime:
         self._usage_tracker = usage_tracker or UsageTracker()
         self._temperature = temperature
         self._top_p = top_p
+        self._seed = seed
 
     @property
     def session(self) -> Session:
@@ -354,6 +356,7 @@ class AgentRuntime:
                 tool_choice=self._tool_choice,
                 temperature=self._temperature,
                 top_p=self._top_p,
+                seed=self._seed,
             )
 
             # 3. Call LLM

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -473,6 +473,7 @@ def run_prompt(
     model: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
 ) -> PromptResult:
     """Send a single prompt to an LLM and return its response.
 
@@ -509,6 +510,7 @@ def run_prompt(
         messages=[InputMessage(role="user", content=[TextBlock(text=prompt)])],
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
     )
     response = client.send(request)
     usage = CostTokenUsage(
@@ -540,6 +542,7 @@ def quick_poll(
     synthesis_prompt: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
 ) -> PollResult:
     """Ask one question of a panel and get synthesized findings back.
 
@@ -604,6 +607,7 @@ def quick_poll(
         synthesis_prompt=synthesis_prompt,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
     )
 
     # sp-atvc: re-price per actual model when panelists ran across
@@ -687,6 +691,7 @@ def run_panel(
     synthesis_prompt: str | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     persona_models: dict[str, str] | None = None,
     extract_schema: str | dict[str, Any] | None = None,
     synthesis_temperature: float | None = None,
@@ -776,6 +781,7 @@ def run_panel(
             synthesis_prompt=synthesis_prompt,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
             persona_models=persona_models,
             extract_schema=resolved_extract_schema,
             synthesis_temperature=synthesis_temperature,
@@ -877,6 +883,7 @@ def run_panel(
         synthesis_prompt=synthesis_prompt,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
         persona_models=persona_models,
         extract_schema=resolved_extract_schema,
         synthesis_temperature=synthesis_temperature,

--- a/src/synth_panel/structured/output.py
+++ b/src/synth_panel/structured/output.py
@@ -115,6 +115,7 @@ class StructuredOutputEngine:
         system: str | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
+        seed: int | None = None,
     ) -> StructuredResult:
         """Run a completion with tool-use forcing and extract structured data.
 
@@ -132,6 +133,7 @@ class StructuredOutputEngine:
                     system=system,
                     temperature=temperature,
                     top_p=top_p,
+                    seed=seed,
                 )
             )
             return StructuredResult(data={}, response=response, total_usage=response.usage)
@@ -174,6 +176,7 @@ class StructuredOutputEngine:
                 tool_choice=ToolChoice.specific(config.tool_name),
                 temperature=temperature,
                 top_p=top_p,
+                seed=seed,
             )
 
             try:

--- a/src/synth_panel/synthesis.py
+++ b/src/synth_panel/synthesis.py
@@ -251,6 +251,7 @@ def synthesize_panel(
     panelist_cost: CostEstimate | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
 ) -> SynthesisResult:
     """Synthesize panelist responses into a structured research finding.
 
@@ -298,6 +299,7 @@ def synthesize_panel(
         config=config,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
     )
 
     # Convert usage
@@ -680,6 +682,7 @@ def _sub_chunk_question_synthesis(
     context_limit: int,
     temperature: float | None,
     top_p: float | None,
+    seed: int | None = None,
     question_index: int | None = None,
 ) -> tuple[SynthesisResult, int]:
     """Synthesize one overflowing question by partitioning panelists (sp-4g6a).
@@ -742,6 +745,7 @@ def _sub_chunk_question_synthesis(
             panelist_cost=None,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
         )
         batch_results.append(res)
 
@@ -758,6 +762,7 @@ def _sub_chunk_question_synthesis(
         panelist_cost=None,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
     )
 
     # Aggregate usage / cost across every batch call + the inner reduce
@@ -796,6 +801,7 @@ def synthesize_panel_mapreduce(
     panelist_cost: CostEstimate | None = None,
     temperature: float | None = None,
     top_p: float | None = None,
+    seed: int | None = None,
     personas: list[dict[str, Any]] | None = None,
     max_workers: int | None = None,
     auto_escalate: bool = False,
@@ -932,6 +938,7 @@ def synthesize_panel_mapreduce(
                 context_limit=plan["context_limit"],
                 temperature=temperature,
                 top_p=top_p,
+                seed=seed,
                 question_index=idx,
             )
             meta["batch_count"] = batch_count
@@ -946,6 +953,7 @@ def synthesize_panel_mapreduce(
             panelist_cost=None,
             temperature=temperature,
             top_p=top_p,
+            seed=seed,
         )
         return idx, res, meta
 
@@ -977,6 +985,7 @@ def synthesize_panel_mapreduce(
         panelist_cost=None,
         temperature=temperature,
         top_p=top_p,
+        seed=seed,
     )
 
     # Cost rollup

--- a/tests/test_compat_matrix.py
+++ b/tests/test_compat_matrix.py
@@ -78,6 +78,7 @@ def patched_panel(monkeypatch):
         extract_schema=None,
         temperature=None,
         top_p=None,
+        seed=None,
         persona_models=None,
     ):
         results = [

--- a/tests/test_seed.py
+++ b/tests/test_seed.py
@@ -1,0 +1,173 @@
+"""Tests for the --seed flag (sy-cxp).
+
+Covers:
+- ``CompletionRequest.seed`` propagates through ``build_openai_body``.
+- Anthropic body never carries ``seed`` even when the request has one.
+- ``LLMClient`` warns once per unsupported provider.
+- CLI parser exposes ``--seed`` on ``panel run`` and forwards it.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+from synth_panel.llm.client import LLMClient
+from synth_panel.llm.models import (
+    CompletionRequest,
+    CompletionResponse,
+    InputMessage,
+    StreamEvent,
+    TextBlock,
+    TokenUsage,
+)
+from synth_panel.llm.providers.anthropic import ANTHROPIC_CONFIG, AnthropicProvider
+from synth_panel.llm.providers.base import LLMProvider, ProviderConfig
+from synth_panel.llm.providers.openai_compat import OPENAI_COMPAT_CONFIG
+
+
+def _request(model: str = "gpt-4o-mini", seed: int | None = 42) -> CompletionRequest:
+    return CompletionRequest(
+        model=model,
+        max_tokens=10,
+        messages=[InputMessage(role="user", content=[TextBlock(text="hi")])],
+        seed=seed,
+    )
+
+
+class TestProviderConfigSeed:
+    def test_anthropic_does_not_support_seed(self):
+        assert ANTHROPIC_CONFIG.supports_seed is False
+
+    def test_openai_supports_seed(self):
+        assert OPENAI_COMPAT_CONFIG.supports_seed is True
+
+
+class TestBuildOpenaiBodySeed:
+    def test_seed_in_body(self):
+        from synth_panel.llm.providers._openai_format import build_openai_body
+
+        body = build_openai_body(_request(seed=42))
+        assert body["seed"] == 42
+
+    def test_no_seed_when_none(self):
+        from synth_panel.llm.providers._openai_format import build_openai_body
+
+        body = build_openai_body(_request(seed=None))
+        assert "seed" not in body
+
+
+class TestAnthropicBodyOmitsSeed:
+    def test_anthropic_body_never_includes_seed(self):
+        provider = AnthropicProvider.__new__(AnthropicProvider)
+        provider._api_key = "sk-test"  # type: ignore[attr-defined]
+        provider._base_url = "https://api.anthropic.com"  # type: ignore[attr-defined]
+        body = provider._build_body(_request(model="claude-sonnet-4-6", seed=42))
+        assert "seed" not in body
+
+
+class _FakeProvider(LLMProvider):
+    def __init__(self, config: ProviderConfig) -> None:
+        self.config = config
+        self.last_request: CompletionRequest | None = None
+
+    def send(self, request: CompletionRequest) -> CompletionResponse:
+        self.last_request = request
+        return CompletionResponse(id="x", model=request.model, usage=TokenUsage())
+
+    def stream(self, request: CompletionRequest) -> Iterator[StreamEvent]:
+        self.last_request = request
+        return iter([])
+
+
+class TestSeedWarning:
+    def test_warns_once_for_unsupported_provider(self, caplog):
+        client = LLMClient()
+        fake = _FakeProvider(ANTHROPIC_CONFIG)
+        client._provider_cache["claude-sonnet-4-6"] = fake
+
+        req = _request(model="claude-sonnet-4-6", seed=7)
+        with caplog.at_level(logging.WARNING, logger="synth_panel.llm.client"):
+            client.send(req)
+            client.send(req)
+            client.send(req)
+
+        warnings = [r for r in caplog.records if "--seed" in r.getMessage()]
+        assert len(warnings) == 1
+        assert "Anthropic" in warnings[0].getMessage()
+        assert "7" in warnings[0].getMessage()
+
+    def test_no_warning_for_supporting_provider(self, caplog):
+        client = LLMClient()
+        fake = _FakeProvider(OPENAI_COMPAT_CONFIG)
+        client._provider_cache["gpt-4o-mini"] = fake
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.llm.client"):
+            client.send(_request(model="gpt-4o-mini", seed=42))
+
+        warnings = [r for r in caplog.records if "--seed" in r.getMessage()]
+        assert warnings == []
+
+    def test_no_warning_when_seed_is_none(self, caplog):
+        client = LLMClient()
+        fake = _FakeProvider(ANTHROPIC_CONFIG)
+        client._provider_cache["claude-sonnet-4-6"] = fake
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.llm.client"):
+            client.send(_request(model="claude-sonnet-4-6", seed=None))
+
+        warnings = [r for r in caplog.records if "--seed" in r.getMessage()]
+        assert warnings == []
+
+    def test_warning_is_per_provider(self, caplog):
+        client = LLMClient()
+        anth = _FakeProvider(ANTHROPIC_CONFIG)
+        unknown_cfg = ProviderConfig(
+            api_key_env="X",
+            base_url_env="Y",
+            default_base_url="z",
+            model_prefixes=(),
+            name="LocalLlama",
+            supports_seed=False,
+        )
+        local = _FakeProvider(unknown_cfg)
+        client._provider_cache["claude-sonnet-4-6"] = anth
+        client._provider_cache["llama3"] = local
+
+        with caplog.at_level(logging.WARNING, logger="synth_panel.llm.client"):
+            client.send(_request(model="claude-sonnet-4-6", seed=1))
+            client.send(_request(model="llama3", seed=1))
+
+        warnings = [r for r in caplog.records if "--seed" in r.getMessage()]
+        assert len(warnings) == 2
+        provider_names = sorted("Anthropic" if "Anthropic" in m.getMessage() else "LocalLlama" for m in warnings)
+        assert provider_names == ["Anthropic", "LocalLlama"]
+
+
+class TestCliParser:
+    def test_seed_flag_accepted(self):
+        from synth_panel.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["panel", "run", "--seed", "42", "--personas", "p.yaml", "--instrument", "i.yaml"])
+        assert args.seed == 42
+
+    def test_seed_defaults_to_none(self):
+        from synth_panel.cli.parser import build_parser
+
+        parser = build_parser()
+        args = parser.parse_args(["panel", "run", "--personas", "p.yaml", "--instrument", "i.yaml"])
+        assert args.seed is None
+
+
+class TestRequestPropagation:
+    """End-to-end: seed on the public request reaches the provider."""
+
+    def test_seed_reaches_provider(self):
+        client = LLMClient()
+        fake = _FakeProvider(OPENAI_COMPAT_CONFIG)
+        client._provider_cache["gpt-4o-mini"] = fake
+
+        client.send(_request(model="gpt-4o-mini", seed=99))
+        assert fake.last_request is not None
+        assert fake.last_request.seed == 99


### PR DESCRIPTION
Adds `--seed` flag for `synthpanel panel run` with provider-aware fallback handling.

**Source bead:** sy-cxp (yggdrasil rig: synthpanel)
**Stranded recovery:** Polecat onyx pushed this work but `gt done` deadlocked on missing tracking bead before MERGE_READY could be sent (root cause documented by jotunheim mayor in [FRICTION] gt-done wisp). Yggdrasil rebuilt bd to server mode; PR opened manually by mayor to recover the work.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)