### PR TITLE
feat: add `synthpanel domains list/inspect` and 4 bundled domain templates (sy-pb6)

### DIFF
--- a/site/cli-coverage.txt
+++ b/site/cli-coverage.txt
@@ -14,6 +14,7 @@
 analyze
 cost
 doctor
+domains
 install-skills
 instruments
 login

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -4668,6 +4668,52 @@ def handle_instruments_graph(args: argparse.Namespace, fmt: OutputFormat) -> int
     return 0
 
 
+def handle_domains_list(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """List bundled domain prompt templates."""
+    from synth_panel.domains import list_domain_templates
+
+    domains = list_domain_templates()
+
+    if fmt is OutputFormat.TEXT:
+        if not domains:
+            print("No domain templates registered.")
+            return 0
+        width = max(len(d["name"]) for d in domains)
+        for d in domains:
+            print(f"  {d['name']:<{width}}  {d['description']}")
+    else:
+        emit(fmt, message="Domain templates", extra={"domains": domains})
+    return 0
+
+
+def handle_domains_inspect(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Print a domain template's full prompt body and metadata."""
+    from synth_panel.domains import DomainNotFoundError, get_domain_template
+
+    try:
+        template = get_domain_template(args.name)
+    except DomainNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.TEXT:
+        print(f"name:        {args.name}")
+        print(f"label:       {template.get('name', '')}")
+        print(f"description: {template.get('description', '')}")
+        print()
+        print("template:")
+        body = template.get("template", "")
+        for line in body.splitlines() or [""]:
+            print(f"  {line}")
+    else:
+        emit(
+            fmt,
+            message="Domain template",
+            extra={"name": args.name, "template": template},
+        )
+    return 0
+
+
 def _render_text_dag(instrument: Instrument) -> str:
     """Plain-text node + edge listing of an instrument's round DAG."""
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1021,6 +1021,28 @@ def build_parser() -> argparse.ArgumentParser:
         help="DAG output format (default: text).",
     )
 
+    # domains — bundled persona-generation domain templates
+    domains_parser = subparsers.add_parser(
+        "domains",
+        help="Inspect bundled domain templates that guide persona generation.",
+    )
+    domains_subparsers = domains_parser.add_subparsers(dest="domains_command")
+
+    domains_subparsers.add_parser(
+        "list",
+        help="List all bundled domain templates.",
+    )
+
+    domains_inspect_parser = domains_subparsers.add_parser(
+        "inspect",
+        help="Show a domain template's full prompt body and metadata.",
+    )
+    domains_inspect_parser.add_argument(
+        "name",
+        metavar="NAME",
+        help="Domain template name (as listed by 'domains list', e.g. career-tech).",
+    )
+
     # analyze
     analyze_parser = subparsers.add_parser(
         "analyze",

--- a/src/synth_panel/domains.py
+++ b/src/synth_panel/domains.py
@@ -85,6 +85,74 @@ _TEMPLATES: dict[str, dict[str, str]] = {
             "Each persona should reflect real clinical workflow constraints and patient care priorities."
         ),
     },
+    "education-k12": {
+        "name": "K-12 Educators",
+        "description": "Teachers, administrators, and support staff across grade bands.",
+        "template": (
+            "Generate a diverse panel of K-12 educators. Include:\n"
+            "- Roles: classroom teachers, principals, assistant principals, paraprofessionals,\n"
+            "  district staff, instructional coaches, school counselors, special-ed teachers\n"
+            "- Grade bands: early elementary (K-2), upper elementary (3-5), middle (6-8), high (9-12)\n"
+            "- Subjects (secondary): ELA, math, science, social studies, electives, CTE\n"
+            "- School types: public, charter, magnet, private, rural, urban, suburban\n"
+            "- Experience: novice (0-3 yrs), mid-career (4-15 yrs), veteran (15+ yrs)\n"
+            "- Ages: spread across 23-62\n"
+            "- Attitudes: tech-forward, traditionalist, burned-out, idealistic, pragmatic\n"
+            "Each persona should reflect real classroom constraints, district politics, and student-population context."
+        ),
+    },
+    "enterprise-buyers": {
+        "name": "Enterprise Software Buyers",
+        "description": "Decision-makers who evaluate and purchase B2B software at >250-seat orgs.",
+        "template": (
+            "Generate a diverse panel of enterprise software buyers. Include:\n"
+            "- Functions: IT/CIO org, security, finance/procurement, HR, sales ops,\n"
+            "  marketing ops, engineering leadership, operations\n"
+            "- Buyer roles: economic buyer, technical evaluator, end-user champion, procurement gatekeeper\n"
+            "- Org sizes: mid-market (250-2k seats), enterprise (2k-25k), F500 (25k+)\n"
+            "- Industries: financial services, healthcare, manufacturing, retail, public sector, tech\n"
+            "- Deal sizes typically signed off: <$50k, $50-250k, $250k-1M, $1M+\n"
+            "- Ages: spread across 32-60\n"
+            "- Attitudes: risk-averse vs. innovator, vendor-loyal vs. best-of-breed, cost-led vs. outcome-led\n"
+            "Each persona should reflect real procurement constraints (security review, legal, budget cycles) and the\n"
+            "specific stakeholders they must align before signing."
+        ),
+    },
+    "creators": {
+        "name": "Content Creators",
+        "description": "Independent creators monetizing audiences across platforms.",
+        "template": (
+            "Generate a diverse panel of content creators. Include:\n"
+            "- Primary platforms: YouTube, TikTok, Instagram, Twitch, Substack, podcasting, X/Twitter\n"
+            "- Audience size: nano (<10k), micro (10-100k), mid (100k-1M), macro (1M+)\n"
+            "- Niches: lifestyle, gaming, education, tech, beauty, fitness, finance, comedy, news\n"
+            "- Monetization mix: ad revenue, brand deals, merch, subscriptions/memberships, courses, affiliate\n"
+            "- Career stage: side hustle, transitioning full-time, full-time established, post-burnout pivot\n"
+            "- Ages: spread across 19-50\n"
+            "- Attitudes: algorithm-chaser vs. community-builder, brand-friendly vs. anti-sponsorship,\n"
+            "  optimistic vs. burnt-out\n"
+            "Each persona should reflect real platform-specific economics and creator-burnout dynamics."
+        ),
+    },
+    "graduate-students": {
+        "name": "Graduate Students",
+        "description": "Master's and PhD students across discipline clusters.",
+        "template": (
+            "Generate a diverse panel of graduate students. Include:\n"
+            "- Degree programs: PhD, research master's, professional master's (MBA, MPH, MSW, MFA, JD)\n"
+            "- Discipline clusters: STEM (CS, bio, physics, engineering), humanities (history, literature,\n"
+            "  philosophy), social sciences (psych, econ, sociology), professional (medicine, law, business)\n"
+            "- Year in program: first-year, mid-program, ABD/dissertating, defending\n"
+            "- Funding situation: fully funded, TA-supported, partial scholarship, self-funded/loans\n"
+            "- Institution type: R1 research, R2, regional, professional school, international\n"
+            "- Ages: spread across 22-42\n"
+            "- Career intent: academia/professoriate, industry research, government/policy, entrepreneurship,\n"
+            "  unsure/exploring\n"
+            "- Attitudes: idealistic, jaded, burned-out, careerist, vocational\n"
+            "Each persona should reflect real advisor-relationship dynamics, funding precarity,\n"
+            "and post-grad job-market anxieties."
+        ),
+    },
 }
 
 

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -13,6 +13,8 @@ from synth_panel.cli.commands import (
     handle_analyze_subgroup,
     handle_cost_summary,
     handle_doctor,
+    handle_domains_inspect,
+    handle_domains_list,
     handle_install_skills,
     handle_instruments_graph,
     handle_instruments_install,
@@ -116,6 +118,15 @@ def main(argv: list[str] | None = None) -> int:
             return handle_instruments_graph(args, output_format)
         else:
             parser.parse_args(["instruments", "--help"])
+            return 1
+    elif args.command == "domains":
+        sub = getattr(args, "domains_command", None)
+        if sub == "list":
+            return handle_domains_list(args, output_format)
+        elif sub == "inspect":
+            return handle_domains_inspect(args, output_format)
+        else:
+            parser.parse_args(["domains", "--help"])
             return 1
     elif args.command == "cost":
         sub = getattr(args, "cost_command", None)

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -43,6 +43,11 @@ class TestListDomainTemplates:
         templates = list_domain_templates()
         assert len(templates) >= 3
 
+    def test_returns_at_least_four(self):
+        # sy-pb6 acceptance: bundled registry must surface ≥4 entries.
+        templates = list_domain_templates()
+        assert len(templates) >= 4
+
     def test_entries_have_required_keys(self):
         for entry in list_domain_templates():
             assert "name" in entry
@@ -52,6 +57,33 @@ class TestListDomainTemplates:
         templates = list_domain_templates()
         names = [t["name"] for t in templates]
         assert names == sorted(names)
+
+
+class TestBundledDomainShape:
+    """Each bundled domain must have the same structural shape as career-tech."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "education-k12",
+            "enterprise-buyers",
+            "creators",
+            "graduate-students",
+        ],
+    )
+    def test_new_domain_loads_and_has_shape(self, name):
+        t = get_domain_template(name)
+        # Same keys as the reference template.
+        ref = get_domain_template("career-tech")
+        assert set(t.keys()) == set(ref.keys())
+        # Non-empty content with enough specificity to drive distinguishable personas.
+        assert isinstance(t["name"], str) and t["name"].strip()
+        assert isinstance(t["description"], str) and t["description"].strip()
+        body = t["template"]
+        assert isinstance(body, str)
+        # Templates should encode multiple bullet-point dimensions like career-tech.
+        assert body.count("\n- ") >= 4, f"{name}: expected ≥4 bullet dimensions"
+        assert "Each persona" in body or "each persona" in body
 
 
 # ---------------------------------------------------------------------------
@@ -216,3 +248,63 @@ class TestDeliberatelyHomogeneous:
         categories = " ".join(warnings).lower()
         assert "age diversity" in categories
         assert "background variety" in categories
+
+
+# ---------------------------------------------------------------------------
+# CLI surface: `synthpanel domains list` / `synthpanel domains inspect`
+# ---------------------------------------------------------------------------
+
+
+class TestDomainsCLI:
+    def test_list_text(self, capsys):
+        from synth_panel.main import main
+
+        code = main(["domains", "list"])
+        out = capsys.readouterr().out
+        assert code == 0
+        # career-tech is the founding bundled entry; tests rely on its presence.
+        assert "career-tech" in out
+        # And at least two of the new entries.
+        new_entries = ("education-k12", "enterprise-buyers", "creators", "graduate-students")
+        assert sum(1 for n in new_entries if n in out) >= 2
+
+    def test_list_json(self, capsys):
+        import json as _json
+
+        from synth_panel.main import main
+
+        code = main(["--output-format", "json", "domains", "list"])
+        assert code == 0
+        payload = _json.loads(capsys.readouterr().out)
+        names = [d["name"] for d in payload["domains"]]
+        assert "career-tech" in names
+        assert len(names) >= 4
+
+    def test_inspect_text(self, capsys):
+        from synth_panel.main import main
+
+        code = main(["domains", "inspect", "career-tech"])
+        out = capsys.readouterr().out
+        assert code == 0
+        assert "career-tech" in out
+        assert "template:" in out
+        assert "Generate a diverse panel" in out
+
+    def test_inspect_unknown_returns_nonzero(self, capsys):
+        from synth_panel.main import main
+
+        code = main(["domains", "inspect", "no-such-domain"])
+        err = capsys.readouterr().err
+        assert code == 1
+        assert "no-such-domain" in err
+
+    def test_inspect_json(self, capsys):
+        import json as _json
+
+        from synth_panel.main import main
+
+        code = main(["--output-format", "json", "domains", "inspect", "career-tech"])
+        assert code == 0
+        payload = _json.loads(capsys.readouterr().out)
+        assert payload["name"] == "career-tech"
+        assert "template" in payload["template"]


### PR DESCRIPTION
Adds `synthpanel domains list` and `synthpanel domains inspect` CLI commands plus 4 new bundled domain templates.

**Source bead:** sy-pb6 (yggdrasil rig: synthpanel)
**Stranded recovery:** Polecat opal pushed this work but `gt done` deadlocked on missing tracking bead. Yggdrasil rebuilt bd to server mode; PR opened manually by mayor to recover.

Note: midgard's #339-related batch (#406-#420) covered AC-/AR- surface; this domains-list work is in a separate lane and confirmed non-overlapping.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)