### PR TITLE
fix(ci): auto-tag fails loud on missing semver label + fetches fresh labels (sy-73j)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -30,9 +30,18 @@ jobs:
       - name: Parse semver labels
         id: check
         env:
-          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
+          # Fetch labels via gh API rather than reading
+          # github.event.pull_request.labels from the event payload. `gh run
+          # rerun` replays the original payload, so labels added after the
+          # initial merge (the recovery path for a missing semver label) are
+          # invisible to the rerun otherwise. See sy-73j.
+          LABELS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '[.labels[].name]')
+          echo "Labels (fresh fetch): $LABELS"
+
           SEMVER_LABELS=$(echo "$LABELS" | jq -r '.[] | select(startswith("semver:"))' | grep -v '^semver:skip$' || true)
           SKIP=$(echo "$LABELS" | jq -r '.[] | select(. == "semver:skip")' || true)
 
@@ -45,18 +54,14 @@ jobs:
           COUNT=$(echo "$SEMVER_LABELS" | grep -c . || true)
 
           if [ "$COUNT" -eq 0 ]; then
-            # Release PRs (titled `chore(release): ...` or `release: ...`) MUST
-            # carry an explicit semver label. v0.9.2 (PR #163) merged without
-            # one, auto-tag silently skipped, PyPI publish never fired, and the
-            # release had to be cut by hand (sp-42i). Fail loudly for release
-            # PRs so the omission surfaces as a red check instead of vanishing.
-            if printf '%s' "$PR_TITLE" | grep -Eq '^(chore\(release\)|release):'; then
-              echo "::error::Release PR '$PR_TITLE' has no semver label. Add semver:patch, semver:minor, semver:major, or semver:skip and re-run this workflow."
-              exit 1
-            fi
-            echo "No semver label found — skipping release"
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            # Every merged PR MUST carry an explicit semver:* label
+            # (patch/minor/major to bump, or semver:skip to opt out). Prior
+            # behaviour silently skipped on missing label, which hid two
+            # release misses (v0.9.2 / PR #163 — sp-42i, and PR #453 — sy-73j)
+            # behind a green check. Fail loud so the merging mayor sees a red
+            # ❌ on the PR and remediates before the omission ships.
+            echo "::error::PR #${PR_NUMBER} '$PR_TITLE' merged without a semver label. Add semver:patch, semver:minor, semver:major, or semver:skip and re-run this workflow."
+            exit 1
           fi
 
           if [ "$COUNT" -gt 1 ]; then


### PR DESCRIPTION
## Summary

PR #453 merged without a `semver:*` label. The auto-tag workflow logged an
`::error::`, set `skipped=true`, and the job concluded with **success** — so no
`v1.1.0` tag was created and `publish.yml` never fired. The release had to be
hand-cut. The same silent-skip mode previously bit v0.9.2 (sp-42i).

This fixes the auto-tag workflow so:

1. **Missing-semver-label now fails loud** for any merged PR (previously only release-titled PRs failed; everything else silently skipped). Merging without a semver decision now surfaces as a red ❌ on the PR.
2. **Labels are fetched fresh** via `gh api repos/.../pulls/N` instead of `github.event.pull_request.labels`. `gh run rerun` replays the original event payload, so adding a label post-merge and rerunning was a no-op against the stale payload. Fresh-fetch makes the documented recovery path (add label → rerun workflow) actually work.

`semver:skip` and `semver:patch` / `:minor` / `:major` paths are unchanged.

## Changes

- `.github/workflows/auto-tag.yml`:
  - missing-semver-label branch: `exit 1` for any merged PR (was: only release-titled PRs).
  - fetch fresh PR labels via `gh api` instead of reading the stale workflow event payload.

## Test plan

- Manual verification on the next polecat PR — merging without `semver:*` should now leave a red check, and adding the label + rerunning the workflow should pick it up.
- GitHub CI runs the workflow lint / actions analyze checks on this PR.

## References

- Bead: sy-73j
- Prior incident: sp-42i (v0.9.2 silent skip)
- Triggering miss: PR #453 (v1.1.0 hand-cut)
- MR: sy-wisp-2x9
- Polecat: garnet
- Branch: polecat/garnet-mp38q94t