### PR TITLE
fix(ci): auto-tag bumps __version__.py + re-renders site before tagging (sy-r87)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -152,6 +152,45 @@ jobs:
           echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
           echo "New tag: $NEW_TAG"
 
+      # Sync src/synth_panel/__version__.py (and the rendered landing page,
+      # which derives from it) to the new tag BEFORE tagging. pyproject.toml
+      # uses `version = {attr = "synth_panel.__version__.__version__"}`, so
+      # the build's package version is whatever this file says at the tagged
+      # SHA. Without this step, the tagged commit carries the previous
+      # version string and the resulting sdist/wheel is named after the
+      # previous release — which, since sy-4qa adopted python-publish.yml's
+      # `skip-existing: true`, now silently no-ops at PyPI instead of going
+      # red. See sy-r87.
+      - name: Bump __version__.py and re-render site
+        if: steps.check.outputs.skipped != 'true'
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.tag }}
+        run: |
+          VERSION="${NEW_TAG#v}"
+          printf '__version__ = "%s"\n' "$VERSION" > src/synth_panel/__version__.py
+          # Keep site/index.html (committed artifact) in lockstep — otherwise
+          # the test_committed_index_matches_template_render guard fails on
+          # the next push to main. render_site.py is stdlib-only Python so it
+          # runs without a setup-python step.
+          python scripts/render_site.py
+
+      - name: Commit version bump to main
+        if: steps.check.outputs.skipped != 'true'
+        env:
+          NEW_TAG: ${{ steps.bump.outputs.tag }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add src/synth_panel/__version__.py site/index.html
+          if git diff --staged --quiet; then
+            echo "__version__.py and site already at ${NEW_TAG} (dev pre-bumped in PR) — nothing to commit."
+          else
+            VERSION="${NEW_TAG#v}"
+            git commit -m "chore(release): sync __version__.py to ${VERSION} (PR #${PR_NUMBER}) (sy-r87)"
+            git push origin HEAD:main
+          fi
+
       - name: Create and push tag
         if: steps.check.outputs.skipped != 'true'
         env:
@@ -162,6 +201,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           MSG=$(printf 'Release %s (PR #%s: %s)' "$NEW_TAG" "$PR_NUMBER" "$PR_TITLE")
+          # Tag the bump commit (or the unchanged HEAD if dev pre-bumped) so
+          # the publish workflow, invoked at `--ref $NEW_TAG`, sees the
+          # matching __version__.py.
           git tag -a "$NEW_TAG" -m "$MSG"
           git push origin "$NEW_TAG"
 


### PR DESCRIPTION
## Summary

`auto-tag.yml` now writes the new version to `src/synth_panel/__version__.py`
(and re-renders `site/index.html` so the committed artifact stays in lockstep)
**before** creating the release tag. Previously the tagged commit carried the
*previous* version string, because `pyproject.toml` uses
`version = {attr = "synth_panel.__version__.__version__"}` and nothing
updated that file on tag creation. Combined with sy-4qa's adoption of
`skip-existing: true` in the shared publish workflow, that mismatch had
stopped going red and would silently no-op at PyPI on every release —
masking missed uploads.

## Evidence

`v1.4.1` tag points at a commit where `__version__.py` reads `"1.4.0"`; PyPI
latest is `1.4.0` because the 1.4.1 release built a `1.4.0` filename and
collided with the already-published artifact.

## Changes

- `.github/workflows/auto-tag.yml`: added **"Bump `__version__.py` and re-render site"** + **"Commit version bump to main"** steps. They run after the version is computed and before the tag is created, so the tag points at a commit whose package version matches the tag.
- If the dev already bumped `__version__.py` in their PR (so `git diff --staged` is empty), the bump commit is skipped and HEAD is tagged unchanged.

## Test plan

- No new automated tests — workflow change is exercised only on PR merge to main. Verified locally that the existing `render_site.py` runs on stdlib alone (no `setup-python` needed) and produces an `index.html` identical to the committed one when `__version__.py` is unchanged.
- `yaml.safe_load` parses the modified workflow without errors.
- **Live integration test**: the first PR merged after this lands will exercise it — expect a `chore(release): sync __version__.py to X.Y.Z` commit on main from `github-actions[bot]` immediately before the `v{X.Y.Z}` tag.

## References

- Bead: sy-r87
- Related: sy-4qa (#458 — adopted shared `python-publish.yml` with `skip-existing: true`, which turned this latent bug into a silent failure mode)
- MR: sy-wisp-b9j
- Polecat: garnet
- Branch: polecat/garnet-mp3colk5