### PR TITLE
docs: clarify builtin vs registry packs in README + registry.md (sy-6o3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,52 @@ today.
 
 Full spec: [`specs/sp-viz-layer/`](specs/sp-viz-layer/).
 
+## Packs: Builtin vs Registry
+
+synthpanel has two kinds of packs, and the distinction matters when you're
+searching for one:
+
+- **Builtin packs** ship inside the `synthpanel` wheel. After `pip install
+  synthpanel` they are immediately resolvable by name — no `pack import`, no
+  network. Reference them anywhere a `--personas` or `--instrument` argument
+  takes a *name* (the unified resolver also accepts a YAML path).
+- **Registry packs** are community-authored. They live in third-party GitHub
+  repos and are listed in
+  [`DataViking-Tech/synthpanel-registry`](https://github.com/DataViking-Tech/synthpanel-registry).
+  You pull them with `synthpanel pack import gh:user/repo`; once imported they
+  become resolvable by name like a builtin. See [docs/registry.md](docs/registry.md)
+  for URI forms, verification, offline cache, and the submission flow.
+
+### Builtin persona packs (10, 160 personas total)
+
+| Pack | Personas |
+|------|----------|
+| `ai-eval-buyers` | 20 |
+| `developer` | 15 |
+| `enterprise-buyer` | 15 |
+| `general-consumer` | 15 |
+| `healthcare-patient` | 15 |
+| `job-seekers` | 15 |
+| `product-research` | 20 |
+| `recruiters-talent` | 15 |
+| `startup-founder` | 15 |
+| `students` | 15 |
+
+`synthpanel pack list` (or MCP `list_persona_packs`) enumerates these plus any
+user-saved packs.
+
+### Builtin instrument packs (8, all v3 branching)
+
+`churn-diagnosis`, `feature-prioritization`, `general-survey`,
+`landing-page-comprehension`, `market-research`, `name-test`,
+`pricing-discovery`, `product-feedback`.
+
+`synthpanel instruments list` enumerates these plus any installed packs.
+
+If you searched the registry for one of the names above and came up empty,
+that's expected — they're SDK builtins, not registry entries. Use the name
+directly with `panel run --personas <name>` or `--instrument <name>`.
+
 ## Defining Personas
 
 ```yaml
@@ -686,9 +732,9 @@ synthpanel panel run \
   --instrument pricing-discovery
 ```
 
-`pricing-discovery` is one of five bundled v3 packs (`pricing-discovery`,
-`name-test`, `feature-prioritization`, `landing-page-comprehension`,
-`churn-diagnosis`). List them with `synthpanel instruments list`.
+`pricing-discovery` is one of eight bundled v3 instrument packs (see
+[Builtin instrument packs](#builtin-instrument-packs-8-all-v3-branching)
+above). List them with `synthpanel instruments list`.
 
 The output now carries a `path` array recording the routing decisions
 that actually fired:

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -1,8 +1,30 @@
 # Pack Registry
 
-synthpanel ships with a small set of bundled persona packs, but most interesting
-packs are written by the community. The **pack registry** is how you discover,
-pull, and publish those packs without leaving the CLI.
+## Builtin vs Registry packs
+
+synthpanel has two pack sources, and the difference matters when you're trying
+to find one:
+
+- **Builtin packs** ship inside the `synthpanel` wheel. They are resolvable by
+  name the moment `pip install synthpanel` finishes — no `pack import`, no
+  network, no registry lookup. The SDK currently bundles **10 persona packs**
+  (160 personas total: `ai-eval-buyers`, `developer`, `enterprise-buyer`,
+  `general-consumer`, `healthcare-patient`, `job-seekers`, `product-research`,
+  `recruiters-talent`, `startup-founder`, `students`) and **8 v3 branching
+  instrument packs** (`churn-diagnosis`, `feature-prioritization`,
+  `general-survey`, `landing-page-comprehension`, `market-research`,
+  `name-test`, `pricing-discovery`, `product-feedback`). See the
+  [primary README's pack overview](../README.md#packs-builtin-vs-registry)
+  for the same list with per-pack persona counts.
+- **Registry packs** are community-authored. They live in third-party GitHub
+  repos and are listed in the registry index described below. You pull them
+  with `synthpanel pack import gh:user/repo`.
+
+If you searched the registry for a builtin pack name and came up empty, that's
+expected — the registry only indexes community-authored packs. Use the builtin
+name directly with `--personas` or `--instrument`.
+
+## The registry
 
 The registry itself is a JSON index (`default.json`) hosted at
 [`DataViking-Tech/synthpanel-registry`](https://github.com/DataViking-Tech/synthpanel-registry).


### PR DESCRIPTION
## Summary

Adds an up-front "Packs: Builtin vs Registry" section to README.md enumerating the 10 builtin persona packs (160 personas) and 8 builtin v3 instrument packs, with a cross-link to docs/registry.md. Mirrors the distinction at the top of docs/registry.md and replaces the stale "one of five bundled v3 packs" claim. Resolves the PMF-research finding that agents searching the registry for SDK-builtin pack names come up empty because builtins are not registry entries.

## Changes

- `README.md`: new "Packs: Builtin vs Registry" section listing 10 persona packs with counts and 8 v3 instrument packs; fixed stale "five bundled v3 packs" → "8 bundled v3 packs" with cross-link.
- `docs/registry.md`: mirrors the builtin-vs-registry distinction up front, enumerates builtin pack names and counts, links back to README.

## Test plan

- Docs-only change — no code paths touched. CI lint/typecheck/coverage/security/test matrices still apply.

## References

- Bead: sy-6o3
- Upstream report: DataViking-Tech/SynthBench#260

Closes #461