### PR TITLE
feat(cli): add 'synthpanel mcp install' to autoregister MCP server (sy-skf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
-(Empty — next-cycle work lands here.)
+### Added
+
+- **`synthpanel mcp install` CLI (sy-skf).** Registers synthpanel as a
+  stdio MCP server in a host's JSON config — defaults to Claude Code's
+  user-scope `~/.claude.json`, with `--scope project` for `./.mcp.json`
+  and `--target` for arbitrary hosts (Cursor, Windsurf, …). Supports
+  `--env KEY=VALUE` for inline credentials, `--force` to overwrite an
+  existing entry, `--dry-run` to preview, and `--uninstall` to remove
+  the entry. Mirrors GH#463; eliminates the hand-edit-and-restart step
+  documented in the MCP README.
 
 ## [1.4.0] - 2026-05-12
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -14,7 +14,22 @@ The server communicates over stdin/stdout using JSON-RPC (the MCP protocol). It 
 
 ### Claude Code / Cursor / Windsurf
 
-Add to your MCP config (e.g., `.claude/mcp.json`, `.cursor/mcp.json`):
+The fastest path is the bundled installer (sy-skf):
+
+```bash
+synthpanel mcp install                                 # writes ~/.claude.json
+synthpanel mcp install --scope project                 # writes ./.mcp.json (checked in)
+synthpanel mcp install --target ~/.cursor/mcp.json     # any host with mcpServers
+synthpanel mcp install --env ANTHROPIC_API_KEY=sk-...  # bake credentials into the entry
+synthpanel mcp install --uninstall                     # remove the entry
+```
+
+The command merges into the host's existing `mcpServers` map, refuses to
+overwrite a clashing entry without `--force`, and writes user-scoped
+files with mode `0600`. `--dry-run` previews the change without touching
+disk.
+
+If you'd rather hand-edit, the entry it produces is:
 
 ```json
 {

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -4422,6 +4422,49 @@ def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return 0
 
 
+def handle_mcp_install(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Register synthpanel as an MCP server in a host's JSON config (sy-skf)."""
+    from synth_panel.cli import mcp_install as helper
+
+    target = helper.resolve_target(getattr(args, "scope", "user"), getattr(args, "target", None))
+    name = getattr(args, "name", None) or helper.DEFAULT_SERVER_NAME
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    try:
+        if getattr(args, "uninstall", False):
+            result = helper.uninstall(target=target, name=name, dry_run=dry_run)
+        else:
+            try:
+                env = helper.parse_env_pairs(getattr(args, "mcp_env", None))
+            except ValueError as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                return 1
+            command = helper.resolve_command(getattr(args, "mcp_command_override", None))
+            result = helper.install(
+                target=target,
+                name=name,
+                command=command,
+                env=env,
+                force=bool(getattr(args, "force", False)),
+                dry_run=dry_run,
+            )
+    except FileExistsError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: failed to parse {target}: {exc}", file=sys.stderr)
+        return 1
+    except OSError as exc:
+        print(f"Error: failed to write {target}: {exc}", file=sys.stderr)
+        return 1
+
+    if fmt is OutputFormat.JSON:
+        print(helper.format_json(result))
+    else:
+        print(helper.format_text(result))
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # install-skills (sy-65k74)
 # ---------------------------------------------------------------------------

--- a/src/synth_panel/cli/mcp_install.py
+++ b/src/synth_panel/cli/mcp_install.py
@@ -1,0 +1,202 @@
+"""Helpers for `synthpanel mcp install` (sy-skf).
+
+Edits a host's MCP config JSON file in-place (or creates it) so that
+synthpanel is registered as a stdio MCP server. The default target is
+Claude Code's user config (~/.claude.json), but the helpers are
+host-agnostic — they only touch the ``mcpServers`` mapping.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SERVER_NAME = "synth_panel"
+
+
+@dataclass
+class InstallResult:
+    """Outcome of an install/uninstall call."""
+
+    target: Path
+    name: str
+    action: str  # "installed", "updated", "removed", "noop", "would-install", "would-update", "would-remove"
+    entry: dict[str, Any] | None  # the server entry that was written (None for remove/noop)
+
+
+def resolve_target(scope: str, target: str | None) -> Path:
+    """Resolve which config file to edit."""
+    if target:
+        return Path(target).expanduser()
+    if scope == "project":
+        return Path.cwd() / ".mcp.json"
+    return Path.home() / ".claude.json"
+
+
+def resolve_command(explicit: str | None) -> str:
+    """Resolve the command string the host should invoke."""
+    if explicit:
+        return explicit
+    found = shutil.which("synthpanel")
+    return found or "synthpanel"
+
+
+def parse_env_pairs(pairs: list[str] | None) -> dict[str, str]:
+    """Parse ``KEY=VALUE`` items into a dict; raise ValueError on bad input."""
+    out: dict[str, str] = {}
+    if not pairs:
+        return out
+    for item in pairs:
+        if "=" not in item:
+            raise ValueError(f"--env expects KEY=VALUE, got {item!r}")
+        key, _, value = item.partition("=")
+        key = key.strip()
+        if not key:
+            raise ValueError(f"--env has empty key in {item!r}")
+        out[key] = value
+    return out
+
+
+def build_entry(command: str, env: dict[str, str]) -> dict[str, Any]:
+    """Build the JSON object the host expects under ``mcpServers[<name>]``."""
+    entry: dict[str, Any] = {
+        "command": command,
+        "args": ["mcp-serve"],
+    }
+    if env:
+        entry["env"] = env
+    return entry
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    """Load a JSON config file; return ``{}`` if missing or empty."""
+    if not path.exists():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    if not text.strip():
+        return {}
+    data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path}: top-level JSON must be an object, got {type(data).__name__}")
+    return data
+
+
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    """Write ``data`` as pretty-printed JSON, atomically, with mode 0600 on user configs."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = json.dumps(data, indent=2, sort_keys=False) + "\n"
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(serialized, encoding="utf-8")
+    # Match restrictive perms when the file lives under $HOME — the entry
+    # may carry an API key in env, mirroring credentials.json hygiene.
+    try:
+        if str(path).startswith(str(Path.home())):
+            os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    tmp.replace(path)
+
+
+def install(
+    *,
+    target: Path,
+    name: str,
+    command: str,
+    env: dict[str, str],
+    force: bool,
+    dry_run: bool,
+) -> InstallResult:
+    """Insert or update the named server entry."""
+    config = _load_config(target)
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        servers = {}
+
+    existing = servers.get(name)
+    new_entry = build_entry(command, env)
+
+    if existing == new_entry:
+        return InstallResult(target=target, name=name, action="noop", entry=new_entry)
+
+    is_update = name in servers
+    if is_update and not force:
+        raise FileExistsError(
+            f"MCP server {name!r} already exists in {target}. Pass --force to overwrite, or choose a different --name."
+        )
+
+    if dry_run:
+        servers[name] = new_entry
+        config["mcpServers"] = servers
+        action = "would-update" if is_update else "would-install"
+        return InstallResult(target=target, name=name, action=action, entry=new_entry)
+
+    servers[name] = new_entry
+    config["mcpServers"] = servers
+    _atomic_write(target, config)
+    action = "updated" if is_update else "installed"
+    return InstallResult(target=target, name=name, action=action, entry=new_entry)
+
+
+def uninstall(*, target: Path, name: str, dry_run: bool) -> InstallResult:
+    """Remove the named server entry. No-op if it isn't present."""
+    if not target.exists():
+        return InstallResult(target=target, name=name, action="noop", entry=None)
+
+    config = _load_config(target)
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict) or name not in servers:
+        return InstallResult(target=target, name=name, action="noop", entry=None)
+
+    if dry_run:
+        return InstallResult(target=target, name=name, action="would-remove", entry=None)
+
+    del servers[name]
+    config["mcpServers"] = servers
+    _atomic_write(target, config)
+    return InstallResult(target=target, name=name, action="removed", entry=None)
+
+
+def format_text(result: InstallResult) -> str:
+    """Render an InstallResult as a single human-readable line."""
+    if result.action in ("noop",):
+        return f"No changes needed for {result.name!r} in {result.target}."
+    if result.action in ("removed", "would-remove"):
+        verb = "Would remove" if result.action.startswith("would-") else "Removed"
+        return f"{verb} MCP server {result.name!r} from {result.target}."
+    verb = {
+        "installed": "Installed",
+        "updated": "Updated",
+        "would-install": "Would install",
+        "would-update": "Would update",
+    }[result.action]
+    return f"{verb} MCP server {result.name!r} in {result.target}."
+
+
+def format_json(result: InstallResult) -> str:
+    """Render an InstallResult as a one-line JSON payload."""
+    payload: dict[str, Any] = {
+        "target": str(result.target),
+        "name": result.name,
+        "action": result.action,
+    }
+    if result.entry is not None:
+        payload["entry"] = result.entry
+    return json.dumps(payload)
+
+
+__all__ = [
+    "DEFAULT_SERVER_NAME",
+    "InstallResult",
+    "build_entry",
+    "format_json",
+    "format_text",
+    "install",
+    "parse_env_pairs",
+    "resolve_command",
+    "resolve_target",
+    "uninstall",
+]

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1181,6 +1181,89 @@ def build_parser() -> argparse.ArgumentParser:
         help="Start the MCP server (stdio transport).",
     )
 
+    # mcp (sy-skf): author-time tooling for MCP host registration
+    mcp_parser = subparsers.add_parser(
+        "mcp",
+        help="MCP host integration: register synthpanel as an MCP server in Claude Code, Cursor, etc.",
+    )
+    mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command")
+
+    mcp_install_parser = mcp_subparsers.add_parser(
+        "install",
+        help=(
+            "Register synthpanel as an MCP server in a host's config "
+            "(default: Claude Code user config at ~/.claude.json). "
+            "Pass --uninstall to remove the entry instead of writing it."
+        ),
+    )
+    mcp_install_parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        default=False,
+        help="Remove the synthpanel MCP server entry instead of installing it.",
+    )
+    mcp_install_parser.add_argument(
+        "--scope",
+        choices=["user", "project"],
+        default="user",
+        help=(
+            "Where to write the entry. 'user' (default) edits "
+            "~/.claude.json so the server is available in every Claude "
+            "Code session. 'project' edits ./.mcp.json so the entry is "
+            "checked in alongside the repo and shared with collaborators."
+        ),
+    )
+    mcp_install_parser.add_argument(
+        "--target",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Override the JSON config file path. When set, --scope is "
+            "ignored. Useful for editors other than Claude Code (e.g. "
+            "--target ~/.cursor/mcp.json)."
+        ),
+    )
+    mcp_install_parser.add_argument(
+        "--name",
+        default="synth_panel",
+        help="Name to register the server under (default: synth_panel).",
+    )
+    mcp_install_parser.add_argument(
+        "--command",
+        default=None,
+        metavar="CMD",
+        dest="mcp_command_override",
+        help=(
+            "Command the host should invoke to start the server "
+            "(default: the resolved path to the running 'synthpanel' "
+            "executable, falling back to the literal string 'synthpanel')."
+        ),
+    )
+    mcp_install_parser.add_argument(
+        "--env",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        dest="mcp_env",
+        help=(
+            "Environment variable to inject into the server process. "
+            "Repeatable. Example: --env ANTHROPIC_API_KEY=sk-..."
+        ),
+    )
+    mcp_install_parser.add_argument(
+        "--force",
+        action="store_true",
+        default=False,
+        help="Overwrite an existing server entry with the same --name without prompting.",
+    )
+    mcp_install_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        dest="dry_run",
+        help="Print the resulting JSON to stdout without modifying any files.",
+    )
+
     # plugin (sy-0rr): author-time tooling for plugin manifests
     plugin_parser = subparsers.add_parser(
         "plugin",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -22,6 +22,7 @@ from synth_panel.cli.commands import (
     handle_instruments_show,
     handle_login,
     handle_logout,
+    handle_mcp_install,
     handle_mcp_serve,
     handle_pack_calibrate,
     handle_pack_diff,
@@ -144,6 +145,13 @@ def main(argv: list[str] | None = None) -> int:
         return handle_report(args, output_format)
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
+    elif args.command == "mcp":
+        sub = getattr(args, "mcp_command", None)
+        if sub == "install":
+            return handle_mcp_install(args, output_format)
+        else:
+            parser.parse_args(["mcp", "--help"])
+            return 1
     elif args.command == "plugin":
         sub = getattr(args, "plugin_command", None)
         if sub == "lint":

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -1,0 +1,395 @@
+"""Tests for `synthpanel mcp install` (sy-skf)."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from synth_panel.cli import mcp_install
+from synth_panel.cli.parser import build_parser
+from synth_panel.main import main
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+class TestParser:
+    def test_install_registered(self):
+        args = build_parser().parse_args(["mcp", "install"])
+        assert args.command == "mcp"
+        assert args.mcp_command == "install"
+        assert args.uninstall is False
+        assert args.scope == "user"
+        assert args.target is None
+        assert args.name == "synth_panel"
+        assert args.mcp_command_override is None
+        assert args.mcp_env is None
+        assert args.force is False
+        assert args.dry_run is False
+
+    def test_install_accepts_overrides(self, tmp_path):
+        args = build_parser().parse_args(
+            [
+                "mcp",
+                "install",
+                "--scope",
+                "project",
+                "--target",
+                str(tmp_path / "cfg.json"),
+                "--name",
+                "custom",
+                "--command",
+                "/usr/local/bin/synthpanel",
+                "--env",
+                "ANTHROPIC_API_KEY=sk-test",
+                "--env",
+                "OPENAI_API_KEY=sk-other",
+                "--force",
+                "--dry-run",
+            ]
+        )
+        assert args.scope == "project"
+        assert args.target == str(tmp_path / "cfg.json")
+        assert args.name == "custom"
+        assert args.mcp_command_override == "/usr/local/bin/synthpanel"
+        assert args.mcp_env == ["ANTHROPIC_API_KEY=sk-test", "OPENAI_API_KEY=sk-other"]
+        assert args.force is True
+        assert args.dry_run is True
+
+    def test_uninstall_flag(self):
+        args = build_parser().parse_args(["mcp", "install", "--uninstall"])
+        assert args.uninstall is True
+
+
+# ---------------------------------------------------------------------------
+# Helper unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_resolve_target_user(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Path.home() reads HOME on POSIX; on macOS this is reliable in tests.
+        target = mcp_install.resolve_target("user", None)
+        assert target == Path.home() / ".claude.json"
+
+    def test_resolve_target_project(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        target = mcp_install.resolve_target("project", None)
+        assert target == tmp_path / ".mcp.json"
+
+    def test_resolve_target_explicit_overrides_scope(self, tmp_path):
+        explicit = tmp_path / "weird.json"
+        target = mcp_install.resolve_target("user", str(explicit))
+        assert target == explicit
+
+    def test_resolve_command_explicit(self):
+        assert mcp_install.resolve_command("/opt/bin/synthpanel") == "/opt/bin/synthpanel"
+
+    def test_resolve_command_falls_back_to_literal(self, monkeypatch):
+        monkeypatch.setattr("synth_panel.cli.mcp_install.shutil.which", lambda _name: None)
+        assert mcp_install.resolve_command(None) == "synthpanel"
+
+    def test_parse_env_pairs(self):
+        out = mcp_install.parse_env_pairs(["A=1", "B=two=words"])
+        assert out == {"A": "1", "B": "two=words"}
+
+    def test_parse_env_pairs_rejects_bad_input(self):
+        with pytest.raises(ValueError):
+            mcp_install.parse_env_pairs(["NOEQUALS"])
+        with pytest.raises(ValueError):
+            mcp_install.parse_env_pairs(["=value"])
+
+    def test_parse_env_pairs_empty(self):
+        assert mcp_install.parse_env_pairs(None) == {}
+        assert mcp_install.parse_env_pairs([]) == {}
+
+    def test_build_entry(self):
+        entry = mcp_install.build_entry("synthpanel", {})
+        assert entry == {"command": "synthpanel", "args": ["mcp-serve"]}
+
+    def test_build_entry_with_env(self):
+        entry = mcp_install.build_entry("synthpanel", {"ANTHROPIC_API_KEY": "sk"})
+        assert entry == {
+            "command": "synthpanel",
+            "args": ["mcp-serve"],
+            "env": {"ANTHROPIC_API_KEY": "sk"},
+        }
+
+
+# ---------------------------------------------------------------------------
+# install / uninstall
+# ---------------------------------------------------------------------------
+
+
+class TestInstall:
+    def test_creates_new_config(self, tmp_path):
+        target = tmp_path / "claude.json"
+        result = mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=False,
+        )
+        assert result.action == "installed"
+        assert target.exists()
+        data = json.loads(target.read_text())
+        assert data == {"mcpServers": {"synth_panel": {"command": "synthpanel", "args": ["mcp-serve"]}}}
+
+    def test_preserves_other_top_level_keys(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"theme": "dark", "telemetry": False}))
+        mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=False,
+        )
+        data = json.loads(target.read_text())
+        assert data["theme"] == "dark"
+        assert data["telemetry"] is False
+        assert "synth_panel" in data["mcpServers"]
+
+    def test_preserves_other_servers(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"other": {"command": "other-bin", "args": []}}}))
+        mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=False,
+        )
+        data = json.loads(target.read_text())
+        assert "other" in data["mcpServers"]
+        assert "synth_panel" in data["mcpServers"]
+
+    def test_collision_requires_force(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"synth_panel": {"command": "old", "args": ["mcp-serve"]}}}))
+        with pytest.raises(FileExistsError):
+            mcp_install.install(
+                target=target,
+                name="synth_panel",
+                command="synthpanel",
+                env={},
+                force=False,
+                dry_run=False,
+            )
+        # File should not have been touched.
+        data = json.loads(target.read_text())
+        assert data["mcpServers"]["synth_panel"]["command"] == "old"
+
+    def test_force_overwrites(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"synth_panel": {"command": "old", "args": ["mcp-serve"]}}}))
+        result = mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=True,
+            dry_run=False,
+        )
+        assert result.action == "updated"
+        data = json.loads(target.read_text())
+        assert data["mcpServers"]["synth_panel"]["command"] == "synthpanel"
+
+    def test_idempotent_noop(self, tmp_path):
+        target = tmp_path / "claude.json"
+        mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=False,
+        )
+        # Second run with identical values: no force needed because content matches.
+        result = mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=False,
+        )
+        assert result.action == "noop"
+
+    def test_dry_run_does_not_write(self, tmp_path):
+        target = tmp_path / "claude.json"
+        result = mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=True,
+        )
+        assert result.action == "would-install"
+        assert not target.exists()
+
+    def test_user_config_gets_restrictive_perms(self, tmp_path, monkeypatch):
+        # Force HOME so the helper treats this file as user-owned.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        target = tmp_path / ".claude.json"
+        mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={"ANTHROPIC_API_KEY": "secret"},
+            force=False,
+            dry_run=False,
+        )
+        mode = stat.S_IMODE(os.stat(target).st_mode)
+        assert mode == 0o600
+
+    def test_rejects_non_object_top_level(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps(["not", "an", "object"]))
+        with pytest.raises(ValueError):
+            mcp_install.install(
+                target=target,
+                name="synth_panel",
+                command="synthpanel",
+                env={},
+                force=True,
+                dry_run=False,
+            )
+
+    def test_handles_empty_file(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text("")
+        result = mcp_install.install(
+            target=target,
+            name="synth_panel",
+            command="synthpanel",
+            env={},
+            force=False,
+            dry_run=False,
+        )
+        assert result.action == "installed"
+
+
+class TestUninstall:
+    def test_removes_entry(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "synth_panel": {"command": "synthpanel", "args": ["mcp-serve"]},
+                        "other": {"command": "other", "args": []},
+                    }
+                }
+            )
+        )
+        result = mcp_install.uninstall(target=target, name="synth_panel", dry_run=False)
+        assert result.action == "removed"
+        data = json.loads(target.read_text())
+        assert "synth_panel" not in data["mcpServers"]
+        assert "other" in data["mcpServers"]
+
+    def test_noop_when_missing_file(self, tmp_path):
+        target = tmp_path / "nope.json"
+        result = mcp_install.uninstall(target=target, name="synth_panel", dry_run=False)
+        assert result.action == "noop"
+        assert not target.exists()
+
+    def test_noop_when_entry_absent(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"other": {}}}))
+        result = mcp_install.uninstall(target=target, name="synth_panel", dry_run=False)
+        assert result.action == "noop"
+
+    def test_dry_run(self, tmp_path):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"synth_panel": {"command": "synthpanel"}}}))
+        result = mcp_install.uninstall(target=target, name="synth_panel", dry_run=True)
+        assert result.action == "would-remove"
+        # Untouched.
+        data = json.loads(target.read_text())
+        assert "synth_panel" in data["mcpServers"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via main()
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_install_writes_target(self, tmp_path, capsys):
+        target = tmp_path / "claude.json"
+        rc = main(["mcp", "install", "--target", str(target)])
+        assert rc == 0
+        data = json.loads(target.read_text())
+        assert "synth_panel" in data["mcpServers"]
+        out = capsys.readouterr().out
+        assert "Installed MCP server" in out
+
+    def test_install_json_output(self, tmp_path, capsys):
+        target = tmp_path / "claude.json"
+        rc = main(
+            [
+                "--output-format",
+                "json",
+                "mcp",
+                "install",
+                "--target",
+                str(target),
+                "--command",
+                "synthpanel",
+            ]
+        )
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["action"] == "installed"
+        assert payload["name"] == "synth_panel"
+        assert payload["target"] == str(target)
+        assert payload["entry"]["args"] == ["mcp-serve"]
+
+    def test_collision_exits_nonzero_without_force(self, tmp_path, capsys):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"synth_panel": {"command": "old", "args": ["mcp-serve"]}}}))
+        rc = main(["mcp", "install", "--target", str(target)])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "already exists" in err
+        assert "--force" in err
+
+    def test_uninstall_via_flag(self, tmp_path, capsys):
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"synth_panel": {"command": "synthpanel"}}}))
+        rc = main(["mcp", "install", "--uninstall", "--target", str(target)])
+        assert rc == 0
+        data = json.loads(target.read_text())
+        assert "synth_panel" not in data.get("mcpServers", {})
+
+    def test_dry_run_does_not_write(self, tmp_path, capsys):
+        target = tmp_path / "claude.json"
+        rc = main(["mcp", "install", "--target", str(target), "--dry-run"])
+        assert rc == 0
+        assert not target.exists()
+        out = capsys.readouterr().out
+        assert "Would install" in out
+
+    def test_bad_env_exits_nonzero(self, tmp_path, capsys):
+        target = tmp_path / "claude.json"
+        rc = main(["mcp", "install", "--target", str(target), "--env", "NOEQUALS"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "--env" in err
+
+    def test_no_subcommand_prints_help(self, capsys):
+        with pytest.raises(SystemExit):
+            main(["mcp"])


### PR DESCRIPTION
## Summary

Adds `synthpanel mcp install` to autoregister the MCP server with Claude Code (and any host that speaks `mcpServers`), eliminating the hand-edit-and-restart loop documented in docs/mcp.md. Defaults to user-scope (`~/.claude.json`); `--scope project` writes `./.mcp.json`; `--target` targets any host config. `--uninstall` removes the entry; `--env`, `--force`, and `--dry-run` round out the surface. User-scope writes are mode `0600` since `--env` can carry an API key.

## Changes

- `src/synth_panel/cli/mcp_install.py`: new module (202 LOC) implementing install/uninstall, scope + target resolution, env handling, secure perms.
- `src/synth_panel/cli/parser.py`: new `mcp install` subcommand surface (+83 LOC).
- `src/synth_panel/cli/commands.py`: command dispatch wiring (+43 LOC).
- `src/synth_panel/main.py`: registry entry (+8 LOC).
- `docs/mcp.md`: replaces hand-edit instructions with the one-liner.
- `CHANGELOG.md`: notes the new command.
- `tests/test_mcp_install.py`: new test file (395 LOC) covering scopes, targets, --env secret masking, file perms, uninstall, dry-run, --force.

## Test plan

- `tests/test_mcp_install.py`: covers user-scope vs project-scope writes, --target override, --env redaction, 0600 perms on user config, uninstall path, dry-run no-write, --force overwrite semantics.
- CI matrix (lint / typecheck / coverage / security / test 3.10-3.14) gates the merge.

## References

- Bead: sy-skf
- Upstream report: DataViking-Tech/SynthBench#262

Closes #463