### PR TITLE
docs(mcp): host-specific integration snippets — Hermes + Troubleshooting (sy-6r1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,40 @@ Zed uses `context_servers` (not `mcpServers`). Add to `~/.config/zed/settings.js
 </details>
 
 <details>
+<summary><b>Hermes</b></summary>
+
+Hermes uses a YAML config with `mcp_servers` and explicit timeout fields. Add this block to your Hermes config:
+
+```yaml
+mcp_servers:
+  synthpanel:
+    command: "synthpanel"
+    args: ["mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."
+```
+
+Or run on demand via `uvx` without a global install:
+
+```yaml
+mcp_servers:
+  synthpanel:
+    command: "uvx"
+    args: ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."
+```
+
+The 180s `timeout` covers a full panel run; the 60s `connect_timeout`
+gives the subprocess room to import the MCP SDK on first launch.
+
+</details>
+
+<details>
 <summary><b>Claude Desktop</b></summary>
 
 Open **Settings → Developer → Edit Config** (or edit the file directly):

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -61,6 +61,56 @@ Prefer to install without the plugin, or use a different host? See
 steps and guidance for hosts that don't speak Claude Code's
 slash-command convention.
 
+### Hermes
+
+Hermes uses a YAML config with an `mcp_servers` map and explicit timeout
+fields. Add this block to your Hermes config:
+
+```yaml
+mcp_servers:
+  synthpanel:
+    command: "synthpanel"
+    args: ["mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."
+```
+
+If you don't want to install the `synthpanel` binary globally, use
+[`uvx`](https://docs.astral.sh/uv/) to fetch and run it on demand:
+
+```yaml
+mcp_servers:
+  synthpanel:
+    command: "uvx"
+    args: ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."
+```
+
+- `timeout` (180s) covers a full panel run — panels with many personas
+  and rounds can take 60–120s in BYOK mode.
+- `connect_timeout` (60s) gives the subprocess room to import the MCP
+  Python SDK and providers on first launch.
+- Drop the `env` block entirely if your Hermes host already advertises
+  `sampling` and you want zero-config first-run (see
+  [Sampling Mode](#sampling-mode)).
+
+Restart Hermes after editing the config so the new server entry is
+picked up.
+
+### Other MCP hosts
+
+Any host that speaks the MCP stdio transport works the same way: launch
+`synthpanel mcp-serve` as a subprocess and pass provider keys through
+the environment. The Hermes block above is the canonical shape — most
+hosts map onto either that YAML form or the JSON form used by Claude
+Code / Cursor / Windsurf. If your host needs an explicit transport
+field, set it to `stdio`.
+
 ### Manual Install (Claude Code without plugin)
 
 If you configured the MCP server manually (without `/plugin install`) you can still get all commands and skills by running:
@@ -423,3 +473,98 @@ Panel results, persona packs, and instrument packs are stored under `~/.synthpan
 ├── packs/instruments/      # Installed instrument packs (YAML)
 └── results/                # Panel results (JSON) + session data
 ```
+
+## Troubleshooting
+
+### `command not found: synthpanel`
+
+The MCP host can't see the `synthpanel` binary on its `PATH`. This is
+the single most common failure mode, because MCP subprocesses inherit
+the host's PATH — not your shell's.
+
+**Fixes, in order of preference:**
+
+1. Install globally so any host can find it:
+   ```bash
+   pip install "synthpanel[mcp]"      # or pipx install "synthpanel[mcp]"
+   which synthpanel                    # confirm the binary is on PATH
+   ```
+2. Or point `command` at the absolute binary path:
+   ```jsonc
+   "command": "/Users/you/.venv/bin/synthpanel"
+   ```
+3. Or run it through `uvx` so the host fetches it on demand:
+   ```jsonc
+   "command": "uvx",
+   "args": ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]
+   ```
+
+Claude Desktop on macOS is particularly strict about PATH — it runs
+under launchd and does not inherit your shell environment. Use an
+absolute path or `uvx` for that host.
+
+### Server starts but no tools appear
+
+The server launched but the host isn't seeing `run_panel`,
+`run_quick_poll`, etc. in the tool picker.
+
+- **MCP extra missing.** `pip install synthpanel` alone is not enough —
+  the MCP server requires the SDK from the `[mcp]` extra:
+  ```bash
+  pip install "synthpanel[mcp]"
+  ```
+- **Stale host cache.** Some hosts cache the tool list per server entry.
+  Restart the host (full quit, not just window close) after editing
+  config or upgrading the package.
+- **Server logs.** Run `synthpanel mcp-serve` in a terminal to confirm
+  it boots and produces no errors before the host launches it.
+
+### Missing or invalid API key
+
+Symptom: tool calls return `MISSING_CREDS` or a provider-specific
+401/403 error.
+
+- The MCP subprocess only sees env vars from the host's `env` block (or
+  the host's inherited environment). Setting `ANTHROPIC_API_KEY` in
+  your shell profile does **not** automatically propagate — put it in
+  the `env` block of the MCP server entry.
+- Run `synthpanel login` to seed the on-disk credential store; the MCP
+  server reads from there as a fallback when the env is empty (see
+  [Model Resolution Order](#model-resolution-order)).
+- If your host advertises MCP `sampling` (Claude Desktop, Claude Code,
+  Cursor, Windsurf), you can omit the key entirely and synthpanel will
+  borrow the host's LLM access — see [Sampling Mode](#sampling-mode).
+
+### Timeouts on long panel runs
+
+Symptom: the host kills the subprocess mid-panel with a timeout error.
+
+- A 5-persona × 3-question BYOK panel typically takes 30–90 seconds.
+  Cross-provider ensembles and larger personas can take 2–5 minutes.
+- Raise the host's per-tool timeout. For Hermes:
+  ```yaml
+  mcp_servers:
+    synthpanel:
+      timeout: 300         # 5 min for heavy panels
+      connect_timeout: 60
+  ```
+  Other hosts use their own field names; consult the host's MCP docs.
+- For exploratory work, prefer `run_quick_poll` (single question) over
+  `run_panel` (full instrument) — it returns in seconds.
+
+### Tool calls fail with `MISSING_DECISION`
+
+Every panel-class tool (`run_panel`, `run_quick_poll`, `extend_panel`)
+**requires** a `decision_being_informed` string (12–280 chars). This
+is a frozen v1.0.0 contract requirement. See
+[Frozen v1.0.0 Contract](#frozen-v100-contract) for the rule and
+[docs/response-contract.md](response-contract.md) for the error
+envelope. `run_prompt` does not require it.
+
+### `SCHEMA_DRIFT` errors on synthesis
+
+The structured-output engine's 3-strike retry budget was exhausted.
+Either re-run the tool (transient model output drift is recoverable),
+or set `SYNTHPANEL_DRIFT_DEGRADE=1` in the MCP `env` block to get a
+degraded result with a `schema_drift` flag instead of an error — see
+[Host Integration Flags](#host-integration-flags).

--- a/site/mcp/index.html
+++ b/site/mcp/index.html
@@ -8,18 +8,18 @@
     </title>
     <meta
       name="description"
-      content="MCP server with 12 tools for synthetic focus group research. Drop-in config for Claude Code, Cursor, Windsurf, Zed, Claude Desktop."
+      content="MCP server with 12 tools for synthetic focus group research. Drop-in config for Claude Code, Cursor, Windsurf, Zed, Hermes, Claude Desktop."
     />
     <link rel="canonical" href="https://synthpanel.dev/mcp" />
 
-    <meta name="keywords" content="MCP server, Model Context Protocol, synthetic focus group, Claude Code MCP, Cursor MCP, Windsurf MCP, AI agent research tool, synthpanel MCP" />
+    <meta name="keywords" content="MCP server, Model Context Protocol, synthetic focus group, Claude Code MCP, Cursor MCP, Windsurf MCP, Hermes MCP, AI agent research tool, synthpanel MCP" />
 
     <meta property="og:type" content="article" />
     <meta property="og:site_name" content="synthpanel" />
     <meta property="og:title" content="synthpanel MCP Server — synthetic focus groups from your AI editor" />
     <meta
       property="og:description"
-      content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, Claude Desktop. 12 tools to run synthetic focus groups, manage persona packs, and query panel results from chat."
+      content="Drop-in MCP config for Claude Code, Cursor, Windsurf, Zed, Hermes, Claude Desktop. 12 tools to run synthetic focus groups, manage persona packs, and query panel results from chat."
     />
     <meta property="og:url" content="https://synthpanel.dev/mcp" />
     <meta property="og:image" content="https://synthpanel.dev/og-image.png" />
@@ -30,7 +30,7 @@
     <meta name="twitter:title" content="synthpanel MCP Server" />
     <meta
       name="twitter:description"
-      content="12 MCP tools for synthetic focus groups. Works with Claude Code, Cursor, Windsurf, Zed, Claude Desktop."
+      content="12 MCP tools for synthetic focus groups. Works with Claude Code, Cursor, Windsurf, Zed, Hermes, Claude Desktop."
     />
     <meta name="twitter:image" content="https://synthpanel.dev/og-image.png" />
     <meta name="twitter:image:alt" content="synthpanel — Run synthetic focus groups with any LLM" />
@@ -40,7 +40,7 @@
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
         "name": "synthpanel MCP Server",
-        "description": "Model Context Protocol server exposing 12 tools for AI agents to run synthetic focus groups, manage persona packs, and query panel results. Drop-in integration for Claude Code, Cursor, Windsurf, Zed, and Claude Desktop.",
+        "description": "Model Context Protocol server exposing 12 tools for AI agents to run synthetic focus groups, manage persona packs, and query panel results. Drop-in integration for Claude Code, Cursor, Windsurf, Zed, Hermes, and Claude Desktop.",
         "url": "https://synthpanel.dev/mcp",
         "applicationCategory": "DeveloperApplication",
         "applicationSubCategory": "MCP Server",
@@ -551,6 +551,89 @@
           </div>
         </details>
 
+        <!-- Hermes -->
+        <details
+          class="mb-3 rounded-lg border border-slate-800 bg-slate-900/40 p-4 transition hover:border-slate-700"
+        >
+          <summary class="flex items-center gap-2 text-base font-semibold text-white">
+            Hermes
+          </summary>
+          <div class="mt-4 space-y-4">
+            <p class="text-sm text-slate-400">
+              Hermes uses a YAML config with an
+              <code class="text-slate-300">mcp_servers</code> map and
+              explicit timeout fields. Add this block to your Hermes
+              config and restart the host:
+            </p>
+            <div
+              class="group relative rounded-lg border border-slate-700 bg-slate-950/70 p-4 font-mono text-sm leading-relaxed shadow"
+            >
+<pre class="whitespace-pre-wrap text-slate-300"><span class="text-emerald-400">mcp_servers</span>:
+  <span class="text-emerald-400">synthpanel</span>:
+    <span class="text-emerald-400">command</span>: <span class="text-amber-300">"synthpanel"</span>
+    <span class="text-emerald-400">args</span>: [<span class="text-amber-300">"mcp-serve"</span>]
+    <span class="text-emerald-400">timeout</span>: 180
+    <span class="text-emerald-400">connect_timeout</span>: 60
+    <span class="text-emerald-400">env</span>:
+      <span class="text-emerald-400">ANTHROPIC_API_KEY</span>: <span class="text-amber-300">"sk-..."</span></pre>
+              <button
+                type="button"
+                class="copy-btn absolute right-3 top-3 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-400 transition hover:border-emerald-400/50 hover:text-emerald-300"
+                data-copy='mcp_servers:
+  synthpanel:
+    command: "synthpanel"
+    args: ["mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."'
+                aria-label="Copy Hermes MCP config"
+              >
+                Copy
+              </button>
+            </div>
+            <p class="text-sm text-slate-400">
+              Or run it on demand via
+              <code class="text-slate-300">uvx</code> without a global
+              install:
+            </p>
+            <div
+              class="group relative rounded-lg border border-slate-700 bg-slate-950/70 p-4 font-mono text-sm leading-relaxed shadow"
+            >
+<pre class="whitespace-pre-wrap text-slate-300"><span class="text-emerald-400">mcp_servers</span>:
+  <span class="text-emerald-400">synthpanel</span>:
+    <span class="text-emerald-400">command</span>: <span class="text-amber-300">"uvx"</span>
+    <span class="text-emerald-400">args</span>: [<span class="text-amber-300">"--from"</span>, <span class="text-amber-300">"synthpanel[mcp]"</span>, <span class="text-amber-300">"synthpanel"</span>, <span class="text-amber-300">"mcp-serve"</span>]
+    <span class="text-emerald-400">timeout</span>: 180
+    <span class="text-emerald-400">connect_timeout</span>: 60
+    <span class="text-emerald-400">env</span>:
+      <span class="text-emerald-400">ANTHROPIC_API_KEY</span>: <span class="text-amber-300">"sk-..."</span></pre>
+              <button
+                type="button"
+                class="copy-btn absolute right-3 top-3 rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-400 transition hover:border-emerald-400/50 hover:text-emerald-300"
+                data-copy='mcp_servers:
+  synthpanel:
+    command: "uvx"
+    args: ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."'
+                aria-label="Copy Hermes MCP config (uvx)"
+              >
+                Copy
+              </button>
+            </div>
+            <p class="text-xs text-slate-500">
+              The 180s
+              <code class="text-slate-300">timeout</code> covers a full
+              panel run; the 60s
+              <code class="text-slate-300">connect_timeout</code> gives
+              the subprocess room to import the MCP SDK on first launch.
+            </p>
+          </div>
+        </details>
+
         <!-- Claude Desktop -->
         <details
           class="mb-3 rounded-lg border border-slate-800 bg-slate-900/40 p-4 transition hover:border-slate-700"
@@ -1002,6 +1085,105 @@
 ├── packs/instruments/      <span class="text-slate-500"># Installed instrument packs (YAML)</span>
 └── results/                <span class="text-slate-500"># Panel results (JSON) + session data</span></pre>
         </div>
+      </section>
+
+      <!-- Troubleshooting -->
+      <section class="mt-16" id="troubleshooting">
+        <h2
+          class="mb-2 text-sm font-semibold uppercase tracking-wider text-slate-400"
+        >
+          Troubleshooting
+        </h2>
+        <dl class="mt-6 space-y-6 text-base text-slate-300">
+          <div>
+            <dt class="font-semibold text-white">
+              <code class="text-slate-200">command not found: synthpanel</code>
+            </dt>
+            <dd class="mt-2 text-sm text-slate-400">
+              The MCP host can't find the binary on its
+              <code class="text-slate-300">PATH</code>. MCP subprocesses
+              inherit the host's environment, not your shell's. Fix by
+              installing globally
+              (<code class="text-slate-300">pip install "synthpanel[mcp]"</code>),
+              pointing
+              <code class="text-slate-300">command</code> at an
+              absolute path (e.g.
+              <code class="text-slate-300">/Users/you/.venv/bin/synthpanel</code>),
+              or running through
+              <code class="text-slate-300">uvx</code>
+              (<code class="text-slate-300">"command": "uvx", "args": ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]</code>).
+              Claude Desktop on macOS is especially strict — use an
+              absolute path or
+              <code class="text-slate-300">uvx</code>.
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-white">
+              Server starts but no tools appear
+            </dt>
+            <dd class="mt-2 text-sm text-slate-400">
+              The MCP server needs the
+              <code class="text-slate-300">[mcp]</code> extra:
+              <code class="text-slate-300">pip install "synthpanel[mcp]"</code>.
+              After config edits or upgrades, fully quit and relaunch
+              the host — tool lists are cached per server entry.
+              Sanity-check by running
+              <code class="text-slate-300">synthpanel mcp-serve</code>
+              in a terminal; it should boot silently.
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-white">Missing API key</dt>
+            <dd class="mt-2 text-sm text-slate-400">
+              The subprocess only sees env vars from the MCP
+              <code class="text-slate-300">env</code> block. A
+              shell-profile export does not propagate. Set the key in
+              the
+              <code class="text-slate-300">env</code> block, run
+              <code class="text-slate-300">synthpanel login</code> to
+              seed the on-disk credential store, or omit the key and
+              let MCP <em>sampling</em> borrow the host's LLM access
+              (Claude Desktop, Claude Code, Cursor, Windsurf).
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-white">
+              Timeouts on long panels
+            </dt>
+            <dd class="mt-2 text-sm text-slate-400">
+              A 5-persona × 3-question BYOK panel takes 30–90 seconds;
+              cross-provider ensembles can take 2–5 minutes. Raise the
+              host's per-tool timeout (Hermes:
+              <code class="text-slate-300">timeout: 300</code>). For
+              exploratory work, prefer
+              <code class="text-slate-300">run_quick_poll</code> over
+              <code class="text-slate-300">run_panel</code>.
+            </dd>
+          </div>
+          <div>
+            <dt class="font-semibold text-white">
+              <code class="text-slate-200">MISSING_DECISION</code> errors
+            </dt>
+            <dd class="mt-2 text-sm text-slate-400">
+              <code class="text-slate-300">run_panel</code>,
+              <code class="text-slate-300">run_quick_poll</code>, and
+              <code class="text-slate-300">extend_panel</code> require a
+              <code class="text-slate-300">decision_being_informed</code>
+              string (12–280 chars). This is a frozen v1.0.0 contract.
+              <code class="text-slate-300">run_prompt</code> does not
+              require it.
+            </dd>
+          </div>
+        </dl>
+        <p class="mt-6 text-xs text-slate-500">
+          Full troubleshooting reference and links into the response
+          contract:
+          <a
+            href="https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md#troubleshooting"
+            class="text-emerald-300 hover:underline"
+            >docs/mcp.md</a
+          >.
+        </p>
       </section>
 
       <!-- Next steps -->

--- a/site/mcp/index.md
+++ b/site/mcp/index.md
@@ -125,6 +125,36 @@ Zed calls them *context servers*. Open `settings.json` (cmd-,) and merge this bl
 }
 ```
 
+Hermes
+
+Hermes uses a YAML config with an `mcp_servers` map and explicit timeout fields. Add this block to your Hermes config and restart the host:
+
+```
+mcp_servers:
+  synthpanel:
+    command: "synthpanel"
+    args: ["mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."
+```
+
+Or run it on demand via `uvx` without a global install:
+
+```
+mcp_servers:
+  synthpanel:
+    command: "uvx"
+    args: ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]
+    timeout: 180
+    connect_timeout: 60
+    env:
+      ANTHROPIC_API_KEY: "sk-..."
+```
+
+The 180s `timeout` covers a full panel run; the 60s `connect_timeout` gives the subprocess room to import the MCP SDK on first launch.
+
 Claude Desktop
 
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS, or `%APPDATA%\Claude\claude_desktop_config.json` on Windows, then restart the app.
@@ -259,6 +289,20 @@ Panel results, persona packs, and instrument packs are stored under `~/.synthpan
 ├── packs/instruments/      # Installed instrument packs (YAML)
 └── results/                # Panel results (JSON) + session data
 ```
+
+## Troubleshooting
+
+`command not found: synthpanel`  The MCP host can't find the binary on its `PATH`. MCP subprocesses inherit the host's environment, not your shell's. Fix by installing globally (`pip install "synthpanel[mcp]"`), pointing `command` at an absolute path (e.g. `/Users/you/.venv/bin/synthpanel`), or running through `uvx` (`"command": "uvx", "args": ["--from", "synthpanel[mcp]", "synthpanel", "mcp-serve"]`). Claude Desktop on macOS is especially strict — use an absolute path or `uvx`.
+
+Server starts but no tools appear  The MCP server needs the `[mcp]` extra: `pip install "synthpanel[mcp]"`. After config edits or upgrades, fully quit and relaunch the host — tool lists are cached per server entry. Sanity-check by running `synthpanel mcp-serve` in a terminal; it should boot silently.
+
+Missing API key  The subprocess only sees env vars from the MCP `env` block. A shell-profile export does not propagate. Set the key in the `env` block, run `synthpanel login` to seed the on-disk credential store, or omit the key and let MCP *sampling* borrow the host's LLM access (Claude Desktop, Claude Code, Cursor, Windsurf).
+
+Timeouts on long panels  A 5-persona × 3-question BYOK panel takes 30–90 seconds; cross-provider ensembles can take 2–5 minutes. Raise the host's per-tool timeout (Hermes: `timeout: 300`). For exploratory work, prefer `run_quick_poll` over `run_panel`.
+
+`MISSING_DECISION` errors `run_panel`, `run_quick_poll`, and `extend_panel` require a `decision_being_informed` string (12–280 chars). This is a frozen v1.0.0 contract. `run_prompt` does not require it.
+
+Full troubleshooting reference and links into the response contract: [docs/mcp.md](https://github.com/DataViking-Tech/SynthPanel/blob/main/docs/mcp.md#troubleshooting).
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- Adds a **Hermes** editor config entry (direct + `uvx` variants) with `timeout: 180` / `connect_timeout: 60` so panel runs and first-launch imports don't get killed by host defaults.
- Adds a **Troubleshooting** section covering `command not found`, server-starts-but-no-tools, missing API key, panel timeouts, `MISSING_DECISION`, and `SCHEMA_DRIFT` recovery.
- Updates `site/mcp` meta (description / keywords / JSON-LD) to list Hermes alongside the other supported hosts.

Hermes-filed (#473) — SynthPanel's MCP wrapper didn't auto-connect in the Hermes environment because no Hermes-specific config snippet was documented.

## Changes

- `README.md`: Hermes details block in the "Use with Claude Code / Cursor / Windsurf / Zed" section.
- `docs/mcp.md`: Hermes editor entry + new Troubleshooting section.
- `site/mcp/index.html`: Hermes details panel (after Zed, before Claude Desktop), new Troubleshooting section before "Next steps", updated meta tags + JSON-LD.
- `site/mcp/index.md`: Regenerated from updated HTML via `scripts/render_site_markdown.py` (the committed `.md` must match a fresh render — see `tests/test_site_markdown.py`).

## Test plan

- [x] `ruff check src/ tests/` passes locally
- [x] `python3 -m pytest tests/test_site_markdown.py tests/test_site_headers.py` passes (renderer parity + headers OK)
- [x] HTML parses cleanly
- [ ] CI: lint, typecheck, security, site-cli-sync, all `test (3.10..3.14)` green

## References

- Bead: sy-6r1
- GH issue: #473
- Issue acceptance criteria all addressed (verified MCP command, host-specific examples including Hermes, troubleshooting covers common failure modes).

Closes #473