### PR TITLE
feat(skills): add Hermes-compatible synthpanel director skill (sy-7pw)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,7 @@
     }
   },
   "skills": [
+    "skills/synthpanel/SKILL.md",
     "skills/focus-group/SKILL.md",
     "skills/name-test/SKILL.md",
     "skills/concept-test/SKILL.md",

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,26 +1,37 @@
 # Agent Skills & Slash Commands
 
-synthpanel ships six Claude Code-native artifacts that drive the MCP
-server: one slash command (`/synthpanel-poll`) and five skills
-(`focus-group`, `name-test`, `concept-test`, `survey-prescreen`,
-`pricing-probe`). They live at the repository root in
-[`commands/`](../commands/) and [`skills/`](../skills/), and Claude Code
-discovers them from the local filesystem rather than from the installed
-Python package — so `pip install synthpanel[mcp]` alone doesn't expose
-them. This page documents how to install them.
+synthpanel ships seven Claude Code-native artifacts that drive the MCP
+server: one slash command (`/synthpanel-poll`), one top-level director
+skill (`synthpanel`), and five workflow skills (`focus-group`,
+`name-test`, `concept-test`, `survey-prescreen`, `pricing-probe`). They
+live at the repository root in [`commands/`](../commands/) and
+[`skills/`](../skills/), and Claude Code discovers them from the local
+filesystem rather than from the installed Python package — so
+`pip install synthpanel[mcp]` alone doesn't expose them. This page
+documents how to install them.
+
+The skill files follow the open
+[Agent Skills Discovery](https://agentskills.io/) format, so
+[Hermes Agent](https://hermes-agent.nousresearch.com/), Codex CLI,
+Cursor, Goose, OpenHands, and other skills-compatible hosts can load
+them with the same files. The `synthpanel` director skill in particular
+includes Hermes-specific frontmatter (`metadata.hermes.*`,
+`required_environment_variables`) so Hermes can install and configure
+it without ad-hoc spelunking.
 
 ## What ships
 
 | Artifact | File | Type | Triggers |
 |---|---|---|---|
 | `/synthpanel-poll <question>` | [`commands/synthpanel-poll.md`](../commands/synthpanel-poll.md) | Slash command | One-question quick poll |
+| `synthpanel` | [`skills/synthpanel/SKILL.md`](../skills/synthpanel/SKILL.md) | Skill (director) | "run a synthetic panel", "test positioning", "compare names", "pricing probe", "poll N personas", "prioritization poll" |
 | `focus-group` | [`skills/focus-group/SKILL.md`](../skills/focus-group/SKILL.md) | Skill | Full focus-group workflow |
 | `name-test` | [`skills/name-test/SKILL.md`](../skills/name-test/SKILL.md) | Skill | 1–3 candidate name comparison |
 | `concept-test` | [`skills/concept-test/SKILL.md`](../skills/concept-test/SKILL.md) | Skill | Concept / value-prop validation |
 | `survey-prescreen` | [`skills/survey-prescreen/SKILL.md`](../skills/survey-prescreen/SKILL.md) | Skill | Pre-screen a survey instrument |
 | `pricing-probe` | [`skills/pricing-probe/SKILL.md`](../skills/pricing-probe/SKILL.md) | Skill | Pricing sensitivity probe |
 
-All six call into the synthpanel MCP server, so the
+All seven call into the synthpanel MCP server, so the
 [MCP server](mcp.md) must be configured first — none of these work
 standalone.
 
@@ -57,52 +68,92 @@ From a clone of this repo:
 # User-scope install — every project gets the artifacts
 mkdir -p ~/.claude/commands ~/.claude/skills
 cp commands/synthpanel-poll.md ~/.claude/commands/
-cp -r skills/focus-group skills/name-test skills/concept-test \
-      skills/survey-prescreen skills/pricing-probe ~/.claude/skills/
+cp -r skills/synthpanel skills/focus-group skills/name-test \
+      skills/concept-test skills/survey-prescreen skills/pricing-probe \
+      ~/.claude/skills/
 
 # OR project-scope install — only this project gets the artifacts
 mkdir -p .claude/commands .claude/skills
 cp commands/synthpanel-poll.md .claude/commands/
-cp -r skills/focus-group skills/name-test skills/concept-test \
-      skills/survey-prescreen skills/pricing-probe .claude/skills/
+cp -r skills/synthpanel skills/focus-group skills/name-test \
+      skills/concept-test skills/survey-prescreen skills/pricing-probe \
+      .claude/skills/
 ```
 
-Restart Claude Code. `/synthpanel-poll "your question"` and the five
-skills (`focus-group`, `name-test`, etc.) are now available.
+Restart Claude Code. `/synthpanel-poll "your question"` and the six
+skills (`synthpanel`, `focus-group`, `name-test`, etc.) are now
+available.
 
 If you don't have a clone, fetch the files directly from GitHub:
 
 ```bash
 SP_RAW=https://raw.githubusercontent.com/DataViking-Tech/SynthPanel/main
 
-mkdir -p ~/.claude/commands ~/.claude/skills/focus-group \
+mkdir -p ~/.claude/commands \
+         ~/.claude/skills/synthpanel ~/.claude/skills/focus-group \
          ~/.claude/skills/name-test ~/.claude/skills/concept-test \
          ~/.claude/skills/survey-prescreen ~/.claude/skills/pricing-probe
 
 curl -fsSL $SP_RAW/commands/synthpanel-poll.md \
      -o ~/.claude/commands/synthpanel-poll.md
 
-for s in focus-group name-test concept-test survey-prescreen pricing-probe; do
+for s in synthpanel focus-group name-test concept-test survey-prescreen pricing-probe; do
   curl -fsSL $SP_RAW/skills/$s/SKILL.md \
        -o ~/.claude/skills/$s/SKILL.md
 done
 ```
 
-### 3. Other MCP hosts (Cursor, Windsurf, Copilot, etc.)
+### 3. Hermes Agent (skills-compatible host)
 
-`/synthpanel-poll` and the skills use Claude Code's slash-command and
-skill conventions, which other hosts don't share. On those hosts:
+Hermes consumes the same SKILL.md format (Agent Skills Discovery,
+agentskills.io). The `synthpanel` director skill carries Hermes-specific
+frontmatter (`metadata.hermes.tags`, `metadata.hermes.config`,
+`required_environment_variables`) so it installs and configures
+cleanly:
+
+```bash
+SP_RAW=https://raw.githubusercontent.com/DataViking-Tech/SynthPanel/main
+HERMES_SKILLS=~/.hermes/skills   # adjust to your Hermes install path
+
+mkdir -p $HERMES_SKILLS/synthpanel $HERMES_SKILLS/focus-group \
+         $HERMES_SKILLS/name-test $HERMES_SKILLS/concept-test \
+         $HERMES_SKILLS/survey-prescreen $HERMES_SKILLS/pricing-probe
+
+for s in synthpanel focus-group name-test concept-test survey-prescreen pricing-probe; do
+  curl -fsSL $SP_RAW/skills/$s/SKILL.md \
+       -o $HERMES_SKILLS/$s/SKILL.md
+done
+```
+
+Hermes will prompt for the configured environment variables (Anthropic /
+OpenAI / Google / xAI keys) on first activation, then route SynthPanel
+triggers ("run a synthetic panel", "test positioning", "compare names",
+"pricing probe", "poll 30 personas") to the `synthpanel` director,
+which in turn delegates to the matching workflow skill. Also configure
+the [MCP server](mcp.md#editor-configuration) so the tools resolve.
+
+The index of skills is also published at
+[`/.well-known/agent-skills/index.json`](https://synthpanel.dev/.well-known/agent-skills/index.json)
+on synthpanel.dev, per Agent Skills Discovery RFC v0.2.0, so
+discovery-aware hosts can find them without prior knowledge.
+
+### 4. Other MCP hosts (Cursor, Windsurf, Copilot, etc.)
+
+`/synthpanel-poll` is Claude Code-specific. On other hosts:
 
 - Configure the [MCP server](mcp.md#editor-configuration) so the host
   can call the synthpanel tools (`run_panel`, `run_quick_poll`,
   `run_prompt`, etc.) directly.
-- Treat the contents of `commands/synthpanel-poll.md` and each
-  `skills/*/SKILL.md` as **prompt templates** — paste the workflow
-  body into the host's chat or your own prompt library and let the
-  agent follow it manually.
+- For hosts that consume SKILL.md (Hermes, Codex CLI, Cursor, Goose,
+  OpenHands, OpenCode, …), drop the `skills/synthpanel` directory plus
+  the workflow skills into that host's skills path.
+- For hosts that don't consume SKILL.md, treat the contents of
+  `commands/synthpanel-poll.md` and each `skills/*/SKILL.md` as
+  **prompt templates** — paste the workflow body into the host's chat
+  or your own prompt library and let the agent follow it manually.
 
 The MCP tools themselves are host-agnostic; only the
-slash-command/skill packaging is Claude Code-specific.
+slash-command/skill packaging is host-specific.
 
 ## Verifying the install
 
@@ -146,6 +197,8 @@ works as long as the named MCP tools still exist.
   mode.
 - [`commands/synthpanel-poll.md`](../commands/synthpanel-poll.md) —
   the actual slash command source.
-- [`skills/`](../skills/) — the five skill workflows.
+- [`skills/synthpanel/SKILL.md`](../skills/synthpanel/SKILL.md) — the
+  top-level director skill (Hermes-compatible).
+- [`skills/`](../skills/) — the five workflow skills.
 - [`.claude-plugin/plugin.json`](../.claude-plugin/plugin.json) —
   what `/plugin install synthpanel` registers.

--- a/scripts/render_agent_skills.py
+++ b/scripts/render_agent_skills.py
@@ -28,6 +28,7 @@ SCHEMA_URL = "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
 # Stable publication order — independent of filesystem traversal so the
 # committed index.json is deterministic across platforms.
 SKILL_ORDER = (
+    "synthpanel",
     "focus-group",
     "name-test",
     "concept-test",

--- a/site/.well-known/agent-skills/index.json
+++ b/site/.well-known/agent-skills/index.json
@@ -2,6 +2,13 @@
   "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "skills": [
     {
+      "name": "synthpanel",
+      "type": "skill-md",
+      "description": "Director skill for SynthPanel — decide when to reach for synthetic panels (focus groups, name tests, concept tests, pricing probes, mass-appeal polls) and route to the right sub-skill, with anti-overclaiming guardrails baked in.",
+      "url": "/.well-known/agent-skills/synthpanel/SKILL.md",
+      "digest": "sha256:99bc765d5214e7875d853cbb55a4e5a7514e807768322733418bdc05974272bc"
+    },
+    {
       "name": "focus-group",
       "type": "skill-md",
       "description": "Run a synthetic focus group — define personas, craft questions, and collect structured qualitative feedback from AI panelists.",

--- a/site/.well-known/agent-skills/synthpanel/SKILL.md
+++ b/site/.well-known/agent-skills/synthpanel/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: synthpanel
+description: Director skill for SynthPanel — decide when to reach for synthetic panels (focus groups, name tests, concept tests, pricing probes, mass-appeal polls) and route to the right sub-skill, with anti-overclaiming guardrails baked in.
+version: 1.0.0
+author: SynthPanel maintainers
+license: MIT
+allowed-tools:
+  - mcp__synth_panel__run_prompt
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__extend_panel
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__save_persona_pack
+  - mcp__synth_panel__list_instrument_packs
+  - mcp__synth_panel__get_instrument_pack
+  - mcp__synth_panel__save_instrument_pack
+  - mcp__synth_panel__list_panel_results
+  - mcp__synth_panel__get_panel_result
+metadata:
+  hermes:
+    tags:
+      - research
+      - synthetic-respondents
+      - focus-group
+      - panels
+      - mcp
+      - market-research
+    related_skills:
+      - focus-group
+      - name-test
+      - concept-test
+      - survey-prescreen
+      - pricing-probe
+    config:
+      - key: synthpanel.preferred_interface
+        description: How to call SynthPanel when both are available (mcp, cli).
+        default: mcp
+        prompt: Prefer the synth_panel MCP server, or the synthpanel CLI?
+      - key: synthpanel.default_panel_size
+        description: Persona count for routine polls and concept tests.
+        default: "5"
+        prompt: Default persona count (3–6 is normal; raise for mass-appeal polls)
+      - key: synthpanel.default_model_alias
+        description: LLM alias for routine runs (sonnet, haiku, gemini, grok, ...).
+        default: haiku
+        prompt: Default LLM alias for routine synthetic runs
+required_environment_variables:
+  - name: ANTHROPIC_API_KEY
+    prompt: Anthropic API key (default provider for SynthPanel)
+    help: Needed for Claude-family models. Skip only if exclusively using another provider.
+    required_for:
+      - default-claude-runs
+  - name: OPENAI_API_KEY
+    prompt: OpenAI API key (optional; only if you ask SynthPanel to use OpenAI models)
+    help: Required only when --model selects an OpenAI or OpenAI-compatible model.
+    required_for:
+      - openai-runs
+  - name: GOOGLE_API_KEY
+    prompt: Google API key (optional; only for Gemini models)
+    help: Required only when --model selects a gemini-* model.
+    required_for:
+      - gemini-runs
+  - name: XAI_API_KEY
+    prompt: xAI API key (optional; only for Grok models)
+    help: Required only when --model selects a grok-* model.
+    required_for:
+      - grok-runs
+---
+
+# SynthPanel — synthetic respondent research
+
+## When to use
+
+Reach for this skill the moment a user asks for any of the following — these
+are the canonical triggers:
+
+- "run a synthetic panel" / "run a focus group" / "synthetic focus group"
+- "test positioning" / "test this value prop" / "concept test"
+- "compare product names" / "name test" / "which name is better"
+- "pricing probe" / "what would people pay" / "price sensitivity"
+- "poll 30 personas" / "poll the panel" / "mass-appeal poll"
+- "prioritization poll" / "rank these options across personas"
+- "pre-screen this survey" / "stress-test these questions"
+
+It is also the right skill when a user wants directional, fast, **synthetic**
+input *before* spending budget on real participants — e.g. "I have a hunch,
+should I bother running this past anyone?" or "what would land vs. what would
+fall flat?"
+
+**Do not** use this skill when the user needs decisions backed by real human
+data (regulatory, statistically powered, claims-grade). Say so explicitly and
+recommend a real panel instead — synthetic output is preflight, not validation.
+
+## Quick reference
+
+SynthPanel exposes two interfaces. They are equivalent; prefer the MCP path
+when configured (`synthpanel.preferred_interface = mcp`).
+
+### MCP tools (preferred when `synth_panel` MCP server is registered)
+
+| Tool | Purpose |
+| --- | --- |
+| `mcp__synth_panel__run_prompt` | One-shot prompt against one persona (smoke test). |
+| `mcp__synth_panel__run_quick_poll` | One-question poll across N personas; returns vote tallies + synthesis. |
+| `mcp__synth_panel__run_panel` | Full panel with persona pack + instrument pack (v1, v2, v3 branching). |
+| `mcp__synth_panel__extend_panel` | Append one ad-hoc round on top of a saved result. Not v3 re-entry. |
+| `mcp__synth_panel__list_persona_packs` / `get_persona_pack` / `save_persona_pack` | Manage persona libraries. |
+| `mcp__synth_panel__list_instrument_packs` / `get_instrument_pack` / `save_instrument_pack` | Manage survey instruments (v1/v2/v3). |
+| `mcp__synth_panel__list_panel_results` / `get_panel_result` | Retrieve saved runs by ID. |
+
+### CLI (fallback or scripted use)
+
+```bash
+synthpanel prompt "Say hello"                                # single prompt
+synthpanel panel run \                                       # full panel
+  --personas examples/personas.yaml \
+  --instrument examples/survey.yaml
+synthpanel panel run --personas examples/personas.yaml \     # branching v3
+  --instrument pricing-discovery
+synthpanel instruments list                                  # discover bundled packs
+synthpanel mcp-serve                                         # start MCP server (stdio)
+synthpanel mcp install                                       # register MCP server in the active editor
+```
+
+Provider env vars map: `ANTHROPIC_API_KEY` (default), `OPENAI_API_KEY`,
+`GOOGLE_API_KEY`/`GEMINI_API_KEY`, `XAI_API_KEY`. Pick the model with
+`--model sonnet|haiku|gpt-4o|gemini|grok-3|...`.
+
+### Sub-skill routing
+
+For task-shaped work, delegate to the matching sub-skill rather than
+re-deriving the workflow here. They live alongside this skill:
+
+| Trigger | Sub-skill |
+| --- | --- |
+| Open-ended exploration with personas | `focus-group` |
+| 1–3 candidate names compared head-to-head | `name-test` |
+| "Does this value-prop land?" / problem validation | `concept-test` |
+| "Pre-screen this survey before fielding it" | `survey-prescreen` |
+| Pricing sensitivity / willingness-to-pay | `pricing-probe` |
+| One-question poll, no follow-ups | `run_quick_poll` MCP tool directly |
+
+## Procedure
+
+1. **Confirm the question is synthetic-appropriate.** If the user needs
+   audited, real-human evidence, stop and say so. Otherwise frame what you
+   are about to do as a synthetic preflight.
+
+2. **Pick the interface.** Check whether the `synth_panel` MCP server is
+   registered (tools prefixed `mcp__synth_panel__*` exist). If yes, use MCP.
+   If not, fall back to the CLI. Tell the user which one you used.
+
+3. **Pick the sub-skill** from the routing table above. If none of the
+   sub-skills fits, run an ad-hoc `run_quick_poll` (single question,
+   `panel_size` personas) or a `run_panel` with an inline instrument.
+
+4. **Dry-run first when feasible.** Use a small persona pack (3–5) and the
+   default fast model (`haiku` / `gemini-flash` tier) to validate the
+   instrument before scaling up. Confirm the questions read clearly and the
+   schemas parse before spending on a 30-persona pass.
+
+5. **Force structured output where it matters.** Use the structured /
+   schema-backed response path (Pydantic-style schemas via tool-use forcing)
+   for any question whose downstream use requires aggregation: vote counts,
+   weighted scores, segment splits, ranked lists. Free-form text is fine for
+   discovery but useless for tallies.
+
+6. **Save results and capture the result ID.** Both `run_panel` and
+   `run_quick_poll` persist runs; surface the result ID in your reply so the
+   user can `get_panel_result` later or `extend_panel` for one more round.
+
+7. **Synthesize with discipline.** Report:
+   - Vote tallies (counts and percentages) for closed-form items.
+   - Weighted scores or rank order for prioritization tasks.
+   - Segment splits when personas span clearly distinct groups.
+   - Top objections, surfaced verbatim from at least one persona.
+   - A confidence note that calls out sample size and synthetic provenance.
+
+8. **Apply skeptical / anti-sycophancy prompting.** When designing the
+   instrument:
+   - Ask "what would make you *not* buy / use / recommend this?" alongside
+     positive framings.
+   - Force at least one persona-disagreement probe ("which of you would push
+     back on the loudest answer here?").
+   - Use negative-control questions for sanity (e.g. an obviously bad
+     concept) when calibrating a panel for the first time.
+   - Prefer instruments with `route_when` branches that catch lukewarm
+     responses and probe the friction, rather than letting personas drift
+     into agreement.
+
+9. **Frame the output as synthetic preflight, not market validation.** Every
+   reply that contains panel results should include a one-line caveat: *this
+   is synthetic input from N AI personas using <model>; treat as a hypothesis
+   generator, not as evidence about real users.*
+
+## Pitfalls
+
+- **Overclaiming.** Synthetic personas are not respondents. Never report
+  results as "users said …" — they didn't. Say "synthetic personas modeled
+  on <demographic> tended to …" and include sample size.
+- **Sycophancy drift.** Without skeptical prompting and disagreement probes,
+  panels of LLM-derived personas converge on whatever the question implies.
+  Bake in pushback questions; check that at least one persona disagrees on
+  every important item.
+- **Persona homogeneity.** Three personas that all look like the model's
+  default voice are worse than one well-shaped persona. Audit persona packs
+  before reuse — diverse `personality_traits` and explicit `background`
+  text matter.
+- **Treating `extend_panel` as branching.** `extend_panel` appends exactly
+  one ad-hoc round on a saved result; it does **not** re-enter a v3
+  instrument's `route_when` DAG. If you want adaptive branching, run a fresh
+  `run_panel` against a v3 instrument instead.
+- **Cost surprises.** Large panels with capable models add up fast. Default
+  to the configured fast model alias (`synthpanel.default_model_alias`,
+  haiku by default); upgrade only when the dry-run signal warrants it.
+- **Theme-matching gotcha on v3 instruments.** `route_when` predicates
+  compare against the *exact* theme strings the synthesizer emits. Prefix v3
+  instruments with a comment block listing canonical theme tags so routes
+  don't silently fall through to `else`.
+
+## Verification
+
+- The user sees an explicit interface note ("used the `synth_panel` MCP
+  server" or "used the `synthpanel` CLI").
+- The reply includes structured numbers — counts, percentages, weighted
+  scores, or rank order — for any aggregation question.
+- A saved result ID is surfaced (e.g. `panel_result_id: 01h…`) so the run
+  is recoverable.
+- A synthetic-preflight caveat appears in the same reply as the results.
+- At least one pushback / counter-argument appears in the synthesis, not
+  just consensus.
+- For pricing or naming work, an explicit recommendation against acting on
+  synthetic-only signal for high-stakes decisions appears.
+
+## See also
+
+- [`focus-group`](../focus-group/SKILL.md) — open-ended qualitative panels.
+- [`name-test`](../name-test/SKILL.md) — head-to-head naming.
+- [`concept-test`](../concept-test/SKILL.md) — value-prop validation.
+- [`survey-prescreen`](../survey-prescreen/SKILL.md) — instrument pre-flight.
+- [`pricing-probe`](../pricing-probe/SKILL.md) — pricing sensitivity.
+- [Agent Skills Discovery index](/.well-known/agent-skills/index.json) on
+  synthpanel.dev — the published index that lists all SynthPanel skills.
+- [`docs/agent-skills.md`](../../docs/agent-skills.md) — install paths
+  (Claude Code plugin, manual copy, other hosts).
+- [`docs/mcp.md`](../../docs/mcp.md) — MCP server reference, sampling mode.

--- a/skills/synthpanel/SKILL.md
+++ b/skills/synthpanel/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: synthpanel
+description: Director skill for SynthPanel — decide when to reach for synthetic panels (focus groups, name tests, concept tests, pricing probes, mass-appeal polls) and route to the right sub-skill, with anti-overclaiming guardrails baked in.
+version: 1.0.0
+author: SynthPanel maintainers
+license: MIT
+allowed-tools:
+  - mcp__synth_panel__run_prompt
+  - mcp__synth_panel__run_quick_poll
+  - mcp__synth_panel__run_panel
+  - mcp__synth_panel__extend_panel
+  - mcp__synth_panel__list_persona_packs
+  - mcp__synth_panel__get_persona_pack
+  - mcp__synth_panel__save_persona_pack
+  - mcp__synth_panel__list_instrument_packs
+  - mcp__synth_panel__get_instrument_pack
+  - mcp__synth_panel__save_instrument_pack
+  - mcp__synth_panel__list_panel_results
+  - mcp__synth_panel__get_panel_result
+metadata:
+  hermes:
+    tags:
+      - research
+      - synthetic-respondents
+      - focus-group
+      - panels
+      - mcp
+      - market-research
+    related_skills:
+      - focus-group
+      - name-test
+      - concept-test
+      - survey-prescreen
+      - pricing-probe
+    config:
+      - key: synthpanel.preferred_interface
+        description: How to call SynthPanel when both are available (mcp, cli).
+        default: mcp
+        prompt: Prefer the synth_panel MCP server, or the synthpanel CLI?
+      - key: synthpanel.default_panel_size
+        description: Persona count for routine polls and concept tests.
+        default: "5"
+        prompt: Default persona count (3–6 is normal; raise for mass-appeal polls)
+      - key: synthpanel.default_model_alias
+        description: LLM alias for routine runs (sonnet, haiku, gemini, grok, ...).
+        default: haiku
+        prompt: Default LLM alias for routine synthetic runs
+required_environment_variables:
+  - name: ANTHROPIC_API_KEY
+    prompt: Anthropic API key (default provider for SynthPanel)
+    help: Needed for Claude-family models. Skip only if exclusively using another provider.
+    required_for:
+      - default-claude-runs
+  - name: OPENAI_API_KEY
+    prompt: OpenAI API key (optional; only if you ask SynthPanel to use OpenAI models)
+    help: Required only when --model selects an OpenAI or OpenAI-compatible model.
+    required_for:
+      - openai-runs
+  - name: GOOGLE_API_KEY
+    prompt: Google API key (optional; only for Gemini models)
+    help: Required only when --model selects a gemini-* model.
+    required_for:
+      - gemini-runs
+  - name: XAI_API_KEY
+    prompt: xAI API key (optional; only for Grok models)
+    help: Required only when --model selects a grok-* model.
+    required_for:
+      - grok-runs
+---
+
+# SynthPanel — synthetic respondent research
+
+## When to use
+
+Reach for this skill the moment a user asks for any of the following — these
+are the canonical triggers:
+
+- "run a synthetic panel" / "run a focus group" / "synthetic focus group"
+- "test positioning" / "test this value prop" / "concept test"
+- "compare product names" / "name test" / "which name is better"
+- "pricing probe" / "what would people pay" / "price sensitivity"
+- "poll 30 personas" / "poll the panel" / "mass-appeal poll"
+- "prioritization poll" / "rank these options across personas"
+- "pre-screen this survey" / "stress-test these questions"
+
+It is also the right skill when a user wants directional, fast, **synthetic**
+input *before* spending budget on real participants — e.g. "I have a hunch,
+should I bother running this past anyone?" or "what would land vs. what would
+fall flat?"
+
+**Do not** use this skill when the user needs decisions backed by real human
+data (regulatory, statistically powered, claims-grade). Say so explicitly and
+recommend a real panel instead — synthetic output is preflight, not validation.
+
+## Quick reference
+
+SynthPanel exposes two interfaces. They are equivalent; prefer the MCP path
+when configured (`synthpanel.preferred_interface = mcp`).
+
+### MCP tools (preferred when `synth_panel` MCP server is registered)
+
+| Tool | Purpose |
+| --- | --- |
+| `mcp__synth_panel__run_prompt` | One-shot prompt against one persona (smoke test). |
+| `mcp__synth_panel__run_quick_poll` | One-question poll across N personas; returns vote tallies + synthesis. |
+| `mcp__synth_panel__run_panel` | Full panel with persona pack + instrument pack (v1, v2, v3 branching). |
+| `mcp__synth_panel__extend_panel` | Append one ad-hoc round on top of a saved result. Not v3 re-entry. |
+| `mcp__synth_panel__list_persona_packs` / `get_persona_pack` / `save_persona_pack` | Manage persona libraries. |
+| `mcp__synth_panel__list_instrument_packs` / `get_instrument_pack` / `save_instrument_pack` | Manage survey instruments (v1/v2/v3). |
+| `mcp__synth_panel__list_panel_results` / `get_panel_result` | Retrieve saved runs by ID. |
+
+### CLI (fallback or scripted use)
+
+```bash
+synthpanel prompt "Say hello"                                # single prompt
+synthpanel panel run \                                       # full panel
+  --personas examples/personas.yaml \
+  --instrument examples/survey.yaml
+synthpanel panel run --personas examples/personas.yaml \     # branching v3
+  --instrument pricing-discovery
+synthpanel instruments list                                  # discover bundled packs
+synthpanel mcp-serve                                         # start MCP server (stdio)
+synthpanel mcp install                                       # register MCP server in the active editor
+```
+
+Provider env vars map: `ANTHROPIC_API_KEY` (default), `OPENAI_API_KEY`,
+`GOOGLE_API_KEY`/`GEMINI_API_KEY`, `XAI_API_KEY`. Pick the model with
+`--model sonnet|haiku|gpt-4o|gemini|grok-3|...`.
+
+### Sub-skill routing
+
+For task-shaped work, delegate to the matching sub-skill rather than
+re-deriving the workflow here. They live alongside this skill:
+
+| Trigger | Sub-skill |
+| --- | --- |
+| Open-ended exploration with personas | `focus-group` |
+| 1–3 candidate names compared head-to-head | `name-test` |
+| "Does this value-prop land?" / problem validation | `concept-test` |
+| "Pre-screen this survey before fielding it" | `survey-prescreen` |
+| Pricing sensitivity / willingness-to-pay | `pricing-probe` |
+| One-question poll, no follow-ups | `run_quick_poll` MCP tool directly |
+
+## Procedure
+
+1. **Confirm the question is synthetic-appropriate.** If the user needs
+   audited, real-human evidence, stop and say so. Otherwise frame what you
+   are about to do as a synthetic preflight.
+
+2. **Pick the interface.** Check whether the `synth_panel` MCP server is
+   registered (tools prefixed `mcp__synth_panel__*` exist). If yes, use MCP.
+   If not, fall back to the CLI. Tell the user which one you used.
+
+3. **Pick the sub-skill** from the routing table above. If none of the
+   sub-skills fits, run an ad-hoc `run_quick_poll` (single question,
+   `panel_size` personas) or a `run_panel` with an inline instrument.
+
+4. **Dry-run first when feasible.** Use a small persona pack (3–5) and the
+   default fast model (`haiku` / `gemini-flash` tier) to validate the
+   instrument before scaling up. Confirm the questions read clearly and the
+   schemas parse before spending on a 30-persona pass.
+
+5. **Force structured output where it matters.** Use the structured /
+   schema-backed response path (Pydantic-style schemas via tool-use forcing)
+   for any question whose downstream use requires aggregation: vote counts,
+   weighted scores, segment splits, ranked lists. Free-form text is fine for
+   discovery but useless for tallies.
+
+6. **Save results and capture the result ID.** Both `run_panel` and
+   `run_quick_poll` persist runs; surface the result ID in your reply so the
+   user can `get_panel_result` later or `extend_panel` for one more round.
+
+7. **Synthesize with discipline.** Report:
+   - Vote tallies (counts and percentages) for closed-form items.
+   - Weighted scores or rank order for prioritization tasks.
+   - Segment splits when personas span clearly distinct groups.
+   - Top objections, surfaced verbatim from at least one persona.
+   - A confidence note that calls out sample size and synthetic provenance.
+
+8. **Apply skeptical / anti-sycophancy prompting.** When designing the
+   instrument:
+   - Ask "what would make you *not* buy / use / recommend this?" alongside
+     positive framings.
+   - Force at least one persona-disagreement probe ("which of you would push
+     back on the loudest answer here?").
+   - Use negative-control questions for sanity (e.g. an obviously bad
+     concept) when calibrating a panel for the first time.
+   - Prefer instruments with `route_when` branches that catch lukewarm
+     responses and probe the friction, rather than letting personas drift
+     into agreement.
+
+9. **Frame the output as synthetic preflight, not market validation.** Every
+   reply that contains panel results should include a one-line caveat: *this
+   is synthetic input from N AI personas using <model>; treat as a hypothesis
+   generator, not as evidence about real users.*
+
+## Pitfalls
+
+- **Overclaiming.** Synthetic personas are not respondents. Never report
+  results as "users said …" — they didn't. Say "synthetic personas modeled
+  on <demographic> tended to …" and include sample size.
+- **Sycophancy drift.** Without skeptical prompting and disagreement probes,
+  panels of LLM-derived personas converge on whatever the question implies.
+  Bake in pushback questions; check that at least one persona disagrees on
+  every important item.
+- **Persona homogeneity.** Three personas that all look like the model's
+  default voice are worse than one well-shaped persona. Audit persona packs
+  before reuse — diverse `personality_traits` and explicit `background`
+  text matter.
+- **Treating `extend_panel` as branching.** `extend_panel` appends exactly
+  one ad-hoc round on a saved result; it does **not** re-enter a v3
+  instrument's `route_when` DAG. If you want adaptive branching, run a fresh
+  `run_panel` against a v3 instrument instead.
+- **Cost surprises.** Large panels with capable models add up fast. Default
+  to the configured fast model alias (`synthpanel.default_model_alias`,
+  haiku by default); upgrade only when the dry-run signal warrants it.
+- **Theme-matching gotcha on v3 instruments.** `route_when` predicates
+  compare against the *exact* theme strings the synthesizer emits. Prefix v3
+  instruments with a comment block listing canonical theme tags so routes
+  don't silently fall through to `else`.
+
+## Verification
+
+- The user sees an explicit interface note ("used the `synth_panel` MCP
+  server" or "used the `synthpanel` CLI").
+- The reply includes structured numbers — counts, percentages, weighted
+  scores, or rank order — for any aggregation question.
+- A saved result ID is surfaced (e.g. `panel_result_id: 01h…`) so the run
+  is recoverable.
+- A synthetic-preflight caveat appears in the same reply as the results.
+- At least one pushback / counter-argument appears in the synthesis, not
+  just consensus.
+- For pricing or naming work, an explicit recommendation against acting on
+  synthetic-only signal for high-stakes decisions appears.
+
+## See also
+
+- [`focus-group`](../focus-group/SKILL.md) — open-ended qualitative panels.
+- [`name-test`](../name-test/SKILL.md) — head-to-head naming.
+- [`concept-test`](../concept-test/SKILL.md) — value-prop validation.
+- [`survey-prescreen`](../survey-prescreen/SKILL.md) — instrument pre-flight.
+- [`pricing-probe`](../pricing-probe/SKILL.md) — pricing sensitivity.
+- [Agent Skills Discovery index](/.well-known/agent-skills/index.json) on
+  synthpanel.dev — the published index that lists all SynthPanel skills.
+- [`docs/agent-skills.md`](../../docs/agent-skills.md) — install paths
+  (Claude Code plugin, manual copy, other hosts).
+- [`docs/mcp.md`](../../docs/mcp.md) — MCP server reference, sampling mode.

--- a/tests/test_synthpanel_skill.py
+++ b/tests/test_synthpanel_skill.py
@@ -1,0 +1,147 @@
+"""Guard the Hermes-compatible director skill at skills/synthpanel/SKILL.md.
+
+The top-level ``synthpanel`` skill exists so Hermes Agent (and other
+skills-compatible hosts) can route SynthPanel triggers without ad-hoc
+repo spelunking. That value depends on specific frontmatter fields
+being present and shaped correctly — Hermes hides skills with malformed
+or missing required metadata. These tests pin that contract.
+
+Spec references:
+- https://agentskills.io/ (open skills format; name + description required)
+- https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills
+  (Hermes-specific ``metadata.hermes.*`` and ``required_environment_variables``)
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATH = REPO_ROOT / "skills" / "synthpanel" / "SKILL.md"
+
+# Canonical trigger phrases from GH#474 — the issue specified these as the
+# proposed triggers Hermes should match against, so the skill body must
+# mention them or routing fails.
+TRIGGER_PHRASES = (
+    "synthetic panel",
+    "focus group",
+    "positioning",
+    "compare product names",
+    "pricing probe",
+    "poll 30 personas",
+    "prioritization poll",
+)
+
+# Anti-overclaiming and structural-quality patterns the GH issue called out.
+GUIDANCE_PATTERNS = (
+    "MCP",
+    "CLI",
+    "dry-run",
+    "structured",
+    "result ID",
+    "synthetic preflight",
+    "sycophancy",
+)
+
+
+def _read_frontmatter() -> dict:
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    match = re.match(r"\A---\n(.*?)\n---\n", text, re.DOTALL)
+    assert match, f"{SKILL_PATH} missing YAML frontmatter"
+    return yaml.safe_load(match.group(1))
+
+
+def test_skill_file_exists() -> None:
+    assert SKILL_PATH.is_file(), f"missing {SKILL_PATH.relative_to(REPO_ROOT)}"
+
+
+def test_required_open_format_fields() -> None:
+    """Agent Skills Discovery requires name + description at minimum."""
+    fm = _read_frontmatter()
+    assert fm["name"] == "synthpanel"
+    assert isinstance(fm["description"], str) and len(fm["description"]) >= 40, (
+        "description must be substantive enough for retrieval"
+    )
+
+
+def test_hermes_metadata_block_present() -> None:
+    fm = _read_frontmatter()
+    hermes = fm.get("metadata", {}).get("hermes")
+    assert isinstance(hermes, dict), "metadata.hermes block missing"
+    tags = hermes.get("tags")
+    assert isinstance(tags, list) and tags, "metadata.hermes.tags must be a non-empty list"
+    related = hermes.get("related_skills")
+    assert isinstance(related, list) and set(related) >= {
+        "focus-group",
+        "name-test",
+        "concept-test",
+        "survey-prescreen",
+        "pricing-probe",
+    }, "related_skills must enumerate the five workflow skills"
+    config = hermes.get("config")
+    assert isinstance(config, list) and config, "metadata.hermes.config must declare at least one setting"
+    for entry in config:
+        assert {"key", "description", "default", "prompt"} <= set(entry), (
+            f"Hermes config entry missing required keys: {entry}"
+        )
+
+
+def test_versioning_and_license_declared() -> None:
+    """Hermes surfaces version and license in its skill catalog UI."""
+    fm = _read_frontmatter()
+    assert re.match(r"^\d+\.\d+\.\d+$", fm["version"]), f"version must be semver, got {fm['version']!r}"
+    assert fm["license"], "license must be set"
+    assert fm["author"], "author must be set"
+
+
+def test_required_environment_variables_declared() -> None:
+    fm = _read_frontmatter()
+    env_vars = {entry["name"]: entry for entry in fm.get("required_environment_variables", [])}
+    assert "ANTHROPIC_API_KEY" in env_vars, "default Claude provider key must be advertised"
+    for name, entry in env_vars.items():
+        assert "prompt" in entry, f"{name} missing 'prompt' for Hermes provisioning"
+        assert "help" in entry, f"{name} missing 'help' text"
+        assert "required_for" in entry, f"{name} missing 'required_for' scope hint"
+
+
+def test_allowed_tools_covers_mcp_surface() -> None:
+    """Claude Code reads allowed-tools to gate MCP calls — keep parity with the MCP server."""
+    fm = _read_frontmatter()
+    allowed = set(fm.get("allowed-tools", []))
+    expected_core = {
+        "mcp__synth_panel__run_prompt",
+        "mcp__synth_panel__run_quick_poll",
+        "mcp__synth_panel__run_panel",
+    }
+    assert expected_core <= allowed, f"core MCP tools missing from allowed-tools: {expected_core - allowed}"
+
+
+def test_body_mentions_all_canonical_triggers() -> None:
+    body = SKILL_PATH.read_text(encoding="utf-8").lower()
+    missing = [phrase for phrase in TRIGGER_PHRASES if phrase.lower() not in body]
+    assert not missing, f"GH#474 triggers missing from skill body: {missing}"
+
+
+def test_body_includes_anti_overclaiming_guidance() -> None:
+    body = SKILL_PATH.read_text(encoding="utf-8")
+    missing = [pat for pat in GUIDANCE_PATTERNS if pat.lower() not in body.lower()]
+    assert not missing, f"required guidance patterns missing: {missing}"
+
+
+def test_body_uses_hermes_conventional_sections() -> None:
+    body = SKILL_PATH.read_text(encoding="utf-8")
+    for header in ("## When to use", "## Procedure", "## Pitfalls", "## Verification"):
+        assert header in body, f"Hermes-conventional section missing: {header}"
+
+
+def test_plugin_manifest_registers_director_skill() -> None:
+    """The Claude Code plugin manifest must list the new skill so /plugin install works."""
+    import json
+
+    manifest = json.loads((REPO_ROOT / ".claude-plugin" / "plugin.json").read_text())
+    assert "skills/synthpanel/SKILL.md" in manifest["skills"], (
+        "skills/synthpanel/SKILL.md missing from .claude-plugin/plugin.json"
+    )


### PR DESCRIPTION
## Summary

Adds a top-level `synthpanel` SKILL.md at `skills/synthpanel/` that tells
agents — Hermes Agent in particular — when to reach for SynthPanel and how
to route the request to one of the existing five workflow skills
(`focus-group`, `name-test`, `concept-test`, `survey-prescreen`,
`pricing-probe`).

The skill carries Hermes-specific frontmatter (`metadata.hermes.tags`,
`metadata.hermes.related_skills`, `metadata.hermes.config`,
`required_environment_variables`) so Hermes can install and configure it
without ad-hoc repo spelunking, while remaining a valid open-format
SKILL.md that Claude Code, Codex CLI, Cursor, Goose, and OpenHands can also
load.

## Behaviour

Covers the canonical triggers from #474 ("run a synthetic panel", "test
positioning", "compare names", "pricing probe", "poll N personas",
"prioritization poll", "pre-screen this survey"); prefers MCP when
available; falls back to CLI; mandates dry-runs and structured /
schema-backed responses; requires saved result IDs; and hard-codes
anti-overclaiming and anti-sycophancy guardrails into the Procedure,
Pitfalls, and Verification sections. Output framing as "synthetic
preflight, not market validation" is required.

## Wiring

- `scripts/render_agent_skills.py`: adds `synthpanel` first in `SKILL_ORDER`, so `/.well-known/agent-skills/index.json` lists it before the five workflow skills.
- `.claude-plugin/plugin.json`: registers the new skill so `/plugin install synthpanel` exposes it in Claude Code.
- `docs/agent-skills.md`: documents the director skill, adds a dedicated Hermes Agent install section, updates manual-copy snippets.

## Test plan

- `tests/test_synthpanel_skill.py` pins the contract: open-format fields, Hermes metadata block, semver version, declared env vars with `prompt`/`help`/`required_for`, `allowed-tools` parity with the MCP surface, presence of all canonical triggers and guidance patterns, Hermes-conventional section headers, plugin-manifest registration.
- Existing `tests/test_agent_skills_index.py` drift guard now covers six skills.
- GitHub CI runs the full suite on this PR.

## References

- Bead: sy-7pw
- Closes #474
- MR: sy-wisp-cg2
- Polecat: topaz
- Branch: polecat/topaz-19e5195276a