### PR TITLE
ci: validate clean install paths (pip, pip[mcp], pipx) in CI (sy-6kr)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,12 +161,17 @@ jobs:
         run: python scripts/check_site_cli_sync.py
 
   install-smoke:
-    # Guards the source/uv install paths agents and contributors actually
-    # use. The historical `composio>=0.5,<0.6` pin silently broke when
-    # upstream yanked the 0.5.x line; this job catches that class of
-    # resolver friction before it hits a first-time contributor. Each
-    # extra is resolved in its own fresh venv so a failure points at the
-    # specific extra. See sy-4c9 / gh-470 for background.
+    # Guards the *source/uv resolution* path agents and contributors hit
+    # when they clone the repo. The historical `composio>=0.5,<0.6` pin
+    # silently broke when upstream yanked the 0.5.x line; this job
+    # catches that class of resolver friction before it hits a first-time
+    # contributor. Each extra is resolved in its own fresh venv so a
+    # failure points at the specific extra. See sy-4c9 / gh-470 for
+    # background.
+    #
+    # Complements `clean-install-smoke` / `clean-install-pipx` below
+    # (sy-6kr), which validate the *built wheel* runtime CLI from PyPI's
+    # perspective. Different failure modes — keep both.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -201,3 +206,105 @@ jobs:
             uv pip install --python "/tmp/venv-$extra/bin/python" -e ".[$extra]"
             echo "::endgroup::"
           done
+
+  clean-install-smoke:
+    # sy-6kr: prove `pip install synthpanel` (no source checkout) yields
+    # a working CLI from a fresh environment. The matrix exercises the
+    # two wheel-from-PyPI agent-onboarding paths (bare wheel, `[mcp]`
+    # extra); pipx gets its own job below. Failures here surface as
+    # dependency-resolver confusion or broken entry points to end users —
+    # we want them to fail in CI instead of in someone's first session.
+    #
+    # Complements `install-smoke` above (sy-4c9), which validates
+    # resolver behaviour across *every* extra from source. This job
+    # exercises the runtime CLI off the built wheel instead.
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        install:
+          - { name: "pip (no extras)", extras: "" }
+          - { name: "pip [mcp]",       extras: "[mcp]" }
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Build wheel
+        run: |
+          pip install --upgrade build
+          python -m build --wheel
+
+      - name: Show built artifact
+        run: ls -lh dist/
+
+      - name: Fresh venv install + smoke (${{ matrix.install.name }})
+        env:
+          # Use a fake key so `doctor`'s "credentials present" check
+          # passes without ever calling a provider. The smoke commands
+          # never make network requests; we just want exit code 0.
+          ANTHROPIC_API_KEY: fake-key-for-smoke-test
+        run: |
+          set -euo pipefail
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/python -m pip install --upgrade pip
+          WHEEL=$(ls dist/synthpanel-*.whl)
+          /tmp/smoke/bin/python -m pip install "${WHEEL}${{ matrix.install.extras }}"
+
+          # No source directory is on the path — `synthpanel` resolves
+          # only via the wheel. If any of these fail, the install path
+          # is broken for new users.
+          /tmp/smoke/bin/synthpanel --version
+          /tmp/smoke/bin/synthpanel --help > /dev/null
+          /tmp/smoke/bin/synthpanel whoami
+          /tmp/smoke/bin/synthpanel doctor
+
+          # `[mcp]` matrix entry must additionally import the MCP server.
+          if [ -n "${{ matrix.install.extras }}" ]; then
+            /tmp/smoke/bin/python -c "from synth_panel.mcp.server import mcp; print('mcp server import OK')"
+          fi
+
+  clean-install-pipx:
+    # sy-6kr: pipx is the canonical "I just want the CLI globally" path
+    # for agent onboarding. Worth its own job because pipx's isolated
+    # venv layout differs from a plain `python -m venv` install, and we
+    # want to catch any pipx-only regression (entry-point shimming,
+    # data-file shipping) before it hits PyPI.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Build wheel
+        run: |
+          pip install --upgrade build
+          python -m build --wheel
+
+      - name: Install via pipx + smoke
+        env:
+          ANTHROPIC_API_KEY: fake-key-for-smoke-test
+        run: |
+          set -euo pipefail
+          pip install --upgrade pipx
+          python -m pipx ensurepath
+          WHEEL=$(ls dist/synthpanel-*.whl)
+          # `--python` keeps pipx pinned to the runner's 3.14; the default
+          # would otherwise reach for the system python.
+          python -m pipx install --python "$(which python)" "${WHEEL}"
+          # pipx installs to ~/.local/bin by default.
+          export PATH="$HOME/.local/bin:$PATH"
+          synthpanel --version
+          synthpanel --help > /dev/null
+          synthpanel whoami
+          synthpanel doctor

--- a/README.md
+++ b/README.md
@@ -137,25 +137,43 @@ defined but not yet emitted on the success path — see the note in the lede).
 
 ## Human Operator Quick Start
 
-Prefer a terminal? Same engine, CLI surface.
+Prefer a terminal? Same engine, CLI surface. Pick the install path that
+matches how you use Python tools:
+
+| Path | When | Command |
+|------|------|---------|
+| **pip** (in your project venv) | You're integrating SynthPanel as a library | `pip install synthpanel` |
+| **pip + MCP** (in your project venv) | You also want the MCP server for agent integration | `pip install 'synthpanel[mcp]'` |
+| **pipx** (global, isolated) | You want `synthpanel` on your PATH without polluting any project | `pipx install synthpanel` |
+| **uvx** (zero-install) | You just want to run it once — no install at all | `uvx --from synthpanel synthpanel --help` |
+| **source** (latest unreleased) | You want main-branch fixes ahead of the next PyPI cut | `pip install git+https://github.com/DataViking-Tech/SynthPanel.git@main` |
+
+After installing, verify the CLI is on your PATH and the runtime is sane
+*before* configuring providers:
 
 ```bash
-# Install from PyPI
-pip install synthpanel
+synthpanel --version          # smoke: package metadata + entry point dispatch
+synthpanel doctor             # diagnostic: python, deps, packs, checkpoint dir
+synthpanel whoami             # which providers (if any) have credentials
+```
 
-# For MCP server support (agent integration)
-pip install synthpanel[mcp]
+`doctor` exits non-zero with actionable guidance when something's
+missing (no provider configured, wrong Python, MCP extra absent, etc.) —
+it's the canonical "did the install land cleanly?" check, and
+`clean-install-smoke` in CI runs the same sequence against the built
+wheel on every push, so all three commands are part of the supported
+contract.
 
-# Or install from source for the latest unreleased changes
-pip install git+https://github.com/DataViking-Tech/SynthPanel.git@main
+Then provide an API key (Claude, OpenAI, Gemini, xAI, or any
+OpenAI-compatible provider) — either export it in your shell or persist
+it once via `synthpanel login`:
 
-# Provide an API key (Claude, OpenAI, Gemini, xAI, or any OpenAI-compatible provider)
-# — either export it in your shell:
+```bash
 export ANTHROPIC_API_KEY="sk-..."
-# — or persist it once with `synthpanel login` (stored at
-#   ~/.config/synthpanel/credentials.json, mode 0600):
-synthpanel login --provider anthropic --api-key sk-...
-synthpanel whoami   # see which providers have credentials available
+# or
+synthpanel login --provider anthropic --api-key sk-...    # stored at
+# ~/.config/synthpanel/credentials.json, mode 0600
+synthpanel whoami
 
 # Run a single prompt
 synthpanel prompt "What do you think of the name Traitprint for a career app?"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,10 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-m 'not acceptance' --cov=synth_panel --cov-report=term-missing --cov-fail-under=80"
+addopts = "-m 'not acceptance and not install_smoke' --cov=synth_panel --cov-report=term-missing --cov-fail-under=80"
 markers = [
     "acceptance: live API acceptance tests (require ANTHROPIC_API_KEY)",
+    "install_smoke: slow fresh-venv install validation (sy-6kr); opt in with `-m install_smoke`",
 ]
 
 [tool.ruff]

--- a/tests/test_install_smoke.py
+++ b/tests/test_install_smoke.py
@@ -1,0 +1,219 @@
+"""sy-6kr: fresh-install smoke tests.
+
+Builds the wheel from this checkout, installs it into a throwaway
+virtualenv (no source on the path), and exercises the documented
+agent-onboarding commands. Mirrors the ``clean-install-smoke`` CI job
+so the contract is also locally reproducible.
+
+These tests are slow (~25 s each — build + venv create + pip install +
+import) so they're gated behind ``-m install_smoke`` and skipped by
+default. CI runs them as a dedicated job; local devs run them ad hoc
+before cutting a release.
+
+To run::
+
+    pytest tests/test_install_smoke.py -m install_smoke
+
+The tests deliberately use a *fake* ``ANTHROPIC_API_KEY`` so ``doctor``
+treats the env as "credentials present" without ever calling a
+provider. Every smoke command must finish in seconds with exit code 0;
+any network call would blow that budget and fail the test.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Mark every test in the module so they share the gating flag.
+pytestmark = pytest.mark.install_smoke
+
+
+def _build_wheel(target_dir: Path) -> Path:
+    """Build a wheel from the current checkout into ``target_dir``.
+
+    Returns the wheel's Path. We deliberately reuse the parent's Python
+    so the wheel's interpreter-tag matches what we'll install into.
+    """
+    target_dir.mkdir(parents=True, exist_ok=True)
+    # ``--outdir`` keeps the build out of the repo's dist/ to avoid
+    # racing with a local ``python -m build`` invocation.
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "build",
+            "--wheel",
+            "--outdir",
+            str(target_dir),
+        ],
+        cwd=_REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    wheels = sorted(target_dir.glob("synthpanel-*.whl"))
+    assert wheels, f"no wheel produced in {target_dir}"
+    return wheels[-1]
+
+
+def _make_venv(venv_dir: Path) -> Path:
+    """Create a fresh venv and return the path to its python executable."""
+    venv.EnvBuilder(with_pip=True, clear=True).create(venv_dir)
+    py = venv_dir / ("Scripts" if os.name == "nt" else "bin") / "python"
+    # Ensure we're not accidentally inheriting the parent's site-packages.
+    # The .pth files that editable installs drop into the parent env are
+    # the most likely contaminant.
+    assert py.exists(), f"venv python missing: {py}"
+    return py
+
+
+def _smoke_env() -> dict[str, str]:
+    """Build the env passed to smoke subprocesses.
+
+    Strips the parent's PYTHONPATH so the wheel install is the *only*
+    way ``synthpanel`` can resolve — that's the whole point of the test.
+    Adds a fake credential so ``doctor`` exits 0.
+    """
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env["ANTHROPIC_API_KEY"] = "fake-key-for-smoke-test"
+    return env
+
+
+def _ensure_build() -> None:
+    """Skip rather than fail when ``build`` is unavailable.
+
+    Outside of CI, devs may run pytest before installing the ``dev``
+    extra. We'd rather skip with a clear hint than burn through a
+    confusing ModuleNotFoundError.
+    """
+    try:
+        import build  # noqa: F401
+    except ImportError:
+        pytest.skip("install `build` first: pip install build")
+
+
+@pytest.fixture(scope="module")
+def installed_wheel(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Module-scoped fixture: build the wheel once, share across tests."""
+    _ensure_build()
+    return _build_wheel(tmp_path_factory.mktemp("wheel"))
+
+
+def _install_and_smoke(
+    tmp_path: Path,
+    wheel: Path,
+    extras: str = "",
+    *,
+    expect_mcp: bool = False,
+) -> None:
+    """Install ``wheel{extras}`` into a fresh venv and run the smoke commands.
+
+    Raises ``subprocess.CalledProcessError`` (via ``check=True``) on any
+    failure, which pytest renders with full stdout/stderr.
+    """
+    venv_dir = tmp_path / "smoke-venv"
+    py = _make_venv(venv_dir)
+    spec = f"{wheel}{extras}"
+
+    # --upgrade pip so we know we're not testing against pip < 23.x's
+    # quirky resolver. Quiet to keep CI logs scannable; on failure pytest
+    # captures the subprocess output via check=True.
+    subprocess.run(
+        [str(py), "-m", "pip", "install", "--quiet", "--upgrade", "pip"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        [str(py), "-m", "pip", "install", "--quiet", spec],
+        check=True,
+        capture_output=True,
+    )
+
+    synthpanel = py.parent / ("synthpanel.exe" if os.name == "nt" else "synthpanel")
+    assert synthpanel.exists(), f"entry-point binary missing after install: {synthpanel}"
+
+    env = _smoke_env()
+
+    # `--version` must work without any provider config. This is the
+    # smallest possible CLI smoke — entry-point dispatch + package
+    # metadata load.
+    out = subprocess.run(
+        [str(synthpanel), "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert "synthpanel" in out.stdout.lower(), f"--version missing 'synthpanel': {out.stdout!r}"
+
+    subprocess.run(
+        [str(synthpanel), "--help"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # whoami always exits 0 (informational) — it must not raise on a
+    # fresh install with no credential store.
+    subprocess.run(
+        [str(synthpanel), "whoami"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # doctor exits 0 iff: python OK, deps OK, credentials present,
+    # checkpoint root writable, packs loaded. Our fake env satisfies
+    # the credential check; the rest must come from the wheel.
+    subprocess.run(
+        [str(synthpanel), "doctor"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    if expect_mcp:
+        # The [mcp] extra must let us import the server's top-level
+        # FastMCP object. We don't actually serve over stdio — that
+        # would block forever. Just prove the import surface lands.
+        subprocess.run(
+            [
+                str(py),
+                "-c",
+                "from synth_panel.mcp.server import mcp; assert mcp is not None",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+
+def test_pip_install_bare_wheel_yields_working_cli(
+    installed_wheel: Path,
+    tmp_path: Path,
+) -> None:
+    """``pip install synthpanel`` (no extras) must give us a CLI that
+    survives --version / --help / whoami / doctor on a fresh venv."""
+    _install_and_smoke(tmp_path, installed_wheel, extras="")
+
+
+def test_pip_install_with_mcp_extra_yields_working_mcp_surface(
+    installed_wheel: Path,
+    tmp_path: Path,
+) -> None:
+    """``pip install 'synthpanel[mcp]'`` must additionally let us import
+    the MCP server (FastMCP top-level object). This is the agent-onboarding
+    happy path."""
+    _install_and_smoke(tmp_path, installed_wheel, extras="[mcp]", expect_mcp=True)


### PR DESCRIPTION
## Summary

Adds `clean-install-smoke` + `clean-install-pipx` jobs to `ci.yml`. Each
builds the wheel, installs it into a fresh venv (no source on path), and
runs the four documented agent-onboarding commands: `--version`, `--help`,
`whoami`, `doctor`. The `[mcp]` matrix entry additionally imports the
FastMCP server object to prove the extra wires correctly. Boardroom's
"synthpanel command not found" fallback to source-spelunking (#469) gets a
regression net.

## Changes

- `.github/workflows/ci.yml`: new `clean-install-smoke` matrix (pip, pip[mcp], pipx) + `clean-install-pipx` job. Wheel build → fresh venv install → run `--version` / `--help` / `whoami` / `doctor` against the installed entrypoint; `[mcp]` row additionally imports the FastMCP server object.
- `tests/test_install_smoke.py`: local repro of the same contract, gated behind `pytest -m install_smoke` so the slow build+venv cycle doesn't run by default.
- `README`: Human Operator Quick Start gets an install-path matrix (pip / pip[mcp] / pipx / uvx / source) and surfaces the `--version` / `doctor` / `whoami` smoke trio as the canonical post-install sanity check.

## Relationship to PR #483 (sy-4c9, install-smoke for extras)

PR #483 added an `install-smoke` job that exercises every optional extra
(`mcp`, `composio`, `convergence`, `pdf`, `full`, `visual`) under both `pip`
and `uv`. This PR adds **clean-install** smoke for the agent-onboarding
surface (entrypoint commands run from the installed wheel, not just import).
The two jobs cover different failure modes — extras resolution vs. installed
entrypoint behaviour — and run independently. The rebase conflict from the
earlier MR (sy-wisp-309) has been resolved against #483's job.

## Test plan

- New `clean-install-smoke` + `clean-install-pipx` CI jobs gate every PR going forward.
- `tests/test_install_smoke.py -m install_smoke` runs the contract locally on demand.
- GitHub CI runs the full suite on this PR.

## References

- Bead: sy-6kr
- Closes #469
- MR: sy-wisp-c50 (superseded sy-wisp-309 after conflict resolution)
- Conflict-resolution task: sy-v5m
- Polecat: garnet-sy
- Branch: polecat/garnet-sy-6kr