### PR TITLE
feat(poll-summary): deterministic structured-response rollup (sy-4yd)

### DIFF
--- a/site/cli-coverage.txt
+++ b/site/cli-coverage.txt
@@ -24,6 +24,7 @@ mcp-serve
 pack
 panel
 plugin
+poll-summary
 prompt
 report
 runs

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -5269,6 +5269,121 @@ def handle_report(args: argparse.Namespace, fmt: OutputFormat) -> int:
     return 0
 
 
+def handle_poll_summary(args: argparse.Namespace, fmt: OutputFormat) -> int:
+    """Render the deterministic structured-response summary for a saved result.
+
+    Loads the result (ID or path), runs :func:`build_poll_summary`, then
+    emits either a human-friendly text block (default) or the full JSON
+    payload. ``--segment-by`` is split on commas; empty string disables
+    segment splits.
+
+    Exits 1 with a typed error message when the result can't be loaded
+    (mirrors ``handle_report``'s ``ReportLoadError`` parity). Exits 0
+    even when the summary is empty — an enum-free result is a valid
+    finding, not an error.
+
+    sy-4yd.
+    """
+    from synth_panel.poll_summary import build_poll_summary
+    from synth_panel.reporting import ReportLoadError, load_panel_json
+
+    try:
+        data = load_panel_json(args.result)
+    except ReportLoadError as err:
+        msg = f"Error: {err}"
+        if fmt is OutputFormat.TEXT:
+            print(msg, file=sys.stderr)
+        else:
+            emit(fmt, message=msg, extra={"error": err.code})
+        return 1
+
+    raw_segment = getattr(args, "segment_by", None)
+    if raw_segment is None:
+        segment_by = None  # use defaults
+    else:
+        # Empty string => disable explicitly; otherwise split on commas
+        # and strip whitespace so `--segment-by "occupation, tier"` works.
+        segment_by = [s.strip() for s in raw_segment.split(",") if s.strip()]
+
+    summary = build_poll_summary(data, segment_by=segment_by)
+    out_format = getattr(args, "poll_summary_format", "text")
+
+    if out_format == "json" or fmt is not OutputFormat.TEXT:
+        payload = summary.to_dict()
+        if fmt is OutputFormat.TEXT:
+            # Direct JSON output for `--format json` regardless of the
+            # top-level --output-format. Lets a user pipe to jq without
+            # also picking the global JSON envelope.
+            print(json.dumps(payload, indent=2))
+        else:
+            emit(fmt, message="poll_summary", extra=payload)
+        return 0
+
+    # Text rendering. Concise — the consumer is either a human eyeballing
+    # the panel or an agent scanning for the headline. Detailed payload
+    # always available via --format json.
+    lines: list[str] = []
+    lines.append(f"Poll summary — {summary.persona_count} panelist{'s' if summary.persona_count != 1 else ''}")
+    if not summary.questions:
+        lines.append("  (no structured questions in this result — see `synthpanel report` for the markdown report)")
+
+    for qs in summary.questions:
+        lines.append("")
+        title = qs.question[:80] + ("…" if len(qs.question) > 80 else "")
+        lines.append(f"  Q{qs.question_index}: {title}  [kind={qs.kind}, n={qs.n}]")
+        if qs.kind == "enum":
+            if qs.winner:
+                lines.append(f"    winner: {qs.winner}")
+            if qs.first_choice_counts:
+                for opt, count in qs.first_choice_counts.items():
+                    pct = (count / qs.n * 100) if qs.n else 0
+                    lines.append(f"      {opt}: {count} ({pct:.0f}%)")
+            if qs.second_choice_counts:
+                lines.append("    second choices:")
+                for opt, count in qs.second_choice_counts.items():
+                    lines.append(f"      {opt}: {count}")
+            if qs.weighted_scores:
+                lines.append("    weighted scores (avg rating per choice):")
+                for opt, score in qs.weighted_scores.items():
+                    lines.append(f"      {opt}: {score:.2f}")
+        elif qs.kind == "scale":
+            if qs.metric_average is not None:
+                lines.append(f"    average: {qs.metric_average:.2f}")
+            if qs.metric_distribution:
+                hist = ", ".join(f"{k}x{v}" for k, v in qs.metric_distribution.items())
+                lines.append(f"    distribution: {hist}")
+        if qs.n_unparseable:
+            lines.append(f"    ({qs.n_unparseable} unparseable response{'s' if qs.n_unparseable != 1 else ''})")
+
+    if summary.segment_splits:
+        lines.append("")
+        lines.append("  segment splits:")
+        for qi, attrs in summary.segment_splits.items():
+            for attr, rows in attrs.items():
+                lines.append(f"    Q{qi} by {attr}:")
+                for value, choices in rows.items():
+                    choice_str = ", ".join(f"{opt}={cnt}" for opt, cnt in choices.items())
+                    lines.append(f"      {value}: {choice_str}")
+
+    if summary.top_objections:
+        lines.append("")
+        lines.append("  top objections:")
+        for obj in summary.top_objections:
+            lines.append(f"    - {obj}")
+
+    if summary.recommended_next_test:
+        lines.append("")
+        lines.append(f"  recommended next test: {summary.recommended_next_test}")
+
+    if summary.warnings:
+        lines.append("")
+        for w in summary.warnings:
+            print(f"  warning: {w}", file=sys.stderr)
+
+    print("\n".join(lines))
+    return 0
+
+
 def _format_path(path: list[dict[str, Any]]) -> str:
     """Render an executed branching path as a single human line.
 

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1175,6 +1175,40 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    # poll-summary (sy-4yd): deterministic structured-response rollup
+    # for a saved panel result. Standalone command (not a `report`
+    # subaction) to keep the existing `report <result>` positional surface
+    # backwards-compatible.
+    poll_summary_parser = subparsers.add_parser(
+        "poll-summary",
+        help=(
+            "Deterministic vote-count / score / objection rollup for a saved poll. "
+            "Works on any result with at least one structured (enum/scale) question."
+        ),
+    )
+    poll_summary_parser.add_argument(
+        "result",
+        metavar="RESULT",
+        help="Panel result ID or path to a result JSON file.",
+    )
+    poll_summary_parser.add_argument(
+        "--format",
+        default="text",
+        choices=["text", "json"],
+        dest="poll_summary_format",
+        help="Output format (default: text). JSON emits the full structured payload.",
+    )
+    poll_summary_parser.add_argument(
+        "--segment-by",
+        default=None,
+        metavar="ATTRS",
+        help=(
+            "Comma-separated persona attributes to split the vote on. "
+            "Default: occupation,segment,age_band,tier. Pass an empty "
+            "string to disable segment splits."
+        ),
+    )
+
     # mcp-serve
     subparsers.add_parser(
         "mcp-serve",

--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -143,6 +143,10 @@ def main(argv: list[str] | None = None) -> int:
         return handle_analyze(args, output_format)
     elif args.command == "report":
         return handle_report(args, output_format)
+    elif args.command == "poll-summary":
+        from synth_panel.cli.commands import handle_poll_summary
+
+        return handle_poll_summary(args, output_format)
     elif args.command == "mcp-serve":
         return handle_mcp_serve(args, output_format)
     elif args.command == "mcp":

--- a/src/synth_panel/mcp/server.py
+++ b/src/synth_panel/mcp/server.py
@@ -781,6 +781,22 @@ async def _run_panel_async_instrument(
     cost_warnings = build_cost_fallback_warnings([*per_model_usage.keys(), synth_model_name])
     merged_warnings = list(mr.warnings) + cost_warnings
 
+    # sy-4yd: attach the deterministic structured-response summary so
+    # MCP callers can read vote counts / weighted scores / objections
+    # from the same envelope without a second tool call. Built from the
+    # final result shape (same as the SDK) so it survives readback.
+    from synth_panel.poll_summary import build_poll_summary
+
+    poll_summary_obj = build_poll_summary(
+        {"results": flat_results, "rounds": rounds_payload, "synthesis": final_synth_dict},
+        personas=personas,
+    )
+    poll_summary_payload = (
+        poll_summary_obj.to_dict()
+        if (poll_summary_obj.questions or poll_summary_obj.top_objections or poll_summary_obj.recommended_next_test)
+        else None
+    )
+
     return {
         "result_id": result_id,
         "model": model,
@@ -800,6 +816,7 @@ async def _run_panel_async_instrument(
         "per_model_results": per_model_results,
         "cost_breakdown": cost_breakdown,
         "metadata": inst_metadata,
+        "poll_summary": poll_summary_payload,
     }
 
 
@@ -930,6 +947,19 @@ async def _run_panel_async(
     synth_model_name = synthesis_dict.get("model") if synthesis_dict else None
     cost_warnings = build_cost_fallback_warnings([*per_model_usage.keys(), synth_model_name])
 
+    # sy-4yd: deterministic poll summary on the single-round envelope too.
+    from synth_panel.poll_summary import build_poll_summary
+
+    poll_summary_obj = build_poll_summary(
+        {"results": result_dicts, "questions": questions, "synthesis": synthesis_dict},
+        personas=personas,
+    )
+    poll_summary_payload = (
+        poll_summary_obj.to_dict()
+        if (poll_summary_obj.questions or poll_summary_obj.top_objections or poll_summary_obj.recommended_next_test)
+        else None
+    )
+
     result: dict[str, Any] = {
         "result_id": result_id,
         "model": model,
@@ -952,6 +982,7 @@ async def _run_panel_async(
         "per_model_results": per_model_results,
         "cost_breakdown": cost_breakdown,
         "metadata": metadata,
+        "poll_summary": poll_summary_payload,
     }
 
     # sp-avmm: synthesis failure must surface loudly at the envelope

--- a/src/synth_panel/poll_summary.py
+++ b/src/synth_panel/poll_summary.py
@@ -1,0 +1,758 @@
+"""Automatic poll summary reporting for structured panel results (sy-4yd).
+
+Walks a saved panel result (PollResult / PanelResult / loaded JSON) and
+emits a deterministic, machine-readable summary of structured responses:
+first-choice vote counts, second-choice vote counts (when the schema
+captures one), weighted scores, metric averages, segment splits by
+persona attribute, top objections, and the synthesis-derived recommended
+next test.
+
+Design constraints (GH #477):
+
+* **Deterministic.** No LLM calls — the summary is a pure function of
+  the result JSON. Two runs over the same input produce byte-identical
+  output. This is what lets agents quote the summary back to a user
+  without a follow-up tool call.
+* **Structured-first, free-text-tolerant.** When a panelist response
+  has a structured ``extraction`` (or a numeric / enum ``response``),
+  it counts toward the typed aggregates. Free-text responses contribute
+  to objections / qualitative notes but never warp the counts.
+* **Shape-agnostic.** Works on PollResult.responses (one question),
+  PanelResult.rounds[].results (many questions), and the raw JSON
+  envelope persisted to disk — the same shapes that
+  :func:`synth_panel.analysis.inspect.build_inspect_report` consumes.
+
+The summary lives at :class:`PollSummary` and is computed via
+:func:`build_poll_summary`. CLI + SDK surfaces are wired up in
+``cli/commands.py`` and ``sdk.py`` respectively.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+# Common field names used by the structured-output engine to surface a
+# panelist's primary choice. Ordered by how strongly each name signals
+# "this is THE choice" — exact matches beat substring matches in the
+# extraction shapes we've seen in the wild.
+_FIRST_CHOICE_KEYS: tuple[str, ...] = (
+    "first_choice",
+    "primary_choice",
+    "choice",
+    "answer",
+    "selection",
+    "winner",
+    "pick",
+    "value",
+)
+
+_SECOND_CHOICE_KEYS: tuple[str, ...] = (
+    "second_choice",
+    "runner_up",
+    "alternate",
+    "fallback",
+)
+
+# Numeric-rating fields. Treated as both a per-response metric (for the
+# overall average) and as a "weight" toward the panelist's first_choice
+# (so an option with mostly 5/5 backers beats one with mostly 3/5 backers
+# even at equal vote counts).
+_SCORE_KEYS: tuple[str, ...] = (
+    "score",
+    "rating",
+    "confidence",
+    "preference_strength",
+    "likelihood",
+)
+
+# Free-text objection / concern fields. Aggregated into ``top_objections``.
+_OBJECTION_KEYS: tuple[str, ...] = (
+    "objections",
+    "concerns",
+    "trust_concerns",
+    "blockers",
+    "pushback",
+    "worries",
+)
+
+# Persona attributes that drive segment splits by default. Authors can
+# extend this via ``segment_by`` on :func:`build_poll_summary`. We keep
+# the default list narrow so the summary stays signal-dense — splitting
+# on every persona attribute produces a noisy long-tail table that
+# obscures the headline result.
+_DEFAULT_SEGMENT_ATTRS: tuple[str, ...] = (
+    "occupation",
+    "segment",
+    "age_band",
+    "tier",
+)
+
+# Cap on top objections + the cap on per-segment value rows. Empirically
+# anything past ~5 starts dragging the headline out of view in CLI text
+# mode and adds little to the agent's decision context.
+_TOP_OBJECTIONS_CAP = 5
+_PER_SEGMENT_VALUE_CAP = 8
+
+
+@dataclass
+class QuestionSummary:
+    """Per-question rollup of structured panelist responses.
+
+    The discriminator is :attr:`kind`:
+
+    * ``"enum"`` — categorical choice. ``first_choice_counts`` is the
+      headline; ``winner`` is the option with the highest count
+      (ties broken by ordering in ``first_choice_counts`` — Counter's
+      first-insertion order in Python 3.7+).
+    * ``"scale"`` — numeric. ``metric_average`` is the headline;
+      ``metric_distribution`` is the histogram.
+    * ``"text"`` — free-form. Counts / averages are ``None`` — the
+      response is summarized only via :class:`PollSummary.top_objections`
+      and the panel's broader synthesis.
+
+    Attributes:
+        question: The question text (truncated to 280 chars for safety).
+        question_index: Zero-based index within the run.
+        kind: One of ``"enum"``, ``"scale"``, ``"text"``.
+        first_choice_counts: For enum questions, ``option -> vote count``.
+            Sorted by descending count, then by first-appearance order.
+        second_choice_counts: Same shape as ``first_choice_counts``, but
+            populated from the panelist's ``second_choice`` extraction
+            field when present. ``None`` when no panelist supplied one.
+        weighted_scores: For enum questions where each panelist also
+            supplied a numeric rating, ``option -> mean rating``.
+            ``None`` when no rating field is present.
+        winner: Option name with the highest first-choice count, or
+            ``None`` when no panelist produced a parseable choice.
+        metric_average: For scale questions, the mean of all parseable
+            numeric responses.
+        metric_distribution: For scale questions, ``stringified_value -> count``.
+            Stringified so the field is JSON-serializable without
+            collapsing 1 and "1" into the same bucket.
+        n: Total panelists who answered this question.
+        n_unparseable: Subset of ``n`` whose response could not be
+            mapped to an option (enum) or a number (scale). Caller can
+            divide to get a parse-rate.
+    """
+
+    question: str
+    question_index: int
+    kind: str  # "enum" | "scale" | "text"
+    n: int
+    n_unparseable: int = 0
+    first_choice_counts: dict[str, int] | None = None
+    second_choice_counts: dict[str, int] | None = None
+    weighted_scores: dict[str, float] | None = None
+    winner: str | None = None
+    metric_average: float | None = None
+    metric_distribution: dict[str, int] | None = None
+
+
+@dataclass
+class PollSummary:
+    """Top-level summary returned by :func:`build_poll_summary`.
+
+    Attributes:
+        questions: Per-question summaries in the order the panel ran
+            them.
+        segment_splits: Three-level dict — ``question_index -> attribute
+            -> attribute_value -> {option: count}``. Lets a caller answer
+            "how did the 25-34 cohort split on Q3?" without rewalking the
+            raw transcript.
+        top_objections: Free-text concerns aggregated across every
+            ``objections`` / ``concerns`` field, normalised and deduped,
+            capped at the most-frequent N. Empty when no objections were
+            captured.
+        recommended_next_test: Echo of ``synthesis.recommendation`` from
+            the panel result when present. The synthesis layer already
+            produces this; we surface it here so a caller can read one
+            object instead of two.
+        persona_count: Total panelists in the result. Useful for
+            normalising the counts (% of panel = count / persona_count).
+        warnings: Non-fatal parser observations — e.g. "Q2 had 3
+            unparseable enum responses". Empty on a clean run.
+    """
+
+    persona_count: int
+    questions: list[QuestionSummary] = field(default_factory=list)
+    segment_splits: dict[str, dict[str, dict[str, dict[str, int]]]] = field(default_factory=dict)
+    top_objections: list[str] = field(default_factory=list)
+    recommended_next_test: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-safe rendering. Used by SDK + MCP surfaces."""
+        return asdict(self)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def build_poll_summary(
+    result: dict[str, Any],
+    *,
+    segment_by: list[str] | None = None,
+    personas: list[dict[str, Any]] | None = None,
+) -> PollSummary:
+    """Compute a :class:`PollSummary` from a saved panel result.
+
+    Args:
+        result: A loaded result JSON dict (from disk or fresh from
+            :func:`run_panel` / :func:`quick_poll`). Both flat
+            (``results: [...]``) and rounds-shaped (``rounds: [{results:
+            [...]}, ...]``) envelopes are accepted.
+        segment_by: Persona attributes to split on. Defaults to the
+            common set (occupation, segment, age_band, tier). Pass
+            ``[]`` to disable segment splits entirely.
+        personas: Optional explicit persona list. When provided, the
+            persona name in each panelist response is looked up here for
+            segment attributes. When omitted, attributes embedded in the
+            panelist record itself are used.
+
+    Returns:
+        A :class:`PollSummary`. Always returns — never raises on a
+        well-formed result. Malformed pieces become entries in
+        ``summary.warnings``.
+    """
+    panelists = _extract_panelists(result)
+    segments = list(_DEFAULT_SEGMENT_ATTRS) if segment_by is None else list(segment_by)
+
+    # The persona lookup lets us join optional persona attributes that
+    # the panelist response doesn't carry inline (the orchestrator only
+    # records ``name`` + ``responses`` per panelist).
+    persona_index: dict[str, dict[str, Any]] = {}
+    if personas:
+        for p in personas:
+            name = p.get("name")
+            if isinstance(name, str):
+                persona_index[name] = p
+
+    questions_meta = _collect_question_meta(result, panelists)
+    summary = PollSummary(persona_count=len(panelists))
+
+    objection_counter: Counter[str] = Counter()
+    seg_table: dict[str, dict[str, dict[str, dict[str, int]]]] = {}
+
+    for qi, qmeta in enumerate(questions_meta):
+        per_panelist = _per_panelist_view(panelists, qi)
+        kind = _detect_kind(qmeta, per_panelist)
+        qsum = _summarise_question(qi, qmeta, per_panelist, kind, summary.warnings)
+        summary.questions.append(qsum)
+
+        # Segments — only meaningful for enum questions where the choice
+        # is comparable across personas. Scale questions get their own
+        # average; text questions feed the objections bucket.
+        if kind == "enum" and segments:
+            seg_table[str(qi)] = _segment_split(per_panelist, persona_index, segments)
+
+        # Objections / concerns get harvested regardless of kind so a
+        # free-text follow-up can still surface trust concerns.
+        for entry in per_panelist:
+            for obj in _harvest_objections(entry):
+                objection_counter[obj] += 1
+
+    summary.segment_splits = seg_table
+    summary.top_objections = [obj for obj, _ in objection_counter.most_common(_TOP_OBJECTIONS_CAP)]
+    summary.recommended_next_test = _extract_recommendation(result)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Extraction helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_panelists(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Flatten the various result envelopes into one list of panelist dicts.
+
+    Handles three shapes, mirroring :func:`analysis.inspect._iter_panelist_entries`:
+
+    * Flat: ``result["results"]`` is the panelist list.
+    * Rounds: ``result["rounds"][i]["results"]`` — we collapse all rounds
+      into one stream because the summary is cross-round by design.
+    * Bare PollResult.responses: top-level list of panelist dicts.
+    """
+    if isinstance(result.get("results"), list):
+        return [p for p in result["results"] if isinstance(p, dict)]
+    if isinstance(result.get("rounds"), list):
+        out: list[dict[str, Any]] = []
+        for rnd in result["rounds"]:
+            if isinstance(rnd, dict) and isinstance(rnd.get("results"), list):
+                out.extend(p for p in rnd["results"] if isinstance(p, dict))
+        return out
+    if isinstance(result.get("responses"), list):
+        return [p for p in result["responses"] if isinstance(p, dict)]
+    return []
+
+
+def _collect_question_meta(
+    result: dict[str, Any],
+    panelists: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Recover one ``{text, response_schema}`` entry per asked question.
+
+    Prefers the run's ``questions`` field when present (carries
+    ``response_schema``). Otherwise falls back to the first panelist's
+    response list — the question text lives there too, just without the
+    schema metadata. ``response_schema`` may be missing in either case;
+    :func:`_detect_kind` is robust to that.
+    """
+    if isinstance(result.get("questions"), list) and result["questions"]:
+        return [q for q in result["questions"] if isinstance(q, dict)]
+
+    if panelists:
+        first_responses = panelists[0].get("responses") or []
+        if isinstance(first_responses, list):
+            return [
+                {"text": r.get("question", "")}
+                for r in first_responses
+                if isinstance(r, dict) and not r.get("follow_up")
+            ]
+    return []
+
+
+def _per_panelist_view(
+    panelists: list[dict[str, Any]],
+    question_index: int,
+) -> list[dict[str, Any]]:
+    """For a question index, return one ``{persona, response_dict}`` per panelist.
+
+    Skips follow-up responses — those don't carry the schema-validated
+    primary answer. Missing responses (panelist failed before reaching
+    this question) become ``{"persona": name, "response_dict": None}``
+    so segment splits still account for the panelist.
+    """
+    out: list[dict[str, Any]] = []
+    for p in panelists:
+        responses = p.get("responses") or []
+        primaries = [r for r in responses if isinstance(r, dict) and not r.get("follow_up")]
+        rd: dict[str, Any] | None = None
+        if 0 <= question_index < len(primaries):
+            rd = primaries[question_index]
+        out.append(
+            {
+                "persona": p.get("persona") or p.get("name"),
+                "persona_attrs": {k: v for k, v in p.items() if k not in ("responses", "usage", "cost")},
+                "response_dict": rd,
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-question summarisation
+# ---------------------------------------------------------------------------
+
+
+def _detect_kind(qmeta: dict[str, Any], per_panelist: list[dict[str, Any]]) -> str:
+    """Classify a question as enum / scale / text.
+
+    Schema-driven when ``qmeta.response_schema`` is present. Otherwise
+    inferred from the response shape: numeric → scale, enum-like dict
+    extractions or short repeating strings → enum, anything else → text.
+    """
+    schema = qmeta.get("response_schema")
+    if isinstance(schema, dict):
+        st = schema.get("type")
+        if st == "enum":
+            return "enum"
+        if st in {"scale", "number", "integer"}:
+            return "scale"
+        if st == "text":
+            # text + extract_schema with a primary choice key still counts
+            # as enum for summary purposes. The schema text/extraction
+            # split is an implementation detail of the orchestrator —
+            # for the consumer, "what did the panel pick" is the question.
+            if _has_choice_extraction(per_panelist):
+                return "enum"
+            return "text"
+
+    # Inference fallback. Order matters: numeric responses (scale) take
+    # precedence over short strings (which would otherwise look enum-y
+    # to the second branch).
+    if _looks_numeric(per_panelist):
+        return "scale"
+    if _has_choice_extraction(per_panelist) or _looks_enum(per_panelist):
+        return "enum"
+    return "text"
+
+
+def _summarise_question(
+    qi: int,
+    qmeta: dict[str, Any],
+    per_panelist: list[dict[str, Any]],
+    kind: str,
+    warnings: list[str],
+) -> QuestionSummary:
+    """Build a :class:`QuestionSummary` for one question."""
+    question_text = str(qmeta.get("text") or "")[:280]
+    n = sum(1 for v in per_panelist if v["response_dict"] is not None)
+
+    if kind == "enum":
+        return _summarise_enum(qi, question_text, per_panelist, n, warnings)
+    if kind == "scale":
+        return _summarise_scale(qi, question_text, per_panelist, n, warnings)
+    return QuestionSummary(question=question_text, question_index=qi, kind="text", n=n)
+
+
+def _summarise_enum(
+    qi: int,
+    question_text: str,
+    per_panelist: list[dict[str, Any]],
+    n: int,
+    warnings: list[str],
+) -> QuestionSummary:
+    """Enum rollup: vote counts, optional second-choice + weighted scores."""
+    first: Counter[str] = Counter()
+    second: Counter[str] = Counter()
+    scores: dict[str, list[float]] = {}
+    unparseable = 0
+
+    for entry in per_panelist:
+        rd = entry["response_dict"]
+        if rd is None:
+            continue
+        choice = _extract_first_choice(rd)
+        if choice is None:
+            unparseable += 1
+            continue
+        first[choice] += 1
+        sc = _extract_second_choice(rd)
+        if sc is not None and sc != choice:
+            second[sc] += 1
+        score = _extract_score(rd)
+        if score is not None:
+            scores.setdefault(choice, []).append(score)
+
+    if unparseable:
+        warnings.append(
+            f"Q{qi}: {unparseable}/{n} response{'s' if unparseable != 1 else ''} "
+            "could not be mapped to an option (response was free-text or empty)."
+        )
+
+    first_counts = _sorted_counts(first)
+    second_counts = _sorted_counts(second) if second else None
+    weighted = {opt: round(sum(vals) / len(vals), 4) for opt, vals in scores.items() if vals} if scores else None
+    winner = next(iter(first_counts), None) if first_counts else None
+
+    return QuestionSummary(
+        question=question_text,
+        question_index=qi,
+        kind="enum",
+        n=n,
+        n_unparseable=unparseable,
+        first_choice_counts=first_counts or None,
+        second_choice_counts=second_counts,
+        weighted_scores=weighted,
+        winner=winner,
+    )
+
+
+def _summarise_scale(
+    qi: int,
+    question_text: str,
+    per_panelist: list[dict[str, Any]],
+    n: int,
+    warnings: list[str],
+) -> QuestionSummary:
+    """Scale rollup: mean + histogram."""
+    values: list[float] = []
+    histogram: Counter[str] = Counter()
+    unparseable = 0
+    for entry in per_panelist:
+        rd = entry["response_dict"]
+        if rd is None:
+            continue
+        v = _extract_score(rd)
+        if v is None:
+            unparseable += 1
+            continue
+        values.append(v)
+        # Histogram bucket: render as int when the value is integral
+        # (Likert 1..5 produces "1".."5", not "1.0".."5.0").
+        bucket = str(int(v)) if v == int(v) else f"{v:g}"
+        histogram[bucket] += 1
+
+    if unparseable:
+        warnings.append(
+            f"Q{qi}: {unparseable}/{n} response{'s' if unparseable != 1 else ''} "
+            "could not be mapped to a number (response was non-numeric)."
+        )
+
+    avg = round(sum(values) / len(values), 4) if values else None
+    # Sort histogram by numeric value of the key for stable, scannable
+    # output ("1","2","3","4","5") rather than insertion order.
+    sorted_hist: dict[str, int] | None = None
+    if histogram:
+        sorted_hist = dict(sorted(histogram.items(), key=lambda kv: float(kv[0])))
+
+    return QuestionSummary(
+        question=question_text,
+        question_index=qi,
+        kind="scale",
+        n=n,
+        n_unparseable=unparseable,
+        metric_average=avg,
+        metric_distribution=sorted_hist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field extractors — robust to multiple shapes
+# ---------------------------------------------------------------------------
+
+
+def _extract_first_choice(response_dict: dict[str, Any]) -> str | None:
+    """Pull the panelist's primary choice from a response record.
+
+    Checks (in order): ``extraction`` dict for any of the known choice
+    keys, then the raw ``response`` field (which is a string for enum
+    schemas). Returns ``None`` when nothing parseable is found —
+    callers add to ``n_unparseable`` rather than guess.
+    """
+    extraction = response_dict.get("extraction")
+    if isinstance(extraction, dict):
+        for key in _FIRST_CHOICE_KEYS:
+            val = extraction.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+            if isinstance(val, (int, float)) and not isinstance(val, bool):
+                return str(val)
+
+    raw = response_dict.get("response")
+    if isinstance(raw, str) and raw.strip():
+        # Enum schemas store the picked option directly as the response
+        # string. Truncate aggressively — a free-text fallthrough can be
+        # an entire paragraph and would pollute the counts dict.
+        text = raw.strip()
+        if len(text) <= 120:
+            return text
+    if isinstance(raw, dict):
+        for key in _FIRST_CHOICE_KEYS:
+            val = raw.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
+
+
+def _extract_second_choice(response_dict: dict[str, Any]) -> str | None:
+    extraction = response_dict.get("extraction")
+    if isinstance(extraction, dict):
+        for key in _SECOND_CHOICE_KEYS:
+            val = extraction.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
+
+
+def _extract_score(response_dict: dict[str, Any]) -> float | None:
+    """Coerce a numeric rating out of a response record.
+
+    Returns ``None`` when nothing numeric is found. Booleans are NOT
+    treated as numbers — ``True/False`` showing up here is a schema
+    mismatch the caller should learn about via ``n_unparseable``.
+    """
+    raw = response_dict.get("response")
+    val = _coerce_number(raw)
+    if val is not None:
+        return val
+
+    extraction = response_dict.get("extraction")
+    if isinstance(extraction, dict):
+        for key in _SCORE_KEYS:
+            v = _coerce_number(extraction.get(key))
+            if v is not None:
+                return v
+    return None
+
+
+def _coerce_number(value: Any) -> float | None:
+    """Best-effort numeric coercion. Strict on booleans."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        s = value.strip()
+        # Pull the first numeric token — "4/5" → 4.0, "rating: 3" → 3.0.
+        m = re.search(r"-?\d+(?:\.\d+)?", s)
+        if m:
+            try:
+                return float(m.group())
+            except ValueError:
+                return None
+    return None
+
+
+def _harvest_objections(entry: dict[str, Any]) -> list[str]:
+    """Pull objections from a per-panelist response view.
+
+    Walks ``extraction`` for any of the objection keys (each may carry
+    a string or a list of strings). Free-text responses with explicit
+    "concern:" / "problem:" prefixes also count — those are how
+    free-text panelists tend to phrase the same signal.
+    """
+    rd = entry.get("response_dict")
+    if not isinstance(rd, dict):
+        return []
+
+    out: list[str] = []
+    extraction = rd.get("extraction")
+    if isinstance(extraction, dict):
+        for key in _OBJECTION_KEYS:
+            val = extraction.get(key)
+            if isinstance(val, str) and val.strip():
+                out.append(val.strip())
+            elif isinstance(val, list):
+                out.extend(str(v).strip() for v in val if isinstance(v, (str, int, float)) and str(v).strip())
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Heuristics for kind detection
+# ---------------------------------------------------------------------------
+
+
+def _looks_numeric(per_panelist: list[dict[str, Any]]) -> bool:
+    """True iff a majority of present responses parse as numbers."""
+    numeric = 0
+    seen = 0
+    for entry in per_panelist:
+        rd = entry["response_dict"]
+        if rd is None:
+            continue
+        seen += 1
+        if _extract_score(rd) is not None:
+            numeric += 1
+    return seen > 0 and numeric / seen > 0.5
+
+
+def _looks_enum(per_panelist: list[dict[str, Any]]) -> bool:
+    """True iff responses repeat heavily across a small option set.
+
+    A 12-panelist run where 5 say "A", 4 say "B", 3 say "C" is enum-shaped
+    even without a schema. A 12-panelist run where every response is a
+    different sentence is text-shaped.
+    """
+    values: list[str] = []
+    for entry in per_panelist:
+        rd = entry["response_dict"]
+        if rd is None:
+            continue
+        v = _extract_first_choice(rd)
+        if v is not None:
+            values.append(v)
+    if len(values) < 3:
+        return False
+    unique = len(set(values))
+    # Enum-shaped: at most a quarter of responses are unique values.
+    return unique <= max(2, len(values) // 4)
+
+
+def _has_choice_extraction(per_panelist: list[dict[str, Any]]) -> bool:
+    """True iff any panelist's extraction carries a recognised choice key."""
+    for entry in per_panelist:
+        rd = entry["response_dict"]
+        if not isinstance(rd, dict):
+            continue
+        extraction = rd.get("extraction")
+        if isinstance(extraction, dict):
+            for key in _FIRST_CHOICE_KEYS:
+                if isinstance(extraction.get(key), (str, int, float)) and not isinstance(extraction.get(key), bool):
+                    return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Segment splits
+# ---------------------------------------------------------------------------
+
+
+def _segment_split(
+    per_panelist: list[dict[str, Any]],
+    persona_index: dict[str, dict[str, Any]],
+    segment_attrs: list[str],
+) -> dict[str, dict[str, dict[str, int]]]:
+    """Return ``attr -> attr_value -> {option: count}`` for one question.
+
+    Pulls attribute values from the per-panelist persona snapshot first,
+    falling back to the explicit ``personas`` list when present. Empty
+    attributes are dropped; the table contains only attributes where at
+    least one panelist had a value AND at least one made a parseable
+    choice.
+    """
+    table: dict[str, dict[str, dict[str, int]]] = {}
+    for attr in segment_attrs:
+        rows: dict[str, dict[str, int]] = {}
+        for entry in per_panelist:
+            rd = entry["response_dict"]
+            if not isinstance(rd, dict):
+                continue
+            choice = _extract_first_choice(rd)
+            if choice is None:
+                continue
+
+            attrs_inline = entry.get("persona_attrs") or {}
+            value = attrs_inline.get(attr)
+            if value is None:
+                # Look up from the explicit personas index.
+                lookup = persona_index.get(entry.get("persona") or "", {})
+                value = lookup.get(attr)
+            if value is None or value == "":
+                continue
+
+            v_str = str(value)
+            rows.setdefault(v_str, {})
+            rows[v_str][choice] = rows[v_str].get(choice, 0) + 1
+
+        if rows:
+            # Cap to keep the table scannable — large persona packs can
+            # produce dozens of values per attribute.
+            trimmed = dict(
+                sorted(
+                    rows.items(),
+                    key=lambda kv: sum(kv[1].values()),
+                    reverse=True,
+                )[:_PER_SEGMENT_VALUE_CAP]
+            )
+            table[attr] = trimmed
+    return table
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+def _sorted_counts(counter: Counter[str]) -> dict[str, int]:
+    """Render a Counter as a count-descending dict (ties keep insertion order)."""
+    return dict(counter.most_common())
+
+
+def _extract_recommendation(result: dict[str, Any]) -> str | None:
+    """Pull ``synthesis.recommendation`` from a result envelope.
+
+    The recommendation field is the part of the synthesis layer that most
+    closely matches "recommended next test". Looks at the top-level
+    ``synthesis``, then the last round's synthesis (the natural
+    "terminal" synthesis for v3 branching runs).
+    """
+    syn = result.get("synthesis")
+    if isinstance(syn, dict):
+        rec = syn.get("recommendation")
+        if isinstance(rec, str) and rec.strip():
+            return rec.strip()
+
+    rounds = result.get("rounds")
+    if isinstance(rounds, list) and rounds:
+        last = rounds[-1]
+        if isinstance(last, dict) and isinstance(last.get("synthesis"), dict):
+            rec = last["synthesis"].get("recommendation")
+            if isinstance(rec, str) and rec.strip():
+                return rec.strip()
+    return None

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -220,6 +220,11 @@ class PollResult(_DictLikeMixin):
     # gate on validity without walking into the nested synthesis dict.
     run_invalid: bool = False
     synthesis_error: dict[str, Any] | None = None
+    # sy-4yd: deterministic structured-response rollup (vote counts,
+    # weighted scores, segment splits, top objections, recommended next
+    # test). ``None`` when synthesis disabled OR when no panelist produced
+    # a parseable structured response. See :mod:`synth_panel.poll_summary`.
+    poll_summary: dict[str, Any] | None = None
 
 
 @dataclass
@@ -285,6 +290,9 @@ class PanelResult(_DictLikeMixin):
     # sp-avmm: synthesis failure markers, mirroring PollResult.
     run_invalid: bool = False
     synthesis_error: dict[str, Any] | None = None
+    # sy-4yd: deterministic structured-response rollup. See PollResult
+    # for field semantics — same payload shape across both result types.
+    poll_summary: dict[str, Any] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -453,6 +461,44 @@ def _extract_attachment_refs(
     return refs
 
 
+def _compute_poll_summary_payload(
+    *,
+    result_dicts: list[dict[str, Any]],
+    questions: list[dict[str, Any]] | None,
+    synthesis: dict[str, Any] | None,
+    personas: list[dict[str, Any]] | None,
+    rounds: list[dict[str, Any]] | None = None,
+) -> dict[str, Any] | None:
+    """Run :func:`build_poll_summary` against a freshly produced result.
+
+    Returns the JSON-safe ``PollSummary.to_dict()`` payload or ``None``
+    when the run is empty / synthesis-free and no structured response
+    landed. Keeping this helper close to the result builders means every
+    SDK return path attaches an identical summary shape without each
+    caller re-implementing the assembly.
+
+    sy-4yd.
+    """
+    from synth_panel.poll_summary import build_poll_summary
+
+    envelope: dict[str, Any] = {
+        "results": result_dicts,
+        "synthesis": synthesis,
+    }
+    if questions is not None:
+        envelope["questions"] = questions
+    if rounds is not None:
+        envelope["rounds"] = rounds
+
+    summary = build_poll_summary(envelope, personas=personas)
+    if not summary.questions and not summary.top_objections and not summary.recommended_next_test:
+        # Degenerate run (no panelists / no responses). Returning None
+        # is more honest than emitting an empty summary that consumers
+        # might mistake for "panel answered nothing of substance".
+        return None
+    return summary.to_dict()
+
+
 def _build_panel_result_from_single_round(
     result_id: str,
     model: str,
@@ -480,6 +526,12 @@ def _build_panel_result_from_single_round(
     # structured output) at the top level so MCP consumers don't have to
     # walk into the nested synthesis dict to find them.
     synthesis_warnings = list(synthesis_dict.get("warnings") or []) if isinstance(synthesis_dict, dict) else []
+    poll_summary_payload = _compute_poll_summary_payload(
+        result_dicts=result_dicts,
+        questions=questions,
+        synthesis=synthesis_dict,
+        personas=personas,
+    )
     return PanelResult(
         result_id=result_id,
         model=model,
@@ -503,6 +555,7 @@ def _build_panel_result_from_single_round(
         metadata=metadata,
         run_invalid=bool(synthesis_error),
         synthesis_error=synthesis_error if isinstance(synthesis_error, dict) else None,
+        poll_summary=poll_summary_payload,
     )
 
 
@@ -560,6 +613,18 @@ def _build_panel_result_from_multi_round(
     if final_warnings:
         synthesis_warnings.extend(final_warnings)
 
+    # sy-4yd: walk every round (not just the terminal one) so v3 branching
+    # runs surface vote counts from any round that asked a structured
+    # question. The summary's per-question entries preserve original
+    # question ordering across rounds.
+    poll_summary_payload = _compute_poll_summary_payload(
+        result_dicts=flat_results,
+        questions=None,
+        synthesis=final_synth_dict,
+        personas=personas,
+        rounds=rounds_payload,
+    )
+
     return PanelResult(
         result_id=result_id,
         model=model,
@@ -575,6 +640,7 @@ def _build_panel_result_from_multi_round(
         terminal_round=mr.terminal_round,
         results=flat_results,
         metadata=metadata,
+        poll_summary=poll_summary_payload,
     )
 
 
@@ -780,6 +846,17 @@ def quick_poll(
         synthesis=synthesis_dict,
     )
 
+    # sy-4yd: compute the deterministic poll summary inline so callers
+    # never see a result without one. Built from the same envelope the
+    # SDK persists, so a saved-result reload via
+    # :func:`get_panel_result` reconstructs an equivalent summary.
+    poll_summary_payload = _compute_poll_summary_payload(
+        result_dicts=result_dicts,
+        questions=questions,
+        synthesis=synthesis_dict,
+        personas=merged,
+    )
+
     return PollResult(
         result_id=result_id,
         question=question,
@@ -791,6 +868,7 @@ def quick_poll(
         metadata=metadata,
         run_invalid=bool(synthesis_error),
         synthesis_error=synthesis_error if isinstance(synthesis_error, dict) else None,
+        poll_summary=poll_summary_payload,
     )
 
 

--- a/tests/test_poll_summary.py
+++ b/tests/test_poll_summary.py
@@ -1,0 +1,361 @@
+"""sy-4yd: deterministic poll summary computation.
+
+Tests cover the contract surface of :mod:`synth_panel.poll_summary`:
+
+* Enum questions roll up to first-choice / second-choice / weighted-score
+  tables with the highest-vote winner.
+* Scale questions produce a mean + histogram with no false-positive bucket
+  collapse (1 vs "1").
+* Segment splits join on persona attributes from either the embedded
+  result record or the explicit ``personas`` list.
+* Objection harvesting reads ``extraction.objections`` and
+  ``extraction.concerns`` lists or scalars.
+* Free-text questions don't fabricate vote counts.
+* Two calls over identical input produce identical output (no
+  set-iteration / dict-ordering flake — the summary is the agent-facing
+  source of truth so byte-stability matters).
+"""
+
+from __future__ import annotations
+
+from synth_panel.poll_summary import (
+    PollSummary,
+    QuestionSummary,
+    build_poll_summary,
+)
+
+
+def _enum_result_envelope() -> dict[str, object]:
+    """Three-panelist run with one enum question + one scale question.
+
+    Panelists carry an ``occupation`` attribute so segment splits land.
+    Mirrors the persistence shape ``save_panel_result`` writes.
+    """
+    return {
+        "persona_count": 3,
+        "question_count": 2,
+        "questions": [
+            {
+                "text": "Which name do you prefer?",
+                "response_schema": {"type": "enum", "options": ["Alpha", "Beta", "Gamma"]},
+            },
+            {
+                "text": "Confidence in your pick (1-5)?",
+                "response_schema": {"type": "scale", "min": 1, "max": 5},
+            },
+        ],
+        "results": [
+            {
+                "persona": "Sarah",
+                "occupation": "engineer",
+                "responses": [
+                    {
+                        "question": "Which name do you prefer?",
+                        "response": "Alpha",
+                        "extraction": {
+                            "choice": "Alpha",
+                            "second_choice": "Beta",
+                            "score": 5,
+                            "concerns": ["domain availability"],
+                        },
+                    },
+                    {"question": "Confidence in your pick (1-5)?", "response": "5"},
+                ],
+            },
+            {
+                "persona": "Marcus",
+                "occupation": "designer",
+                "responses": [
+                    {
+                        "question": "Which name do you prefer?",
+                        "response": "Alpha",
+                        "extraction": {
+                            "choice": "Alpha",
+                            "second_choice": "Gamma",
+                            "score": 4,
+                            "concerns": "domain availability",
+                        },
+                    },
+                    {"question": "Confidence in your pick (1-5)?", "response": "4"},
+                ],
+            },
+            {
+                "persona": "Priya",
+                "occupation": "engineer",
+                "responses": [
+                    {
+                        "question": "Which name do you prefer?",
+                        "response": "Beta",
+                        "extraction": {
+                            "choice": "Beta",
+                            "second_choice": "Alpha",
+                            "score": 3,
+                            "concerns": ["pronunciation"],
+                        },
+                    },
+                    {"question": "Confidence in your pick (1-5)?", "response": "3"},
+                ],
+            },
+        ],
+        "synthesis": {
+            "recommendation": "Validate 'Alpha' with a 50-person paid survey.",
+        },
+    }
+
+
+class TestEnumRollup:
+    """First-choice + second-choice + weighted-score + winner."""
+
+    def test_winner_is_highest_first_choice_count(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q0 = summary.questions[0]
+        assert q0.kind == "enum"
+        assert q0.winner == "Alpha"
+
+    def test_first_choice_counts_in_descending_order(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q0 = summary.questions[0]
+        assert list(q0.first_choice_counts.items()) == [("Alpha", 2), ("Beta", 1)]
+
+    def test_second_choice_counts_aggregate_independently(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q0 = summary.questions[0]
+        # Sarah → Beta, Marcus → Gamma, Priya → Alpha
+        assert q0.second_choice_counts == {"Beta": 1, "Gamma": 1, "Alpha": 1}
+
+    def test_weighted_scores_average_per_option(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q0 = summary.questions[0]
+        # Alpha: (5 + 4) / 2 = 4.5; Beta: 3 / 1 = 3.0
+        assert q0.weighted_scores == {"Alpha": 4.5, "Beta": 3.0}
+
+    def test_n_counts_total_responses(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        assert summary.questions[0].n == 3
+        assert summary.questions[0].n_unparseable == 0
+
+
+class TestScaleRollup:
+    def test_average_is_mean_of_numeric_responses(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q1 = summary.questions[1]
+        assert q1.kind == "scale"
+        # (5 + 4 + 3) / 3 = 4.0
+        assert q1.metric_average == 4.0
+
+    def test_histogram_uses_integer_strings_for_integral_values(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q1 = summary.questions[1]
+        # No "5.0" / "4.0" / "3.0" — they round-trip as "5"/"4"/"3"
+        assert q1.metric_distribution == {"3": 1, "4": 1, "5": 1}
+
+    def test_histogram_is_sorted_by_numeric_value(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        q1 = summary.questions[1]
+        # Insertion would have been 5, 4, 3 (the order panelists answered).
+        # The summary sorts numerically so the histogram is scannable.
+        assert list(q1.metric_distribution.keys()) == ["3", "4", "5"]
+
+    def test_non_numeric_scale_response_counts_as_unparseable(self) -> None:
+        env = _enum_result_envelope()
+        # Replace one numeric response with free-text so the unparseable
+        # path is exercised.
+        env["results"][0]["responses"][1]["response"] = "no idea"
+        summary = build_poll_summary(env)
+        q1 = summary.questions[1]
+        assert q1.n_unparseable == 1
+        assert q1.metric_average == 3.5  # (4 + 3) / 2
+
+
+class TestSegmentSplits:
+    def test_split_by_occupation_groups_panelists(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        # Q0 (enum) — split should join on the inline ``occupation`` attr.
+        splits = summary.segment_splits["0"]
+        assert "occupation" in splits
+        # engineer: Sarah → Alpha, Priya → Beta
+        # designer: Marcus → Alpha
+        assert splits["occupation"]["engineer"] == {"Alpha": 1, "Beta": 1}
+        assert splits["occupation"]["designer"] == {"Alpha": 1}
+
+    def test_empty_segment_by_disables_splits(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope(), segment_by=[])
+        assert summary.segment_splits == {}
+
+    def test_scale_questions_do_not_produce_segment_splits(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        # Q1 is scale; we deliberately skip segment splitting for scale
+        # questions because the natural rollup is the mean, not the
+        # vote count.
+        assert "1" not in summary.segment_splits
+
+
+class TestObjectionHarvesting:
+    def test_collects_from_scalar_and_list_extraction_fields(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        # Sarah + Priya have list-shaped objections; Marcus has a scalar.
+        # The most common ("domain availability") appears twice.
+        assert summary.top_objections[0] == "domain availability"
+        assert "pronunciation" in summary.top_objections
+
+    def test_caps_top_objections_at_five(self) -> None:
+        env: dict[str, object] = {
+            "persona_count": 1,
+            "questions": [{"text": "What's the issue?", "response_schema": {"type": "text"}}],
+            "results": [
+                {
+                    "persona": "Tester",
+                    "responses": [
+                        {
+                            "question": "What's the issue?",
+                            "response": "various concerns",
+                            "extraction": {
+                                "objections": [f"objection-{i}" for i in range(10)],
+                            },
+                        }
+                    ],
+                }
+            ],
+        }
+        summary = build_poll_summary(env)
+        assert len(summary.top_objections) == 5
+
+
+class TestRecommendedNextTest:
+    def test_echoes_synthesis_recommendation(self) -> None:
+        summary = build_poll_summary(_enum_result_envelope())
+        assert summary.recommended_next_test == "Validate 'Alpha' with a 50-person paid survey."
+
+    def test_returns_none_when_synthesis_absent(self) -> None:
+        env = _enum_result_envelope()
+        del env["synthesis"]
+        summary = build_poll_summary(env)
+        assert summary.recommended_next_test is None
+
+    def test_falls_back_to_terminal_round_synthesis(self) -> None:
+        env: dict[str, object] = {
+            "persona_count": 1,
+            "rounds": [
+                {
+                    "name": "discovery",
+                    "results": [],
+                    "synthesis": {"recommendation": "discovery rec"},
+                },
+                {
+                    "name": "wrap_up",
+                    "results": [],
+                    "synthesis": {"recommendation": "wrap_up rec — this one wins"},
+                },
+            ],
+        }
+        summary = build_poll_summary(env)
+        # The summary prefers the LAST round's synthesis as the natural
+        # "terminal" finding for v3 branching runs.
+        assert summary.recommended_next_test == "wrap_up rec — this one wins"
+
+
+class TestFreeTextQuestions:
+    def test_free_text_kind_does_not_fabricate_counts(self) -> None:
+        env: dict[str, object] = {
+            "persona_count": 2,
+            "questions": [{"text": "Why?", "response_schema": {"type": "text"}}],
+            "results": [
+                {
+                    "persona": "A",
+                    "responses": [{"question": "Why?", "response": "The pricing felt too high for what we got."}],
+                },
+                {
+                    "persona": "B",
+                    "responses": [{"question": "Why?", "response": "Onboarding took too long."}],
+                },
+            ],
+        }
+        summary = build_poll_summary(env)
+        q0 = summary.questions[0]
+        assert q0.kind == "text"
+        assert q0.first_choice_counts is None
+        assert q0.metric_average is None
+
+
+class TestDeterminism:
+    def test_same_input_produces_byte_identical_dict(self) -> None:
+        env = _enum_result_envelope()
+        a = build_poll_summary(env).to_dict()
+        b = build_poll_summary(env).to_dict()
+        assert a == b
+
+    def test_summary_is_pickleable_safe(self) -> None:
+        """No exotic objects — everything must round-trip through ``asdict``."""
+        env = _enum_result_envelope()
+        summary = build_poll_summary(env)
+        as_dict = summary.to_dict()
+        # The dataclass should preserve every documented top-level key.
+        for key in ("persona_count", "questions", "segment_splits", "top_objections", "recommended_next_test"):
+            assert key in as_dict
+
+
+class TestExtractionFallbacks:
+    """Schemaless / extraction-free results should still produce a summary
+    when responses repeat heavily (inference fallback)."""
+
+    def test_repeated_string_responses_infer_enum(self) -> None:
+        env: dict[str, object] = {
+            "persona_count": 6,
+            "questions": [{"text": "Yes or no?"}],  # no schema
+            "results": [
+                {"persona": "p1", "responses": [{"question": "Yes or no?", "response": "yes"}]},
+                {"persona": "p2", "responses": [{"question": "Yes or no?", "response": "yes"}]},
+                {"persona": "p3", "responses": [{"question": "Yes or no?", "response": "yes"}]},
+                {"persona": "p4", "responses": [{"question": "Yes or no?", "response": "no"}]},
+                {"persona": "p5", "responses": [{"question": "Yes or no?", "response": "no"}]},
+                {"persona": "p6", "responses": [{"question": "Yes or no?", "response": "yes"}]},
+            ],
+        }
+        summary = build_poll_summary(env)
+        q0 = summary.questions[0]
+        assert q0.kind == "enum"
+        assert q0.winner == "yes"
+        assert q0.first_choice_counts == {"yes": 4, "no": 2}
+
+
+def test_personas_lookup_supplies_missing_inline_attrs() -> None:
+    """When panelist records lack attributes, the personas arg fills them in."""
+    env: dict[str, object] = {
+        "persona_count": 2,
+        "questions": [{"text": "Pick", "response_schema": {"type": "enum", "options": ["X", "Y"]}}],
+        "results": [
+            {"persona": "Alice", "responses": [{"question": "Pick", "response": "X"}]},
+            {"persona": "Bob", "responses": [{"question": "Pick", "response": "Y"}]},
+        ],
+    }
+    personas = [
+        {"name": "Alice", "tier": "free"},
+        {"name": "Bob", "tier": "paid"},
+    ]
+    summary = build_poll_summary(env, personas=personas)
+    splits = summary.segment_splits["0"]
+    assert splits["tier"] == {"free": {"X": 1}, "paid": {"Y": 1}}
+
+
+def test_empty_result_returns_empty_summary() -> None:
+    summary = build_poll_summary({"results": []})
+    assert isinstance(summary, PollSummary)
+    assert summary.persona_count == 0
+    assert summary.questions == []
+    assert summary.top_objections == []
+
+
+def test_question_summary_truncates_long_question_text() -> None:
+    long_q = "Q" + "x" * 500
+    env: dict[str, object] = {
+        "questions": [{"text": long_q, "response_schema": {"type": "enum"}}],
+        "results": [
+            {"persona": "A", "responses": [{"question": long_q, "response": "Yes"}]},
+            {"persona": "B", "responses": [{"question": long_q, "response": "Yes"}]},
+            {"persona": "C", "responses": [{"question": long_q, "response": "No"}]},
+        ],
+    }
+    qs: QuestionSummary = build_poll_summary(env).questions[0]
+    # 280 chars is the safety cap so a single bad question can't push
+    # the serialized summary into MB territory.
+    assert len(qs.question) <= 280


### PR DESCRIPTION
## Summary

Adds `synth_panel.poll_summary` — a deterministic, **LLM-free** aggregator
that walks a saved panel result and emits first-choice vote counts,
second-choice vote counts, weighted scores, scale averages + histograms,
segment splits by persona attribute, top objections, and the
synthesis-derived recommended next test. The same payload is surfaced
everywhere a panel result lives.

## Surfaces

- **SDK**: `PollResult.poll_summary` and `PanelResult.poll_summary` populated automatically when responses contain a parseable structured answer or numeric rating.
- **MCP**: `run_panel` and `run_quick_poll` envelopes carry the same `poll_summary` block at the top level so agents can quote the headline (winner, segment split, top objection) without a second tool call.
- **CLI**: new `synthpanel poll-summary <result>` command renders the summary for a saved result as text (default, scannable for humans) or JSON (full structured payload, pipe-to-jq friendly). `--segment-by` flag accepts a comma-separated list of persona attributes or an empty string to disable segment splits.

## Robustness

The module accepts the three result envelopes already in use
(`PollResult.responses`, `PanelResult.rounds[].results`, raw JSON from
disk) and falls back from `response_schema` to shape inference when the
schema isn't recorded, so older saved results still summarize cleanly.

## Test plan

`tests/test_poll_summary.py` covers:
- the enum / scale / text discriminator
- weighted scoring math
- segment-split joins (inline + explicit personas)
- objection harvesting from scalar + list extraction fields
- synthesis-recommendation echo
- byte-stable determinism across repeated calls

GitHub CI runs the full suite on this PR.

## References

- Bead: sy-4yd
- Closes #477
- MR: sy-wisp-nyt
- Polecat: garnet-sy
- Branch: polecat/garnet-sy-4yd