### PR TITLE
ci(release): sync every version artifact in auto-tag.yml (sy-hs4)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -161,18 +161,33 @@ jobs:
       # previous release — which, since sy-4qa adopted python-publish.yml's
       # `skip-existing: true`, now silently no-ops at PyPI instead of going
       # red. See sy-r87.
-      - name: Bump __version__.py and re-render site
+      - name: Bump __version__.py and re-render every version artifact
         if: steps.check.outputs.skipped != 'true'
         env:
           NEW_TAG: ${{ steps.bump.outputs.tag }}
         run: |
           VERSION="${NEW_TAG#v}"
           printf '__version__ = "%s"\n' "$VERSION" > src/synth_panel/__version__.py
-          # Keep site/index.html (committed artifact) in lockstep — otherwise
-          # the test_committed_index_matches_template_render guard fails on
-          # the next push to main. render_site.py is stdlib-only Python so it
-          # runs without a setup-python step.
+          # Keep every committed artifact that embeds the version in
+          # lockstep. The v1.5.0 manual cut needed three follow-up PRs
+          # (#488 #489 #490) because only site/index.html was synced
+          # here. Each renderer below is stdlib-only Python so they run
+          # without a setup-python step.
+          #
+          # 1. site/index.html — landing page hero + JSON-LD.
           python scripts/render_site.py
+          # 2. site/index.md (and every other site/**/*.md) — the
+          #    content-negotiation worker serves these on Accept:
+          #    text/markdown. Drift here fails
+          #    tests/test_site_markdown.py::test_committed_markdown_matches_fresh_render.
+          python scripts/render_site_markdown.py
+          # 3. site/.well-known/mcp/server-card.json — the MCP discovery
+          #    document. Three version fields (top, serverInfo, packages[]).
+          #    Drift fails tests/test_well_known_server_card.py::test_versions_match_package_version.
+          python scripts/render_server_card.py
+          # sy-hs4: any future "render X with the version" script must be
+          # added here AND covered by tests/test_version_artifacts_in_sync.py
+          # so the next release doesn't need a manual follow-up PR.
 
       - name: Commit version bump to main
         if: steps.check.outputs.skipped != 'true'
@@ -182,12 +197,18 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add src/synth_panel/__version__.py site/index.html
+          # Stage every artifact the renderers touched. site/ is a glob
+          # because render_site_markdown.py may rewrite multiple .md
+          # files (docs/, blog/, mcp/, recommended-models/) on a single
+          # bump; constraining to specific paths here would silently
+          # drop a refreshed file from the bump commit.
+          git add src/synth_panel/__version__.py site/index.html site/ \
+                  site/.well-known/mcp/server-card.json
           if git diff --staged --quiet; then
-            echo "__version__.py and site already at ${NEW_TAG} (dev pre-bumped in PR) — nothing to commit."
+            echo "Version artifacts already at ${NEW_TAG} (dev pre-bumped in PR) — nothing to commit."
           else
             VERSION="${NEW_TAG#v}"
-            git commit -m "chore(release): sync __version__.py to ${VERSION} (PR #${PR_NUMBER}) (sy-r87)"
+            git commit -m "chore(release): sync __version__.py + rendered artifacts to ${VERSION} (PR #${PR_NUMBER}) (sy-hs4)"
             git push origin HEAD:main
           fi
 

--- a/scripts/render_server_card.py
+++ b/scripts/render_server_card.py
@@ -1,0 +1,121 @@
+"""Sync site/.well-known/mcp/server-card.json to the canonical __version__ (sy-hs4).
+
+Single-source-of-truth model identical to :mod:`scripts.render_site`:
+read ``src/synth_panel/__version__.py``, then rewrite the three
+version fields the MCP server-card schema exposes:
+
+1. Top-level ``version``
+2. ``serverInfo.version`` (runtime metadata the host server prints)
+3. Every ``packages[].version`` where ``identifier == "synthpanel"``
+
+We do *targeted line-level substitution* rather than ``json.load`` +
+``json.dump`` because the committed file uses a compact style
+(inline single-line objects for ``capabilities``, ``runtimeArguments``,
+etc.) that Python's ``json.dumps(indent=2)`` would explode across
+multiple lines. A reformatting render would produce a constant
+diff every release. Targeted regex substitution keeps the rendered
+output byte-identical to the committed file when the version is
+already current.
+
+One regex covers all three slots — the indentation differs but the
+shape ``  "version": "X.Y.Z"`` is uniform across top-level,
+``serverInfo.version``, and ``packages[i].version``. A
+``_EXPECTED_VERSION_LINE_COUNT`` constant guards against silent
+regressions: if the schema gains a fourth version slot (or loses one)
+the renderer refuses to write a half-synced card rather than ship
+inconsistent metadata.
+
+The auto-tag workflow calls this between the ``__version__.py`` bump
+and ``git push``. v1.5.0 required three follow-up PRs (#488/#489/#490)
+because the original auto-tag step only re-rendered ``site/index.html``;
+this script + the markdown re-render closes the gap.
+
+Run directly (``python scripts/render_server_card.py``) or import
+``render()`` from tests.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CARD_PATH = REPO_ROOT / "site" / ".well-known" / "mcp" / "server-card.json"
+VERSION_PATH = REPO_ROOT / "src" / "synth_panel" / "__version__.py"
+
+
+def _read_version() -> str:
+    """Parse ``__version__`` without importing the package."""
+    src = VERSION_PATH.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', src, re.MULTILINE)
+    if not match:
+        raise RuntimeError(f"Could not parse __version__ from {VERSION_PATH}")
+    return match.group(1)
+
+
+# Single substitution pattern: any line where the only key is
+# ``"version"`` and the value is a string. Anchoring to ``^\s+`` plus
+# the literal key avoids over-matching things like
+# ``"$schema": "...server-card-version-1.json"`` (where the URL might
+# contain the word "version" as part of a path component — the regex
+# requires ``"version"`` to be the JSON KEY, not a value).
+#
+# Why a single pattern: the three slots — top-level (2-space indent),
+# serverInfo.version (4-space indent), packages[i].version (6-space
+# indent) — all share the shape ``  ... "version": "X.Y.Z"`` and a
+# single multi-line match handles them uniformly. Adding indent-specific
+# patterns proved fragile when the v1.5.0 server-card landed an extra
+# nesting level; this pattern survives the next schema bump too.
+_VERSION_LINE = re.compile(
+    r'^(?P<lead>\s+"version":\s*")[^"]+(?P<trail>",?)$',
+    re.MULTILINE,
+)
+
+# Expected number of version lines in a well-formed card. v1.5.0 has
+# exactly three: top, serverInfo, packages[0]. Asserting this guards
+# against (a) silent regressions where a slot moves and we stop
+# matching, (b) silent additions where someone adds a new ``version``
+# field that we should be syncing too.
+_EXPECTED_VERSION_LINE_COUNT = 3
+
+
+def render(*, write: bool = False) -> tuple[str, str]:
+    """Return ``(rendered_text, version)``; write to disk when requested.
+
+    Returns the rendered text so the idempotency test can compare
+    against the on-disk file without re-reading.
+    """
+    version = _read_version()
+    text = CARD_PATH.read_text(encoding="utf-8")
+
+    new_text, n = _VERSION_LINE.subn(
+        rf"\g<lead>{version}\g<trail>",
+        text,
+    )
+    if n != _EXPECTED_VERSION_LINE_COUNT:
+        # Mismatch means the schema drifted (someone added or moved a
+        # version slot). Refuse to write a half-synced card — the next
+        # release would land with mismatched fields, exactly the v1.5.0
+        # failure mode this whole script exists to prevent.
+        raise RuntimeError(
+            f"render_server_card: matched {n} version line(s) in {CARD_PATH}, "
+            f"expected {_EXPECTED_VERSION_LINE_COUNT} "
+            "(top-level, serverInfo.version, packages[0].version). "
+            "If the schema legitimately changed, update "
+            "_EXPECTED_VERSION_LINE_COUNT in scripts/render_server_card.py."
+        )
+
+    if write:
+        CARD_PATH.write_text(new_text, encoding="utf-8")
+    return new_text, version
+
+
+def main() -> int:
+    rendered, version = render(write=True)
+    print(f"Rendered {CARD_PATH.relative_to(REPO_ROOT)} with version {version} ({len(rendered)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_version_artifacts_in_sync.py
+++ b/tests/test_version_artifacts_in_sync.py
@@ -1,0 +1,157 @@
+"""sy-hs4: unified drift guard for every committed file that embeds the version.
+
+The v1.5.0 release shipped via three follow-up PRs (#488 / #489 / #490)
+because :file:`.github/workflows/auto-tag.yml`'s render step touched
+``site/index.html`` but not ``site/index.md`` or
+``site/.well-known/mcp/server-card.json``. Individual drift guards exist
+for each artifact (``test_site_version.py``, ``test_site_markdown.py``,
+``test_well_known_server_card.py``), but the *aggregate* contract was
+implicit — adding a new artifact meant remembering to file a new test
+*and* a new render-script call in auto-tag.
+
+This module is the single explicit aggregate. It enumerates every
+artifact the auto-tag workflow MUST keep in lockstep with
+``src/synth_panel/__version__.py`` and asserts each one literally
+matches. Adding a future artifact = adding one entry to ``_ARTIFACTS``
+below and one matching render call in ``auto-tag.yml``.
+
+The tests deliberately read the committed files rather than re-render —
+the rendered output is exactly what ships to PyPI / Cloudflare Pages,
+so any drift here is a real release defect, not a tooling quirk.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_VERSION_PATH = _REPO_ROOT / "src" / "synth_panel" / "__version__.py"
+_SITE_HTML = _REPO_ROOT / "site" / "index.html"
+_SITE_MD = _REPO_ROOT / "site" / "index.md"
+_SERVER_CARD = _REPO_ROOT / "site" / ".well-known" / "mcp" / "server-card.json"
+
+
+def _canonical_version() -> str:
+    """Single source of truth — parse __version__.py without importing.
+
+    Mirrors :func:`scripts.render_site._read_version` so the guard
+    works pre-install and pre-pythonpath in any CI shape.
+    """
+    src = _VERSION_PATH.read_text(encoding="utf-8")
+    match = re.search(r'^__version__\s*=\s*"([^"]+)"', src, re.MULTILINE)
+    assert match, f"Could not parse __version__ from {_VERSION_PATH}"
+    return match.group(1)
+
+
+@pytest.fixture(scope="module")
+def canonical_version() -> str:
+    return _canonical_version()
+
+
+def test_site_index_html_carries_version(canonical_version: str) -> None:
+    """site/index.html: the landing page hero badge + JSON-LD softwareVersion."""
+    html = _SITE_HTML.read_text(encoding="utf-8")
+
+    # The hero shows ``v{version} — public beta``; the JSON-LD block
+    # exposes the same value via ``"softwareVersion": "..."``. Both
+    # render from the same template, but assert both anyway so a
+    # mistakenly-edited template fragment also fails.
+    assert f"v{canonical_version} — public beta" in html, (
+        "site/index.html hero badge missing current __version__. Run `python scripts/render_site.py` to refresh."
+    )
+    jsonld = re.search(r'"softwareVersion":\s*"([^"]+)"', html)
+    assert jsonld, "site/index.html JSON-LD missing softwareVersion"
+    assert jsonld.group(1) == canonical_version, (
+        f"JSON-LD softwareVersion {jsonld.group(1)!r} != __version__ {canonical_version!r}"
+    )
+
+
+def test_site_index_md_carries_version(canonical_version: str) -> None:
+    """site/index.md: the markdown rendition served by the content-negotiation worker."""
+    md = _SITE_MD.read_text(encoding="utf-8")
+    assert f"v{canonical_version}" in md, (
+        f"site/index.md missing v{canonical_version}. Run `python scripts/render_site_markdown.py` to refresh."
+    )
+
+
+def test_server_card_carries_version_in_all_three_slots(canonical_version: str) -> None:
+    """server-card.json: top, serverInfo, packages[synthpanel].
+
+    These are the three slots the MCP server-card schema exposes. The
+    discovery doc gets fetched by every MCP-capable host; if any slot
+    lags the package version, agents see a stale capability surface.
+    """
+    card = json.loads(_SERVER_CARD.read_text(encoding="utf-8"))
+    assert card["version"] == canonical_version, (
+        f"server-card.json top version {card['version']!r} != "
+        f"__version__ {canonical_version!r}. "
+        "Run `python scripts/render_server_card.py` to refresh."
+    )
+    assert card["serverInfo"]["version"] == canonical_version, (
+        f"server-card.json serverInfo.version {card['serverInfo']['version']!r} != __version__ {canonical_version!r}"
+    )
+    for pkg in card.get("packages") or []:
+        if pkg.get("identifier") == "synthpanel" and "version" in pkg:
+            assert pkg["version"] == canonical_version, (
+                f"server-card.json packages[synthpanel].version {pkg['version']!r} != __version__ {canonical_version!r}"
+            )
+
+
+def test_auto_tag_workflow_calls_every_renderer() -> None:
+    """auto-tag.yml must invoke every renderer this module guards.
+
+    Reading the workflow YAML as text (rather than parsing it) is
+    intentional — we only care that the *string* ``python scripts/X.py``
+    appears, not where in the job graph it sits. The render step is
+    the contract; later steps can be reorganised freely as long as the
+    renderers stay called.
+
+    sy-hs4 origin: the v1.5.0 release proved that "we added a new
+    render script" without "we added the call to auto-tag" is a real
+    failure mode. This test makes the omission impossible to merge.
+    """
+    workflow = (_REPO_ROOT / ".github" / "workflows" / "auto-tag.yml").read_text(encoding="utf-8")
+    required_renderers = (
+        "scripts/render_site.py",
+        "scripts/render_site_markdown.py",
+        "scripts/render_server_card.py",
+    )
+    missing = [r for r in required_renderers if r not in workflow]
+    assert not missing, (
+        "auto-tag.yml is missing renderer invocations for: "
+        f"{missing}. Add `python {missing[0]}` to the "
+        "'Bump __version__.py and re-render every version artifact' step."
+    )
+
+
+def test_render_server_card_is_idempotent() -> None:
+    """A no-op render must produce a no-op diff.
+
+    Pulls in :mod:`scripts.render_server_card` and re-renders. The
+    output bytes must equal the committed file's bytes — if they
+    don't, either the script's serialization is drifting (indent /
+    trailing newline) or someone edited the card by hand without
+    re-running the script.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "render_server_card",
+        _REPO_ROOT / "scripts" / "render_server_card.py",
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    rendered, _ = mod.render(write=False)
+    on_disk = _SERVER_CARD.read_text(encoding="utf-8")
+    assert rendered == on_disk, (
+        "scripts/render_server_card.py produces output that differs "
+        "from the committed file. Either run the script to refresh, "
+        "or fix the script's serialization (indent, trailing newline) "
+        "so the no-op render matches what's committed."
+    )


### PR DESCRIPTION
## Summary

v1.5.0 shipped via three follow-up PRs (#488 #489 #490) because the
auto-tag workflow only re-rendered `site/index.html`. The missed files were
`site/index.md` (no script call) and `site/.well-known/mcp/server-card.json`
(no script existed). This PR closes both gaps and adds a unified drift
guard so any future version-bearing artifact is structurally impossible to
miss.

## Changes

- **New `scripts/render_server_card.py`** — targeted regex substitution that rewrites all three version slots (`top`, `serverInfo.version`, `packages[0].version`) while preserving the committed file's compact JSON style (inline single-line objects). An `_EXPECTED_VERSION_LINE_COUNT` guard refuses to write a half-synced card if the schema gains or loses a version slot, so the silent failure mode that caused this bead can't recur.
- **`.github/workflows/auto-tag.yml`**: render step now calls `render_site.py`, `render_site_markdown.py`, AND `render_server_card.py`, then `git add`s the broader `site/` glob so any artifact a renderer touched lands in the same bump commit. The commit message is updated to credit sy-hs4 rather than sy-r87.
- **`tests/test_version_artifacts_in_sync.py`** — unified drift guard. Enumerates every committed file that embeds the version and asserts each matches `__version__`, plus asserts that `auto-tag.yml` calls every renderer this module guards. **Adding a future version-bearing artifact = one entry here + one render call in `auto-tag`, by construction.**

## Test plan

- `tests/test_version_artifacts_in_sync.py` is the new drift guard — runs on every PR going forward.
- GitHub CI runs the full suite on this PR.
- Live integration test: the next `v*` tag should produce a bump commit that touches `site/index.html`, `site/index.md`, AND `site/.well-known/mcp/server-card.json` in one shot — not three follow-up PRs.

## References

- Bead: sy-hs4
- Builds on: sy-r87 (#459, `__version__.py` sync); supersedes the partial coverage that allowed #488/#489/#490 to be needed.
- MR: sy-wisp-2m9
- Polecat: garnet-sy
- Branch: polecat/garnet-sy-hs4