### PR TITLE
docs: task-oriented persona + model recommendation guide (sy-iao)

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,9 @@ searching for one:
 | `students` | 15 |
 
 `synthpanel pack list` (or MCP `list_persona_packs`) enumerates these plus any
-user-saved packs.
+user-saved packs. Picking the right pack for your task?
+See [docs/task-recommendations.md](docs/task-recommendations.md) for the
+task → pack → model-config matrix with copy/paste commands.
 
 ### Builtin instrument packs (8, all v3 branching)
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -163,6 +163,11 @@ The response envelope (`panel_verdict.json`) is closed-shape with
 > tagged-themes (objections/risks), confidence, and ranking, plus a
 > runnable 35-persona prioritization example.
 
+> **Picking which `pack_id` / `model` / `models[]` to pass?** See
+> [docs/task-recommendations.md](task-recommendations.md) for the
+> task → persona pack → model config lookup with copy/paste examples
+> (positioning, GTM, pricing, trust audit, healthcare comms, hiring).
+
 ### Research Tools
 
 | Tool | Description |

--- a/docs/model-packs.md
+++ b/docs/model-packs.md
@@ -4,6 +4,12 @@
 > model or model mix to run a panel through. Persona packs answer *"who
 > answers the question?"* — model packs answer *"which LLMs do the
 > answering?"*.
+>
+> **Looking for the task → pack + model lookup table?** See
+> [docs/task-recommendations.md](task-recommendations.md) — that page maps
+> common research tasks (positioning, GTM, pricing, trust audit, etc.)
+> to the persona pack *and* model pack that match. This page is the
+> deeper reference for the model packs themselves.
 
 ## TL;DR
 

--- a/docs/task-recommendations.md
+++ b/docs/task-recommendations.md
@@ -1,0 +1,266 @@
+# Task-Oriented Recommendations — Picking a Persona Pack + Model Config
+
+> **Audience:** AI agents (and the humans configuring them) deciding which
+> persona pack and which model setup to use for a given research task.
+> This page is the "what should I run?" lookup; the deep references are
+> [docs/model-packs.md](model-packs.md) for the model configurations and
+> [README §Builtin persona packs](../README.md#builtin-persona-packs-14-232-personas-total)
+> for the full persona-pack catalogue.
+
+## TL;DR — task → pack → model
+
+| Task / decision shape | Persona pack | Model config | Why |
+|---|---|---|---|
+| **Product positioning / messaging** | `product-research` (20) | `fast-cheap-preflight` for iteration → `balanced-research-ensemble` before any claim leaves the building | PMs and researchers will steelman your wording; ensembles narrow which lines actually generalize across model families |
+| **Broad mass-appeal copy / naming** | `broad-professionals` (20) | `consumer-mass-appeal` weighted split, or `balanced-research-ensemble` before publishing | "Person on the street" coverage; if results will be cited externally, use the model-diverse ensemble |
+| **Enterprise GTM / procurement narrative** | `enterprise-ai-buyers` (18) **and/or** `skeptical-executives` (18) | `skeptical-red-team-ensemble` (`sonnet,gpt-4o,gemini-2.5-pro`) at `--temperature 0.9` | These personas are vendor-fatigued and ROI-fixated; the higher-rigor ensemble surfaces objections cheaper models miss |
+| **Trust / credibility / methodology audit** | `market-research-critics` (16) | `skeptical-red-team-ensemble` | Hostile audience by design — pair with the model pack that doesn't agreement-bias |
+| **Pricing discovery** | `general-consumer` (15) or audience-specific pack | `fast-cheap-preflight` for tier shape → `balanced-research-ensemble` for the actual price point | Cheap models lock in the shape; spend on the ensemble when the number matters |
+| **AI / eval tooling discovery** | `ai-eval-buyers` (20) | `--best-model-for "Technology & Digital Life"` (SynthBench-driven) for single-model runs; `balanced-research-ensemble` for high-stakes | This audience reads benchmark numbers — match the model choice to leaderboard evidence |
+| **Dev-tool feedback / technical positioning** | `developer` (15) or `startup-founder` (15) | `technical-founder-research` (`sonnet:0.4,gpt-4o:0.4,gemini-2.5-pro:0.2`) | Technical buyers detect glibness; weight toward the higher-quality families |
+| **Hiring / talent / job-search messaging** | `recruiters-talent` (15) for employer-side, `job-seekers` (15) for candidate-side | `fast-cheap-preflight` for shape → `balanced-research-ensemble` for finals | Two distinct audiences — don't pool them; run separate panels |
+| **Healthcare messaging / patient comms** | `healthcare-patient` (15) | `balanced-research-ensemble` by default; **never single-model for clinical/compliance** copy | Stakes are high; ensemble + `synthpanel report` + human SME review is the floor |
+| **Education / student outreach** | `students` (15) | `fast-cheap-preflight` for early loops; `consumer-mass-appeal` weighted split for finals | Age-skewed audience; the weighted split keeps cost down |
+| **Founder / early-stage hypothesis testing** | `startup-founder` (15) | `fast-cheap-preflight` is enough until you're charging money | Founders forgive directional answers; save the ensemble budget for paying-customer questions |
+| **Pre-launch / board-deck / go-no-go** | Audience-appropriate pack (above) | `high-stakes-validation` 4-way ensemble + `--blend` | The one place you *should* spend on the full ensemble + blend |
+
+> **Heuristic for the model-config column:** if a human is going to act
+> on the answer, use an **ensemble**. If an agent is just orienting
+> itself ("does this question even make sense?"), `fast-cheap-preflight`
+> is fine. The SynthBench-driven `--best-model-for "<topic>"` slot is
+> for the in-between case: a single model, chosen by leaderboard
+> evidence rather than vibes.
+
+## When single-model is acceptable
+
+Use a single cheap model (`fast-cheap-preflight`) when:
+
+- You're iterating on the **instrument** itself (wording, branching,
+  schema), not the answer. The shape of the responses tells you whether
+  the question is legible; the content barely matters yet.
+- You're **dry-running** a panel before a real spend — verifying
+  persona attachment, attachment refs, output format, etc.
+- The decision downstream is **reversible and low-stakes** — internal
+  team naming, a Slack-only experiment, draft copy you're going to
+  rewrite anyway.
+- The decision is **directional**, not quantitative — "are people
+  excited or skeptical?" rather than "what % would buy at $79?".
+
+Use a **SynthBench-recommended** single model (`--best-model-for
+"<topic>"`) when:
+
+- You need a single number/distribution and want it to be backed by
+  leaderboard evidence. The CLI prints the choice + Synth-Population
+  Score (SPS) + JSD to stderr before the run, so the choice is
+  inspectable and overridable. See
+  [docs/recommended-models.md](recommended-models.md) for the full flag
+  reference.
+
+## When to escalate to an ensemble
+
+Switch to a model-diverse ensemble (`balanced-research-ensemble` or
+heavier) when **any** of the following is true:
+
+- The answer will be **acted on** by a human or autonomous agent —
+  shipped copy, a price tier, a positioning line, an investor message.
+- The answer will be **cited externally** — pitch deck, blog post,
+  podcast, conference talk.
+- The audience is **professionally skeptical** (`market-research-critics`,
+  `enterprise-ai-buyers`, `skeptical-executives`). Single-model panels
+  systematically underweight objections for these audiences because
+  cheap models agreement-bias.
+- The cost of a **false positive** ("ship this") is much higher than
+  the cost of a slower decision.
+- You need **dispersion** signal — `synthesis.disagreements` and
+  `synthesis.surprises` are much richer when models with different
+  training data disagree.
+
+The cost ratio is real: a 4-way ensemble runs the full panel 4×, so
+budget accordingly. See [docs/ensemble.md](ensemble.md) for the
+mechanics and the `--blend` aggregation algorithm.
+
+## Copy/paste commands
+
+Each row below is a complete, runnable invocation against a bundled
+persona pack. Export the pack first (the CLI takes a file path, not a
+pack name); the MCP / SDK surfaces accept the pack name directly.
+
+### Product positioning — fast iteration
+
+```bash
+synthpanel pack export product-research > /tmp/product-research.yaml
+synthpanel panel run \
+  --personas /tmp/product-research.yaml \
+  --instrument /tmp/positioning.yaml \
+  --model haiku \
+  --output-format json
+```
+
+```jsonc
+// MCP equivalent
+{
+  "tool": "run_panel",
+  "arguments": {
+    "pack_id": "product-research",
+    "instrument": { /* ... */ },
+    "model": "haiku",
+    "decision_being_informed": "iterating positioning before final commit"
+  }
+}
+```
+
+### Product positioning — pre-publication ensemble
+
+```bash
+synthpanel panel run \
+  --personas /tmp/product-research.yaml \
+  --instrument /tmp/positioning.yaml \
+  --models 'haiku,sonnet,gemini-2.5-flash' \
+  --blend \
+  --output-format json
+```
+
+```jsonc
+{
+  "tool": "run_panel",
+  "arguments": {
+    "pack_id": "product-research",
+    "instrument": { /* ... */ },
+    "models": ["haiku", "sonnet", "gemini-2.5-flash"],
+    "decision_being_informed": "finalizing the launch positioning"
+  }
+}
+```
+
+### Enterprise GTM — skeptical ensemble
+
+```bash
+synthpanel pack export skeptical-executives > /tmp/skeptical-executives.yaml
+synthpanel panel run \
+  --personas /tmp/skeptical-executives.yaml \
+  --instrument /tmp/gtm-pitch.yaml \
+  --models 'sonnet,gpt-4o,gemini-2.5-pro' \
+  --blend --temperature 0.9 \
+  --output-format json
+```
+
+```jsonc
+{
+  "tool": "run_panel",
+  "arguments": {
+    "pack_id": "skeptical-executives",
+    "instrument": { /* ... */ },
+    "models": ["sonnet", "gpt-4o", "gemini-2.5-pro"],
+    "temperature": 0.9,
+    "decision_being_informed": "stress-test the GTM pitch before a CRO review"
+  }
+}
+```
+
+### Trust / credibility audit — hostile audience
+
+```bash
+synthpanel pack export market-research-critics > /tmp/market-research-critics.yaml
+synthpanel panel run \
+  --personas /tmp/market-research-critics.yaml \
+  --instrument /tmp/methodology-claim.yaml \
+  --models 'sonnet,gpt-4o,gemini-2.5-pro' \
+  --blend --temperature 0.9 \
+  --output-format json
+```
+
+### AI / eval discovery — SynthBench-guided single model
+
+```bash
+synthpanel pack export ai-eval-buyers > /tmp/ai-eval-buyers.yaml
+synthpanel panel run \
+  --personas /tmp/ai-eval-buyers.yaml \
+  --instrument /tmp/eval-tool-positioning.yaml \
+  --best-model-for "Technology & Digital Life" \
+  --output-format json
+```
+
+`--best-model-for` consults the SynthBench leaderboard for the named
+topic and prints its choice to stderr before the run (see
+[docs/recommended-models.md](recommended-models.md)). Override with
+`--model <alias>` if you want to ignore the recommendation.
+
+### Healthcare patient messaging — ensemble + report
+
+```bash
+synthpanel pack export healthcare-patient > /tmp/healthcare-patient.yaml
+synthpanel panel run \
+  --personas /tmp/healthcare-patient.yaml \
+  --instrument /tmp/patient-comms.yaml \
+  --models 'sonnet,gpt-4o,gemini-2.5-pro' \
+  --blend \
+  --save --output-format json \
+| jq -r '.result_id' \
+| xargs synthpanel report --output patient-comms-panel.md
+```
+
+> **Never run healthcare comms on a single cheap model.** Use the
+> ensemble + render to Markdown for human SME review before any patient-
+> facing copy ships.
+
+### Hiring messaging — two-sided
+
+The employer-side and candidate-side audiences should run as **separate**
+panels; pooling them dilutes the signal.
+
+```bash
+# Employer side
+synthpanel pack export recruiters-talent > /tmp/recruiters-talent.yaml
+synthpanel panel run --personas /tmp/recruiters-talent.yaml \
+  --instrument /tmp/hiring-pitch.yaml --model haiku --save --output-format json
+
+# Candidate side
+synthpanel pack export job-seekers > /tmp/job-seekers.yaml
+synthpanel panel run --personas /tmp/job-seekers.yaml \
+  --instrument /tmp/hiring-pitch.yaml --model haiku --save --output-format json
+```
+
+## How the recommendations were chosen
+
+These are not arbitrary defaults. They follow from three observations
+that SynthBench surfaces in the live leaderboard data:
+
+1. **No single model is best at everything.** Different families top
+   different topic slices on
+   [SynthBench](https://synthbench.org) — `claude-haiku-4-5` leads
+   "Economy & Work", `gemini-2.5-flash` leads "Technology & Digital
+   Life". Single-model panels inherit the leading model's blind spots
+   wholesale. → ensemble for high-stakes work.
+2. **Model-diverse ensembles narrow the variance to the human baseline**
+   on most topics. The trade-off is cost (N× panel) and latency
+   (parallel but bounded by the slowest provider). → reserve ensembles
+   for decisions that will be acted on.
+3. **Skeptical audiences are not just persona-skeptical — they're
+   model-skeptical.** Cheap models agreement-bias against critical
+   personas, so combining a hostile pack with a cheap model gives you
+   *less* signal, not more. → pair `market-research-critics` /
+   `skeptical-executives` / `enterprise-ai-buyers` with the
+   higher-rigor ensemble.
+
+For deeper context: [docs/model-packs.md](model-packs.md) walks each
+model pack with cost order-of-magnitude;
+[docs/recommended-models.md](recommended-models.md) covers
+`--best-model-for`; [docs/ensemble.md](ensemble.md) covers the
+`--models` syntax and `--blend` algorithm;
+[docs/calibration.md](calibration.md) covers the human-baseline
+calibration step that closes the loop.
+
+## Status — docs-only for v1.5.1
+
+The convenience flags the upstream issue floats —
+
+```bash
+synthpanel pack list --recommend
+synthpanel models recommend --task positioning
+synthpanel recommend --task enterprise-gtm
+```
+
+— **do not exist yet.** This page is the agent-facing surface for
+v1.5.1. The flags above would compile to the same recommendations
+documented here; if/when they ship, this table becomes their
+implementation reference.


### PR DESCRIPTION
## Summary

Adds \`docs/task-recommendations.md\` — a docs-only deliverable for v1.5.1 that maps common research tasks to (persona pack, model config) with copy/paste commands. The model-pack vocabulary already lives in \`docs/model-packs.md\`; this page is the agent-facing lookup that sits in front of it.

Hermes-filed (#498) — \`pack list\` is much better in v1.5.0, but an agent still has to infer which pack/model to use for a task like "enterprise GTM" or "trust audit." This page closes that gap without shipping new CLI surface.

## Acceptance criteria — addressed

- [x] **Docs tell agents which persona pack to choose for common tasks** — 12-row task → pack matrix covering positioning, GTM, pricing, trust audit, AI/eval discovery, healthcare, hiring, etc.
- [x] **Docs tell agents when single-model is acceptable vs when ensemble is recommended** — dedicated "When single-model is acceptable" and "When to escalate to an ensemble" sections with explicit decision rules.
- [x] **Guidance explicitly references SynthBench** — three findings from the live leaderboard data drive the recommendations (no single model best at everything; ensembles narrow variance; skeptical audiences are model-skeptical). \`--best-model-for "<topic>"\` is documented as the SynthBench-driven single-model option.
- [x] **Examples include copy/paste commands** — every major row has a runnable CLI + MCP block; pack export → file path → \`panel run\` flow shown.

## Changes

- \`docs/task-recommendations.md\` (new): lookup table + decision rules + copy/paste commands.
- \`README.md\`: callout under "Builtin persona packs" linking the new doc.
- \`docs/mcp.md\`: callout under "Tools (12)" so MCP-first agents see it.
- \`docs/model-packs.md\`: header banner pointing model-pack readers at the task-oriented lookup.

## Test plan

- [x] \`ruff check src/ tests/\` passes locally
- [x] \`pytest tests/test_site_markdown.py tests/test_site_headers.py --no-cov\` passes (21/21)
- [x] All claimed CLI flags / pack names verified — \`pack export\`, \`--models\`, \`--blend\`, \`--temperature\`, \`--best-model-for\`, \`--save\` against \`src/synth_panel/cli/parser.py\`; pack names against \`src/synth_panel/packs/*.yaml\`.
- [ ] CI: lint, typecheck, security, site-cli-sync, all \`test (3.10..3.14)\` green

## References

- Bead: sy-iao
- GH issue: #498
- Target release: v1.5.1

Closes #498