### PR TITLE
cli: mcp install --dry-run prints generated config (sy-0k2)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -26,8 +26,25 @@ synthpanel mcp install --uninstall                     # remove the entry
 
 The command merges into the host's existing `mcpServers` map, refuses to
 overwrite a clashing entry without `--force`, and writes user-scoped
-files with mode `0600`. `--dry-run` previews the change without touching
-disk.
+files with mode `0600`.
+
+`--dry-run` previews the change without touching disk. In text mode it
+puts the human prose on stderr and the resulting JSON config on stdout,
+so you can pipe the preview through `jq`, redirect it to a file, or feed
+it back into the installer:
+
+```bash
+synthpanel mcp install --target ~/.cursor/mcp.json --dry-run
+# stderr: Would install MCP server 'synth_panel' in /Users/you/.cursor/mcp.json.
+# stdout: { "mcpServers": { "synth_panel": { ... } } }
+
+synthpanel mcp install --target ~/.cursor/mcp.json --dry-run 2>/dev/null \
+  | jq '.mcpServers.synth_panel'
+```
+
+In `--output-format json` mode the entire payload (action, entry, and
+the full `resulting_config`) lands on stdout as a single JSON object
+with no stderr noise — one stream, fully parseable.
 
 If you'd rather hand-edit, the entry it produces is:
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -4459,7 +4459,20 @@ def handle_mcp_install(args: argparse.Namespace, fmt: OutputFormat) -> int:
         return 1
 
     if fmt is OutputFormat.JSON:
+        # JSON mode already carries the resulting-config snapshot in the
+        # payload (see helper.format_json); a single line on stdout
+        # preserves the existing machine-readable contract.
         print(helper.format_json(result))
+    elif dry_run:
+        # sy-0k2 / gh-495: surface the actual config payload so dry-run
+        # output is usable by agents and shell pipelines. Human prose
+        # goes to stderr; stdout is pretty-printed JSON of the resulting
+        # config so callers can pipe through `jq`, diff, or write it to
+        # the target themselves.
+        print(helper.format_text(result), file=sys.stderr)
+        rendered = helper.format_resulting_config(result)
+        if rendered is not None:
+            print(rendered)
     else:
         print(helper.format_text(result))
     return 0

--- a/src/synth_panel/cli/mcp_install.py
+++ b/src/synth_panel/cli/mcp_install.py
@@ -26,6 +26,11 @@ class InstallResult:
     name: str
     action: str  # "installed", "updated", "removed", "noop", "would-install", "would-update", "would-remove"
     entry: dict[str, Any] | None  # the server entry that was written (None for remove/noop)
+    # sy-0k2 / gh-495: the full config payload that would (or did) result
+    # from this call. Populated for every dry-run so `--dry-run` can print
+    # exactly what would be written. Also populated on the actual-write
+    # path so callers in JSON mode see a uniform shape.
+    resulting_config: dict[str, Any] | None = None
 
 
 def resolve_target(scope: str, target: str | None) -> Path:
@@ -120,7 +125,16 @@ def install(
     new_entry = build_entry(command, env)
 
     if existing == new_entry:
-        return InstallResult(target=target, name=name, action="noop", entry=new_entry)
+        # No-op: report the current on-disk config as the resulting config
+        # so dry-run consumers can still inspect the unchanged state.
+        config["mcpServers"] = servers
+        return InstallResult(
+            target=target,
+            name=name,
+            action="noop",
+            entry=new_entry,
+            resulting_config=config,
+        )
 
     is_update = name in servers
     if is_update and not force:
@@ -128,36 +142,78 @@ def install(
             f"MCP server {name!r} already exists in {target}. Pass --force to overwrite, or choose a different --name."
         )
 
-    if dry_run:
-        servers[name] = new_entry
-        config["mcpServers"] = servers
-        action = "would-update" if is_update else "would-install"
-        return InstallResult(target=target, name=name, action=action, entry=new_entry)
-
     servers[name] = new_entry
     config["mcpServers"] = servers
+    if dry_run:
+        action = "would-update" if is_update else "would-install"
+        return InstallResult(
+            target=target,
+            name=name,
+            action=action,
+            entry=new_entry,
+            resulting_config=config,
+        )
+
     _atomic_write(target, config)
     action = "updated" if is_update else "installed"
-    return InstallResult(target=target, name=name, action=action, entry=new_entry)
+    return InstallResult(
+        target=target,
+        name=name,
+        action=action,
+        entry=new_entry,
+        resulting_config=config,
+    )
 
 
 def uninstall(*, target: Path, name: str, dry_run: bool) -> InstallResult:
     """Remove the named server entry. No-op if it isn't present."""
     if not target.exists():
-        return InstallResult(target=target, name=name, action="noop", entry=None)
+        return InstallResult(
+            target=target,
+            name=name,
+            action="noop",
+            entry=None,
+            resulting_config={},
+        )
 
     config = _load_config(target)
     servers = config.get("mcpServers")
     if not isinstance(servers, dict) or name not in servers:
-        return InstallResult(target=target, name=name, action="noop", entry=None)
+        # Surface the unchanged config so dry-run consumers see the
+        # current state even on no-op.
+        if isinstance(servers, dict):
+            config["mcpServers"] = servers
+        return InstallResult(
+            target=target,
+            name=name,
+            action="noop",
+            entry=None,
+            resulting_config=config,
+        )
 
     if dry_run:
-        return InstallResult(target=target, name=name, action="would-remove", entry=None)
+        # Materialize the post-removal config without writing.
+        preview_servers = {k: v for k, v in servers.items() if k != name}
+        preview = dict(config)
+        preview["mcpServers"] = preview_servers
+        return InstallResult(
+            target=target,
+            name=name,
+            action="would-remove",
+            entry=None,
+            resulting_config=preview,
+        )
 
     del servers[name]
     config["mcpServers"] = servers
     _atomic_write(target, config)
-    return InstallResult(target=target, name=name, action="removed", entry=None)
+    return InstallResult(
+        target=target,
+        name=name,
+        action="removed",
+        entry=None,
+        resulting_config=config,
+    )
 
 
 def format_text(result: InstallResult) -> str:
@@ -185,7 +241,22 @@ def format_json(result: InstallResult) -> str:
     }
     if result.entry is not None:
         payload["entry"] = result.entry
+    # sy-0k2 / gh-495: expose the full resulting config when available so
+    # agents can see exactly what would (or did) land on disk.
+    if result.resulting_config is not None:
+        payload["resulting_config"] = result.resulting_config
     return json.dumps(payload)
+
+
+def format_resulting_config(result: InstallResult) -> str | None:
+    """Render the full resulting MCP config as pretty-printed JSON.
+
+    Returns ``None`` when no resulting-config snapshot is available
+    (callers should fall back to ``format_text`` in that case).
+    """
+    if result.resulting_config is None:
+        return None
+    return json.dumps(result.resulting_config, indent=2, sort_keys=False)
 
 
 __all__ = [
@@ -193,6 +264,7 @@ __all__ = [
     "InstallResult",
     "build_entry",
     "format_json",
+    "format_resulting_config",
     "format_text",
     "install",
     "parse_env_pairs",

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -376,12 +376,77 @@ class TestCLI:
         assert "synth_panel" not in data.get("mcpServers", {})
 
     def test_dry_run_does_not_write(self, tmp_path, capsys):
+        # sy-0k2 / gh-495: dry-run human prose goes to stderr; stdout
+        # carries the generated config as pretty JSON.
         target = tmp_path / "claude.json"
         rc = main(["mcp", "install", "--target", str(target), "--dry-run"])
         assert rc == 0
         assert not target.exists()
-        out = capsys.readouterr().out
-        assert "Would install" in out
+        captured = capsys.readouterr()
+        assert "Would install" in captured.err
+        # stdout must be valid JSON so callers can `| jq` or write-it-out themselves.
+        payload = json.loads(captured.out)
+        assert payload["mcpServers"]["synth_panel"]["command"]
+        assert payload["mcpServers"]["synth_panel"]["args"] == ["mcp-serve"]
+
+    def test_dry_run_preserves_existing_servers_in_preview(self, tmp_path, capsys):
+        # sy-0k2 / gh-495: the dry-run preview must show ALL servers that
+        # would be in the file, not just the one being added.
+        target = tmp_path / "claude.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "theme": "dark",
+                    "mcpServers": {"other": {"command": "other-bin", "args": []}},
+                }
+            )
+        )
+        rc = main(["mcp", "install", "--target", str(target), "--dry-run"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["theme"] == "dark"
+        assert set(payload["mcpServers"].keys()) == {"other", "synth_panel"}
+
+    def test_dry_run_uninstall_preview_drops_entry(self, tmp_path, capsys):
+        # sy-0k2 / gh-495: uninstall dry-run preview shows the post-removal
+        # state so callers can verify what would disappear.
+        target = tmp_path / "claude.json"
+        target.write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "synth_panel": {"command": "synthpanel", "args": ["mcp-serve"]},
+                        "other": {"command": "other-bin", "args": []},
+                    }
+                }
+            )
+        )
+        rc = main(["mcp", "install", "--uninstall", "--target", str(target), "--dry-run"])
+        assert rc == 0
+        # Original file untouched.
+        on_disk = json.loads(target.read_text())
+        assert "synth_panel" in on_disk["mcpServers"]
+        # Preview reflects the post-removal state.
+        captured = capsys.readouterr()
+        assert "Would remove" in captured.err
+        preview = json.loads(captured.out)
+        assert "synth_panel" not in preview["mcpServers"]
+        assert "other" in preview["mcpServers"]
+
+    def test_dry_run_json_mode_includes_resulting_config(self, tmp_path, capsys):
+        # sy-0k2 / gh-495: in JSON mode the entire payload (line, entry,
+        # resulting_config) lands on stdout as a single object so callers
+        # can parse one stream.
+        target = tmp_path / "claude.json"
+        rc = main(["--output-format", "json", "mcp", "install", "--target", str(target), "--dry-run"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # Nothing should land on stderr in JSON mode — the contract is one stream.
+        assert captured.err == ""
+        payload = json.loads(captured.out)
+        assert payload["action"] == "would-install"
+        assert payload["entry"]["args"] == ["mcp-serve"]
+        assert "synth_panel" in payload["resulting_config"]["mcpServers"]
 
     def test_bad_env_exits_nonzero(self, tmp_path, capsys):
         target = tmp_path / "claude.json"


### PR DESCRIPTION
## Summary

Pre-1.5.0 `synthpanel mcp install --dry-run` only confirmed the target:

```
Would install MCP server 'synth_panel' in /tmp/c.json.
```

Agents and shell pipelines can't inspect, diff, or pipe what they can't
see — they had to either run a non-dry install and read the file back, or
reconstruct the entry by hand from the docs. This PR makes `--dry-run`
actually print the generated config.

## Changes

- **`InstallResult` gains a `resulting_config` field** carrying the full post-operation JSON config (always populated for dry-runs; also populated on the actual-write path so JSON-mode consumers see a uniform shape). `install()` and `uninstall()` materialize the preview without writing.
- **`handle_mcp_install` splits text-mode dry-run output across streams**: human prose ("Would install ... in ...") goes to **stderr**; pretty-printed JSON of the resulting config goes to **stdout**. Pipeable into `jq`, redirectable to a file, or feedable back into the installer.
- **JSON mode (`--output-format json`)** folds the resulting config into the existing payload via `format_json`, so callers parsing the machine-readable stream get the full config plus `action`/`entry` as a single object on stdout — no stderr noise.
- **Non-dry-run text mode is unchanged** (single human line on stdout).

## Test plan

- Updated existing `test_dry_run_does_not_write` to assert the stderr/stdout split and that stdout is parseable JSON.
- Added coverage for:
  - dry-run preview preserves existing servers and top-level keys,
  - uninstall dry-run shows post-removal state,
  - JSON mode emits a single object containing `resulting_config`.
- GitHub CI runs the full suite on this PR.

## Docs

`docs/mcp.md` documents the new dry-run output contract with a `jq`-pipeable example.

## References

- Bead: sy-0k2
- Closes #495
- MR: sy-wisp-9yv
- Polecat: jasper-sy
- Branch: polecat/jasper-sy-0k2