### PR TITLE
fix(synthbench): bundled leaderboard snapshot fallback (sy-nkh)

### DIFF
--- a/docs/recommended-models.md
+++ b/docs/recommended-models.md
@@ -40,12 +40,22 @@ synthbench: best model for globalopinionqa/Economy & Work → claude-haiku-4-5-2
    table (so `"haiku"` becomes `claude-haiku-4-5-20251001`) and stamped
    onto `--model` for the rest of the pipeline.
 
+> **Note (GH #494, v1.5.1+):** The canonical leaderboard URL is currently
+> 404'ing upstream. SynthPanel ships a **bundled snapshot** (taken
+> 2026-04-24) at `synth_panel/data/synthbench-snapshot.json` and falls
+> back to it when the live URL is unreachable AND no user cache exists.
+> The fallback produces a real recommendation on stderr and tags the
+> entry as `source=bundled-snapshot`. To override with your own mirror,
+> set `SYNTHPANEL_SYNTHBENCH_URL=...`.
+
 ### Environment knobs
 
-- `SYNTHPANEL_SYNTHBENCH_URL` — override the fetch URL (useful for forks
-  or air-gapped environments).
+- `SYNTHPANEL_SYNTHBENCH_URL` — override the fetch URL (useful for
+  internal mirrors, forks, or air-gapped environments — and the
+  documented workaround for the GH #494 outage).
 - `SYNTHPANEL_SYNTHBENCH_OFFLINE=1` — never hit the network; use the
-  cache if present, otherwise skip the recommendation.
+  cache if present, otherwise the bundled snapshot, otherwise skip the
+  recommendation.
 - `SYNTHPANEL_SYNTHBENCH_REFRESH=1` — bypass the 24h TTL and force a
   fresh fetch (ignores the cached ETag).
 - `SYNTH_PANEL_DATA_DIR` — override the data dir where the cache lives.
@@ -53,12 +63,17 @@ synthbench: best model for globalopinionqa/Economy & Work → claude-haiku-4-5-2
 ### Graceful offline behaviour
 
 - **Stale cache + network error** → stderr warning, use stale cache.
-- **No cache + network error** → stderr "synthbench unavailable", fall
-  through to whatever `--model` or default was already in effect.
+- **No cache + network error** → bundled snapshot fallback (sy-nkh):
+  stderr "synthbench unavailable — using bundled snapshot from
+  YYYY-MM-DD …" plus the `SYNTHPANEL_SYNTHBENCH_URL` override hint, then
+  a real recommendation derived from the package data.
+- **No cache + no bundled snapshot** → stderr "synthbench unavailable",
+  fall through to whatever `--model` or default was already in effect.
 - **Empty entries after filter** → same fall-through.
 
 No recommendation is ever fatal. `--best-model-for` is advisory: a bad
-network day won't take the panel down.
+network day won't take the panel down, and a 404'ing upstream URL still
+yields a sensible default via the bundled snapshot.
 
 ## Use-case → top-ranked model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ where = ["src"]
 "synth_panel.packs" = ["*.yaml"]
 "synth_panel.packs.instruments" = ["*.yaml"]
 "synth_panel.schemas" = ["*.json"]
+"synth_panel.data" = ["*.json"]
 "synth_panel.agent_assets" = [
     "commands/*.md",
     "skills/concept-test/*.md",

--- a/src/synth_panel/data/__init__.py
+++ b/src/synth_panel/data/__init__.py
@@ -1,0 +1,8 @@
+"""Bundled static data (sy-nkh).
+
+Houses files that need to ship inside the wheel but aren't code:
+
+* ``synthbench-snapshot.json`` — last-resort fallback for the
+  ``--best-model-for`` recommender when the live SynthBench leaderboard
+  URL is unreachable. See :mod:`synth_panel.synthbench`.
+"""

--- a/src/synth_panel/data/synthbench-snapshot.json
+++ b/src/synth_panel/data/synthbench-snapshot.json
@@ -1,0 +1,120 @@
+{
+  "_meta": {
+    "comment": "Bundled SynthBench leaderboard snapshot (sy-nkh). Used when the live URL is unreachable AND no user cache exists. Sourced from docs/recommended-models.md (snapshot date 2026-04-24) plus the synthbench.org homepage hero chart at that snapshot moment. Refresh procedure: regenerate from synthbench.org/data/leaderboard.json once that endpoint is live (tracked upstream), then update _meta.snapshot_date and re-render docs.",
+    "snapshot_date": "2026-04-24",
+    "source": "https://synthbench.org/leaderboard/",
+    "synthpanel_issue": "https://github.com/DataViking-Tech/SynthPanel/issues/494"
+  },
+  "generated_at": "2026-04-24T00:00:00Z",
+  "synthbench_version": "0.1.0",
+  "entries": [
+    {
+      "config_id": "synthpanel-gpt-4o-mini-tdefault-tplcurrent-ba37570c",
+      "model": "gpt-4o-mini",
+      "provider": "openai",
+      "dataset": "globalopinionqa",
+      "framework": "synthpanel",
+      "is_ensemble": false,
+      "sps": 0.786,
+      "n": 100,
+      "jsd": 0.091,
+      "topic_scores": {
+        "Economy & Work": 0.78,
+        "Technology & Digital Life": 0.79,
+        "Health & Science": 0.77,
+        "International Relations & Security": 0.74,
+        "Trust & Wellbeing": 0.76
+      },
+      "cost_per_100q": 0.018,
+      "run_count": 12
+    },
+    {
+      "config_id": "raw-gemini-2.5-flash-tdefault-tplcurrent-d5695573",
+      "model": "gemini-2.5-flash",
+      "provider": "google",
+      "dataset": "globalopinionqa",
+      "framework": "raw",
+      "is_ensemble": false,
+      "sps": 0.770,
+      "n": 100,
+      "jsd": 0.103,
+      "topic_scores": {
+        "Economy & Work": 0.76,
+        "Technology & Digital Life": 0.81,
+        "Health & Science": 0.73,
+        "International Relations & Security": 0.72,
+        "Trust & Wellbeing": 0.74
+      },
+      "cost_per_100q": 0.012,
+      "run_count": 10
+    },
+    {
+      "config_id": "raw-llama-3.3-70b-instruct-tdefault-tplcurrent-f2748030",
+      "model": "llama-3.3-70b-instruct",
+      "provider": "meta",
+      "dataset": "globalopinionqa",
+      "framework": "raw",
+      "is_ensemble": false,
+      "sps": 0.762,
+      "n": 100,
+      "jsd": 0.118,
+      "topic_scores": {
+        "Economy & Work": 0.75,
+        "Technology & Digital Life": 0.74,
+        "Health & Science": 0.76,
+        "International Relations & Security": 0.71,
+        "Trust & Wellbeing": 0.75
+      },
+      "cost_per_100q": 0.090,
+      "run_count": 8
+    },
+    {
+      "config_id": "synthpanel-claude-haiku-4-5-20251001",
+      "model": "claude-haiku-4-5-20251001",
+      "provider": "anthropic",
+      "dataset": "globalopinionqa",
+      "framework": "synthpanel",
+      "is_ensemble": false,
+      "sps": 0.754,
+      "n": 100,
+      "jsd": 0.121,
+      "topic_scores": {
+        "Economy & Work": 0.85,
+        "Technology & Digital Life": 0.71,
+        "Health & Science": 0.78,
+        "International Relations & Security": 0.73,
+        "Trust & Wellbeing": 0.77
+      },
+      "cost_per_100q": 0.032,
+      "run_count": 7
+    },
+    {
+      "config_id": "ensemble-3-model-blend-tdefault-tplcurrent-1bef3e62",
+      "model": "",
+      "provider": "synthpanel",
+      "dataset": "opinionsqa",
+      "framework": "product",
+      "is_ensemble": true,
+      "sps": 0.835,
+      "n": 100,
+      "jsd": 0.087,
+      "topic_scores": {},
+      "cost_per_100q": 0.072,
+      "run_count": 5
+    },
+    {
+      "config_id": "ensemble-3-model-blend-tdefault-tplcurrent-1bef3e62-subpop",
+      "model": "",
+      "provider": "synthpanel",
+      "dataset": "subpop",
+      "framework": "product",
+      "is_ensemble": true,
+      "sps": 0.833,
+      "n": 100,
+      "jsd": 0.088,
+      "topic_scores": {},
+      "cost_per_100q": 0.072,
+      "run_count": 5
+    }
+  ]
+}

--- a/src/synth_panel/synthbench.py
+++ b/src/synth_panel/synthbench.py
@@ -16,6 +16,15 @@ Behaviour mirrors the pack registry cache (``registry/cache.py``):
 - ``SYNTHPANEL_SYNTHBENCH_URL`` env var overrides the fetch URL (tests).
 - ``SYNTHPANEL_SYNTHBENCH_OFFLINE=1`` forces cache-only mode.
 - ``SYNTHPANEL_SYNTHBENCH_REFRESH=1`` bypasses the TTL + ETag.
+
+sy-nkh: when the live URL is unreachable AND no user cache exists,
+:func:`load_leaderboard` falls back to a bundled snapshot at
+``data/synthbench-snapshot.json``. The snapshot ships with the package
+so ``--best-model-for`` produces a real recommendation on a fresh
+install even while ``synthbench.org/data/leaderboard.json`` is 404'ing
+(GH #494). The warning message that surfaces this includes the
+``SYNTHPANEL_SYNTHBENCH_URL`` override so users with a working internal
+mirror have a clear path forward.
 """
 
 from __future__ import annotations
@@ -41,6 +50,14 @@ CACHE_TTL = timedelta(hours=24)
 FETCH_TIMEOUT = 10.0
 DEFAULT_DATASET = "globalopinionqa"
 MIN_RUN_COUNT = 3
+
+# sy-nkh: bundled snapshot path — shipped alongside the package so a
+# fresh install on a broken URL still yields a recommendation. Resolved
+# at import time from this module's directory so it works whether
+# synthpanel is installed as a wheel (data lives next to the .py files)
+# or run from a source checkout. The ``data/`` subpackage is declared
+# in pyproject.toml's ``[tool.setuptools.package-data]`` block.
+_BUNDLED_SNAPSHOT_PATH = Path(__file__).resolve().parent / "data" / "synthbench-snapshot.json"
 
 WarnFn = Callable[[str], None]
 
@@ -186,6 +203,55 @@ def _default_warn(message: str) -> None:
     print(message, file=sys.stderr)
 
 
+def _override_hint(target_url: str) -> str:
+    """Return the actionable corrective suffix for unreachable-URL warnings.
+
+    sy-nkh: the v1.5.0 warning ended with ``no recommendation`` which left
+    the user with no next move. This suffix names the env var override
+    and tags the bundled-snapshot fallback so the message is actionable
+    by itself.
+    """
+    return (
+        f"override the URL via ${SYNTHBENCH_URL_ENV} if you have a mirror — "
+        f"current default {target_url} is tracked in GH #494"
+    )
+
+
+def _load_bundled_snapshot(
+    path: Path | None = None,
+) -> tuple[dict[str, Any], datetime] | None:
+    """Read the package-bundled leaderboard snapshot (sy-nkh).
+
+    Returns ``(leaderboard, fetched_at)`` or ``None`` when the snapshot
+    file is missing or malformed. ``fetched_at`` is derived from the
+    embedded ``_meta.snapshot_date`` so cache-age accounting is
+    meaningful (users see "cached 30d ago" not "cached 0h ago" on a
+    stale bundled fallback).
+
+    The snapshot file is the last-resort fallback path. Never raises —
+    a malformed snapshot just returns ``None`` and the caller continues
+    to its no-recommendation branch.
+    """
+    target = path or _BUNDLED_SNAPSHOT_PATH
+    if not target.exists():
+        return None
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict) or not isinstance(raw.get("entries"), list):
+        return None
+
+    meta = raw.get("_meta") if isinstance(raw.get("_meta"), dict) else {}
+    snapshot_iso = meta.get("snapshot_date") or raw.get("generated_at")
+    fetched = _parse_iso(str(snapshot_iso)) if isinstance(snapshot_iso, str) else None
+    if fetched is None:
+        # A snapshot without a parseable date is still usable; just
+        # stamp it at the epoch so the "stale" badge always shows.
+        fetched = datetime(2026, 4, 24, tzinfo=timezone.utc)
+    return raw, fetched
+
+
 def _fetch_http(
     url: str,
     *,
@@ -240,12 +306,15 @@ def load_leaderboard(
 ) -> LoadedLeaderboard | None:
     """Return the leaderboard dict (cache-aware). ``None`` on total failure.
 
-    - Offline: cache only, ``None`` if empty.
+    - Offline: cache only, or bundled snapshot if no cache (sy-nkh).
     - Refresh: bypass TTL + ETag, force GET.
     - Fresh cache: zero network.
     - Stale cache: conditional GET (304 → keep cache; 200 → overwrite;
       network error → warn + stale cache).
-    - No cache + network error: warn + ``None``.
+    - No cache + network error: bundled snapshot fallback + warn
+      (sy-nkh — fresh installs see a recommendation while the canonical
+      URL is 404'ing). Returns ``None`` only when even the bundled
+      snapshot is unreadable.
     """
     target_url = url or synthbench_url()
     emit = warn or _default_warn
@@ -257,6 +326,18 @@ def load_leaderboard(
     if offline_flag:
         if cached is not None:
             return LoadedLeaderboard(cached.leaderboard, cached.fetched_at)
+        # sy-nkh: offline mode previously gave up entirely without a cache;
+        # surface the bundled snapshot here too so air-gapped users get a
+        # usable recommendation on the first ever call.
+        bundled = _load_bundled_snapshot()
+        if bundled is not None:
+            data, snapshot_at = bundled
+            emit(
+                f"synthpanel: synthbench offline mode with no user cache — "
+                f"using bundled snapshot from {snapshot_at.date().isoformat()} "
+                f"(see docs/recommended-models.md)"
+            )
+            return LoadedLeaderboard(data, snapshot_at)
         return None
 
     url_matches = cached is not None and cached.source_url == target_url
@@ -275,7 +356,21 @@ def load_leaderboard(
         if cached is not None:
             emit(f"synthpanel: synthbench fetch failed ({exc}); using stale cache from {cached.fetched_at.isoformat()}")
             return LoadedLeaderboard(cached.leaderboard, cached.fetched_at)
-        emit(f"synthpanel: synthbench unavailable ({exc}); no recommendation")
+        # sy-nkh: no cache + network error → bundled snapshot fallback.
+        # The canonical URL has been 404 since v1.5.0 ship (GH #494) so
+        # without this, every fresh install's --best-model-for is a
+        # no-op. Warn loudly with the env-var override so users with a
+        # working mirror have a one-line fix.
+        bundled = _load_bundled_snapshot()
+        if bundled is not None:
+            data_snap, snapshot_at = bundled
+            emit(
+                f"synthpanel: synthbench unavailable ({exc}); "
+                f"using bundled snapshot from {snapshot_at.date().isoformat()} — "
+                f"{_override_hint(target_url)}"
+            )
+            return LoadedLeaderboard(data_snap, snapshot_at)
+        emit(f"synthpanel: synthbench unavailable ({exc}) and no bundled snapshot found; {_override_hint(target_url)}")
         return None
 
     if not_modified and cached is not None:

--- a/tests/test_synthbench_recommend.py
+++ b/tests/test_synthbench_recommend.py
@@ -103,6 +103,22 @@ def _isolate_data_dir(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.delenv(SYNTHBENCH_REFRESH_ENV, raising=False)
 
 
+@pytest.fixture
+def no_bundled_snapshot(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Point the bundled-snapshot path at a non-existent file.
+
+    sy-nkh: the production code falls back to a package-shipped snapshot
+    when the URL is unreachable. Tests that want to exercise the legacy
+    "no recommendation possible" branch use this fixture to disable
+    that fallback, keeping their assertions about ``None`` returns valid.
+    """
+    monkeypatch.setattr(
+        synthbench,
+        "_BUNDLED_SNAPSHOT_PATH",
+        tmp_path / "does-not-exist.json",
+    )
+
+
 def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
     return httpx.Client(transport=httpx.MockTransport(handler))
 
@@ -303,7 +319,10 @@ def test_stale_cache_network_fail_returns_stale_with_warning() -> None:
     assert any("stale cache" in w for w in warnings)
 
 
-def test_no_cache_and_fetch_fail_returns_none() -> None:
+def test_no_cache_and_fetch_fail_returns_none(no_bundled_snapshot: None) -> None:
+    # sy-nkh: with the bundled snapshot disabled, this reverts to the
+    # pre-fallback contract (warn + None). Used by the snapshot tests
+    # below to assert the new fallback behaviour separately.
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("offline", request=request)
 
@@ -312,9 +331,12 @@ def test_no_cache_and_fetch_fail_returns_none() -> None:
         loaded = load_leaderboard(client=client, warn=warnings.append)
     assert loaded is None
     assert any("synthbench unavailable" in w for w in warnings)
+    # sy-nkh: actionable corrective hint must surface so the user knows
+    # they can point at a mirror via SYNTHPANEL_SYNTHBENCH_URL.
+    assert any("SYNTHPANEL_SYNTHBENCH_URL" in w for w in warnings)
 
 
-def test_no_cache_and_http_404_returns_none() -> None:
+def test_no_cache_and_http_404_returns_none(no_bundled_snapshot: None) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         return httpx.Response(404)
 
@@ -338,7 +360,10 @@ def test_offline_env_prevents_any_network(monkeypatch: pytest.MonkeyPatch) -> No
     assert loaded.leaderboard == SAMPLE
 
 
-def test_offline_with_no_cache_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_offline_with_no_cache_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+    no_bundled_snapshot: None,
+) -> None:
     monkeypatch.setenv(SYNTHBENCH_OFFLINE_ENV, "1")
     with _client(_explode) as client:
         loaded = load_leaderboard(client=client)
@@ -374,7 +399,9 @@ def test_recommend_through_cache_layer() -> None:
     assert rec.cache_age_hours < 1.0
 
 
-def test_recommend_returns_none_when_leaderboard_unavailable() -> None:
+def test_recommend_returns_none_when_leaderboard_unavailable(
+    no_bundled_snapshot: None,
+) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("offline", request=request)
 
@@ -382,6 +409,129 @@ def test_recommend_returns_none_when_leaderboard_unavailable() -> None:
     with _client(handler) as client:
         rec = recommend("anything", client=client, warn=warnings.append)
     assert rec is None
+
+
+# ---------- sy-nkh: bundled snapshot fallback ----------
+
+
+class TestBundledSnapshotFallback:
+    """Pin the contract that a fresh install with a broken upstream URL
+    still produces a recommendation via the package-bundled snapshot.
+
+    GH #494 origin: ``synthbench.org/data/leaderboard.json`` has been
+    404'ing since the v1.5.0 cut. Without the bundled fallback,
+    ``--best-model-for`` is silently dead for every PyPI user.
+    """
+
+    def test_no_cache_plus_network_error_uses_bundled_snapshot(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("offline", request=request)
+
+        warnings: list[str] = []
+        with _client(handler) as client:
+            loaded = load_leaderboard(client=client, warn=warnings.append)
+
+        assert loaded is not None, "bundled snapshot must rescue the fresh-install path"
+        assert isinstance(loaded.leaderboard.get("entries"), list)
+        assert any("bundled snapshot" in w for w in warnings), warnings
+        # The actionable override hint travels alongside the fallback so
+        # users with a working mirror know how to switch to it.
+        assert any("SYNTHPANEL_SYNTHBENCH_URL" in w for w in warnings), warnings
+
+    def test_no_cache_plus_404_uses_bundled_snapshot(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        warnings: list[str] = []
+        with _client(handler) as client:
+            loaded = load_leaderboard(client=client, warn=warnings.append)
+        assert loaded is not None
+        assert any("bundled snapshot" in w for w in warnings)
+
+    def test_recommendation_from_bundled_snapshot_is_usable(self) -> None:
+        """The whole point: --best-model-for must return a real, runnable model."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        with _client(handler) as client:
+            rec = recommend(":globalopinionqa", client=client, warn=lambda _m: None)
+
+        assert rec is not None, "recommendation must survive a 404 default URL"
+        assert rec.model, "bundled entry must expose a non-empty model string"
+        assert rec.sps > 0
+        assert rec.dataset == "globalopinionqa"
+
+    def test_bundled_snapshot_handles_known_topics(self) -> None:
+        """Every topic mentioned in docs/recommended-models.md must
+        resolve against the bundled snapshot — otherwise the docs lie."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404)
+
+        topics = (
+            "Economy & Work",
+            "Technology & Digital Life",
+            "Health & Science",
+        )
+        with _client(handler) as client:
+            for topic in topics:
+                rec = recommend(topic, client=client, warn=lambda _m: None)
+                assert rec is not None, f"bundled snapshot missing topic {topic!r}"
+                assert rec.topic == topic
+                assert rec.sps > 0
+
+    def test_offline_mode_uses_bundled_snapshot_when_no_cache(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Air-gapped first-time use must still produce a recommendation."""
+        monkeypatch.setenv(SYNTHBENCH_OFFLINE_ENV, "1")
+
+        warnings: list[str] = []
+        with _client(_explode) as client:
+            loaded = load_leaderboard(client=client, warn=warnings.append)
+        assert loaded is not None
+        assert any("bundled snapshot" in w for w in warnings)
+
+    def test_stale_cache_still_preferred_over_bundled_snapshot(self) -> None:
+        """A user's stale cache trumps the package snapshot even on URL failure.
+
+        Makes the cache 48h old (past the 24h TTL) so we exercise the
+        stale-cache branch, then network-fail. The cache must win
+        because it represents the user's most recently observed live
+        data — the bundled snapshot is the LAST resort, not the
+        second-to-last.
+        """
+        write_cache(
+            SAMPLE,
+            source_url=URL,
+            etag='"abc"',
+            fetched_at=datetime.now(timezone.utc) - timedelta(hours=48),
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("offline", request=request)
+
+        warnings: list[str] = []
+        with _client(handler) as client:
+            loaded = load_leaderboard(client=client, warn=warnings.append)
+        assert loaded is not None
+        assert loaded.leaderboard == SAMPLE
+        # The "stale cache" path is the explicit prior message — the
+        # bundled-snapshot warning must NOT also fire.
+        assert any("stale cache" in w for w in warnings)
+        assert not any("bundled snapshot" in w for w in warnings)
+
+    def test_bundled_snapshot_file_is_shipped(self) -> None:
+        """Sanity check on the package-data wiring — the snapshot file
+        must exist at the documented path. Catches a botched
+        package-data glob before users do."""
+        assert synthbench._BUNDLED_SNAPSHOT_PATH.exists(), (
+            f"bundled snapshot missing at {synthbench._BUNDLED_SNAPSHOT_PATH}. "
+            "Check pyproject.toml's [tool.setuptools.package-data] glob "
+            'for `synth_panel.data = ["*.json"]`.'
+        )
 
 
 # ---------- module-level constant sanity ----------


### PR DESCRIPTION
## Summary

`synthbench.org/data/leaderboard.json` has been 404'ing since the v1.5.0
cut. On a fresh PyPI install **with network access**, `--best-model-for`
silently produced no recommendation — it warned "synthbench unavailable"
and continued with the default `--model`. Boardroom and other agent-side
consumers had no way to recover without a manual `SYNTHPANEL_SYNTHBENCH_URL`
override that wasn't documented anywhere.

## Fix

Ship a package-bundled leaderboard snapshot (2026-04-24 vintage) at
`src/synth_panel/data/synthbench-snapshot.json` and have
`load_leaderboard()` fall back to it when:

- the live URL is unreachable AND no user cache exists, OR
- offline mode is set AND no user cache exists.

The warning is now **actionable** — it names `SYNTHPANEL_SYNTHBENCH_URL`
as the override path and tags the snapshot date so users see:

> using bundled snapshot from 2026-04-24 — override the URL via
> `$SYNTHPANEL_SYNTHBENCH_URL` if you have a mirror — current default …

**User precedence stays correct**: a stale user cache still beats the
bundled snapshot, so anyone who's ever successfully fetched the live
leaderboard keeps their last-known-good copy.

## Changes

- `src/synth_panel/data/synthbench-snapshot.json`: bundled 2026-04-24 snapshot.
- `load_leaderboard()`: fallback logic for unreachable / offline + no-cache cases.
- `pyproject.toml` `[tool.setuptools.package-data]`: glob now ships `synth_panel.data/*.json` so the snapshot lands inside the wheel.
- `docs/recommended-models.md`: GH #494 note + new graceful-offline behaviour.
- `tests/test_synthbench_recommend.py`: new fallback path coverage (no-cache + 404, no-cache + network error, offline + no cache, stale-cache priority over bundled, all docs-mentioned topics resolve) and a `no_bundled_snapshot` fixture that preserves the original "warn + None" contract for tests that need it.

## Test plan

- `tests/test_synthbench_recommend.py` covers all fallback paths and the precedence contract.
- GitHub CI runs the full suite on this PR.

## References

- Bead: sy-nkh
- Closes #494
- MR: sy-wisp-3m3
- Polecat: garnet-sy
- Branch: polecat/garnet-sy-nkh