### PR TITLE
fix(cli): handle BrokenPipeError cleanly when output is piped (sy-4bs)

### DIFF
--- a/src/synth_panel/main.py
+++ b/src/synth_panel/main.py
@@ -6,6 +6,8 @@ slash commands, and output formatting.
 
 from __future__ import annotations
 
+import os
+import signal
 import sys
 
 from synth_panel.cli.commands import (
@@ -52,8 +54,62 @@ from synth_panel.cli.repl import run_repl
 from synth_panel.logging_config import setup_logging
 
 
+def _quiet_broken_pipe() -> None:
+    """Make `synthpanel … | head` exit silently like a regular Unix tool.
+
+    Two failure modes overlap here:
+
+    * A mid-stream write to a closed pipe raises ``BrokenPipeError`` because
+      Python overrides the default ``SIGPIPE`` disposition. Restoring
+      ``SIG_DFL`` lets the kernel just kill the process on pipe close, the
+      way ``cat`` / ``ls`` / ``--help`` from any other tool behaves.
+
+    * Even after handling the mid-stream write, the interpreter shutdown
+      flush still finds the broken pipe and prints
+      ``Exception ignored while flushing sys.stdout: BrokenPipeError``.
+      Redirecting fd 1 to ``/dev/null`` before shutdown swallows that
+      final flush. The exit-time flush hits ``/dev/null`` instead of the
+      closed pipe, so no warning escapes to stderr.
+    """
+    if hasattr(signal, "SIGPIPE"):
+        # Windows has no SIGPIPE — that's why the hasattr guard.
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    try:
+        sys.stdout.flush()
+    except BrokenPipeError:
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+        except (OSError, ValueError):
+            # If stdout is detached or already closed there's nothing
+            # more we can do; the silence we wanted is already achieved.
+            pass
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point. Returns exit code."""
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    try:
+        return _main(argv)
+    except BrokenPipeError:
+        _quiet_broken_pipe()
+        # 0 — Unix convention treats SIGPIPE-killed pipelines as expected
+        # for short-circuiting consumers like `head`. argparse's `--help`
+        # already returned its work; signalling success matches `man`,
+        # `pydoc`, and other paginated tools.
+        return 0
+    finally:
+        # Even on normal exit, a buffered write may still be pending when
+        # the pipe is already closed (argparse `--help` ends in
+        # ``parser.exit(0)`` after buffered prints). Flushing here surfaces
+        # any deferred BrokenPipeError so we can swap stdout for devnull
+        # before the interpreter's own shutdown flush triggers the
+        # "Exception ignored" warning on stderr.
+        _quiet_broken_pipe()
+
+
+def _main(argv: list[str] | None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/tests/test_broken_pipe.py
+++ b/tests/test_broken_pipe.py
@@ -1,0 +1,166 @@
+"""sy-4bs: piping CLI output into a short-circuiting consumer is silent.
+
+Before this fix, ``synthpanel … --help | head`` printed
+``Exception ignored while flushing sys.stdout: BrokenPipeError`` to
+stderr because Python's interpreter shutdown flush hit the closed pipe.
+Agents that introspect SynthPanel by grepping ``--help`` (the documented
+pattern in README's Human Operator Quick Start) saw the traceback in
+their tool-output streams and treated it as a tool failure.
+
+Two layers under test:
+
+1. The ``_quiet_broken_pipe`` helper directly — a fast unit test, no
+   subprocess, validates the stdout-redirect-to-devnull behaviour.
+2. The actual CLI under a head-truncated pipe — an integration test
+   via subprocess that confirms zero stderr noise on a real pipe close.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------- unit tests
+
+
+def test_quiet_broken_pipe_restores_sigpipe_default() -> None:
+    """The helper resets SIGPIPE to SIG_DFL so kernel-level pipe close kills
+    the process silently instead of Python raising BrokenPipeError."""
+    if not hasattr(signal, "SIGPIPE"):
+        pytest.skip("SIGPIPE not available on this platform (Windows)")
+
+    from synth_panel.main import _quiet_broken_pipe
+
+    prior = signal.signal(signal.SIGPIPE, signal.SIG_IGN)
+    try:
+        _quiet_broken_pipe()
+        assert signal.getsignal(signal.SIGPIPE) is signal.SIG_DFL
+    finally:
+        signal.signal(signal.SIGPIPE, prior)
+
+
+def test_quiet_broken_pipe_redirects_stdout_when_flush_fails() -> None:
+    """If flushing stdout raises BrokenPipeError, the helper must dup2
+    /dev/null onto stdout's fd. Verified at the syscall layer via mocks so
+    the test doesn't fight pytest's stdout capture."""
+    from synth_panel.main import _quiet_broken_pipe
+
+    fake_stdout = mock.Mock()
+    fake_stdout.flush.side_effect = BrokenPipeError(32, "Broken pipe")
+    fake_stdout.fileno.return_value = 1
+
+    devnull_fd = 999  # arbitrary sentinel; never actually used
+    with (
+        mock.patch.object(sys, "stdout", fake_stdout),
+        mock.patch("os.open", return_value=devnull_fd) as fake_open,
+        mock.patch("os.dup2") as fake_dup2,
+    ):
+        _quiet_broken_pipe()
+
+    fake_open.assert_called_once_with(os.devnull, os.O_WRONLY)
+    fake_dup2.assert_called_once_with(devnull_fd, 1)
+
+
+def test_quiet_broken_pipe_swallows_secondary_oserror() -> None:
+    """If the recovery path itself fails (eg detached stdout), the helper
+    must not raise — that would leak a traceback back to the caller and
+    re-create the original problem."""
+    from synth_panel.main import _quiet_broken_pipe
+
+    fake_stdout = mock.Mock()
+    fake_stdout.flush.side_effect = BrokenPipeError(32, "Broken pipe")
+    fake_stdout.fileno.side_effect = ValueError("I/O operation on closed file")
+
+    with mock.patch.object(sys, "stdout", fake_stdout):
+        # Must not raise.
+        _quiet_broken_pipe()
+
+
+# ----------------------------------------------------- integration via pipe
+
+
+def _run_piped(args: list[str], head_lines: int = 3) -> tuple[int, bytes, bytes]:
+    """Run ``python -m synth_panel <args> | head -N`` and return the pipeline
+    exit code, head's stdout, and synthpanel's stderr."""
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT / "src")}
+    sp = subprocess.Popen(
+        [sys.executable, "-m", "synth_panel", *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+        cwd=REPO_ROOT,
+    )
+    head = subprocess.Popen(
+        ["head", "-n", str(head_lines)],
+        stdin=sp.stdout,
+        stdout=subprocess.PIPE,
+    )
+    assert sp.stdout is not None
+    sp.stdout.close()
+    head_out, _ = head.communicate(timeout=30)
+    assert sp.stderr is not None
+    sp_err = sp.stderr.read()
+    sp.wait(timeout=10)
+    return sp.returncode, head_out, sp_err
+
+
+def _synthpanel_importable() -> bool:
+    """Skip integration tests when synthpanel can't be imported (missing
+    optional deps in the test environment). The unit tests above still
+    cover the fix's contract."""
+    try:
+        import synth_panel  # noqa: F401
+        from synth_panel.cli import parser  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+needs_cli = pytest.mark.skipif(not _synthpanel_importable(), reason="synthpanel CLI not importable in this environment")
+
+
+@needs_cli
+def test_help_piped_to_head_produces_no_stderr_noise() -> None:
+    """The exact failure mode from GH#499: argparse help through a
+    short-circuiting consumer must not surface BrokenPipeError on stderr."""
+    rc, _, err = _run_piped(["panel", "run", "--help"])
+    assert b"BrokenPipeError" not in err, f"BrokenPipeError leaked to stderr: {err!r}"
+    assert b"Exception ignored" not in err, f"shutdown-flush warning leaked to stderr: {err!r}"
+    assert rc == 0, f"unexpected non-zero exit {rc}; stderr={err!r}"
+
+
+@needs_cli
+def test_top_level_help_piped_is_clean() -> None:
+    rc, _, err = _run_piped(["--help"])
+    assert b"BrokenPipeError" not in err
+    assert b"Exception ignored" not in err
+    assert rc == 0
+
+
+@needs_cli
+def test_subcommand_help_piped_is_clean() -> None:
+    rc, _, err = _run_piped(["prompt", "--help"], head_lines=1)
+    assert b"BrokenPipeError" not in err
+    assert b"Exception ignored" not in err
+    assert rc == 0
+
+
+@needs_cli
+def test_normal_listing_piped_to_head_is_clean() -> None:
+    """Not help-only — any stdout-heavy subcommand should behave the same.
+    `instruments list` enumerates the bundled v3 packs and easily overflows
+    a `head -2` consumer."""
+    rc, _, err = _run_piped(["instruments", "list"], head_lines=2)
+    assert b"BrokenPipeError" not in err
+    assert b"Exception ignored" not in err
+    assert rc == 0


### PR DESCRIPTION
## Summary

`synthpanel panel run --help | head` (the documented agent-onboarding
pattern from README's Human Operator Quick Start) used to print:

```
Exception ignored while flushing sys.stdout:
BrokenPipeError: [Errno 32] Broken pipe
```

to stderr. Agents that introspect SynthPanel by grepping `--help` output
saw the traceback in their tool-output streams and treated it as a tool
failure even though help actually rendered.

## Fix

Two overlapping failure modes, one fix in `main.py`:

- **Python overrides the default SIGPIPE disposition** with a Python-level `BrokenPipeError`. Restoring `SIG_DFL` makes mid-stream writes after the pipe closes kill the process silently, matching `cat`, `ls`, `pydoc`, and other Unix tools.
- **The interpreter's shutdown flush still hits the closed pipe** even after the in-process write succeeded into Python's stdout buffer. A `finally`-block flush surfaces the deferred `BrokenPipeError` so we can `dup2 /dev/null` onto fd 1 before interpreter shutdown re-attempts the flush — the late flush then lands on `/dev/null` and stderr stays clean.

Wired into `synth_panel.main:main` so every CLI route (the `synthpanel`
console_script entry, `python -m synth_panel`, and direct
`from synth_panel.main import main` import) gets the same behaviour
without each subcommand having to opt in.

## Test plan

`tests/test_broken_pipe.py`:

- **Unit tests** pin the SIGPIPE handler restoration and the `flush → dup2-devnull` recovery (via mocks so they don't fight pytest's stdout capture), plus that the recovery path swallows secondary `OSError`s so it can never re-raise.
- **Integration tests** subprocess `python -m synth_panel … | head` for:
  - top-level help,
  - `panel run --help` (the #499 repro),
  - `prompt --help`,
  - `instruments list` (a normal stdout-heavy subcommand).

Every case must yield empty stderr and exit 0. GitHub CI runs the full suite on this PR.

## References

- Bead: sy-4bs
- Closes #499
- MR: sy-wisp-roe
- Polecat: topaz-sy-4bs
- Branch: polecat/topaz-sy-4bs-19e52c5664f