### PR TITLE
feat(doctor): add --install-only mode (sy-e28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,13 @@ jobs:
           /tmp/smoke/bin/synthpanel --version
           /tmp/smoke/bin/synthpanel --help > /dev/null
           /tmp/smoke/bin/synthpanel whoami
+
+          # sy-e28: prove the no-credentials install-only mode works in a
+          # clean wheel install. Unset the fake key for this step so it
+          # actually exercises the "credentials missing" path; exit code
+          # must still be 0 because install_ok dominates.
+          env -u ANTHROPIC_API_KEY /tmp/smoke/bin/synthpanel doctor --install-only
+
           /tmp/smoke/bin/synthpanel doctor
 
           # `[mcp]` matrix entry must additionally import the MCP server.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ### Added
 
+- **`synthpanel doctor --install-only` (sy-e28).** Validates package,
+  dependency, bundled-pack, and checkpoint-root health without requiring
+  a provider credential. Designed for clean-room CI and post-`pip install`
+  agent smoke tests where keys haven't been provisioned yet. Credential
+  status is still reported in the output; only the exit-code gate
+  changes. JSON output gains `install_ok` and `install_only` fields
+  alongside the existing `credential_configured` and `checks_ok`, so
+  agents can branch on install vs. credential health independently.
+  `clean-install-smoke` in CI exercises the new mode against the built
+  wheel with no provider env set.
 - **`synthpanel mcp install` CLI (sy-skf).** Registers synthpanel as a
   stdio MCP server in a host's JSON config — defaults to Claude Code's
   user-scope `~/.claude.json`, with `--scope project` for `./.mcp.json`

--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ After installing, verify the CLI is on your PATH and the runtime is sane
 *before* configuring providers:
 
 ```bash
-synthpanel --version          # smoke: package metadata + entry point dispatch
-synthpanel doctor             # diagnostic: python, deps, packs, checkpoint dir
-synthpanel whoami             # which providers (if any) have credentials
+synthpanel --version              # smoke: package metadata + entry point dispatch
+synthpanel doctor --install-only  # install health only — no credentials needed
+synthpanel doctor                 # full preflight (install + credentials)
+synthpanel whoami                 # which providers (if any) have credentials
 ```
 
 `doctor` exits non-zero with actionable guidance when something's
@@ -170,6 +171,14 @@ it's the canonical "did the install land cleanly?" check, and
 `clean-install-smoke` in CI runs the same sequence against the built
 wheel on every push, so all three commands are part of the supported
 contract.
+
+Use `synthpanel doctor --install-only` immediately after `pip install
+synthpanel` to validate the package, dependencies, and bundled packs
+without provisioning a provider key — exit 0 in that mode means the
+install is healthy, even when credentials are not yet configured. The
+JSON output (`--output-format json doctor --install-only`) separates
+`install_ok`, `credential_configured`, and `checks_ok` so agents and CI
+can branch on each surface independently.
 
 Then provide an API key (Claude, OpenAI, Gemini, xAI, or any
 OpenAI-compatible provider) — either export it in your shell or persist

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -5681,6 +5681,12 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
     )
 
     verbose = bool(getattr(args, "verbose", False))
+    # sy-e28: agents and clean-install CI smoke tests need to validate
+    # package health without provisioning a provider key. --install-only
+    # drops the credential check from the exit-code gate but keeps it in
+    # the report so the output still tells you whether you can actually
+    # run a panel.
+    install_only = bool(getattr(args, "install_only", False))
 
     # --- Python runtime
     py_version_str = sys.version.split()[0]
@@ -5766,7 +5772,13 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
         pack_load_errors.append(f"pack registry load failed: {exc}")
     packs_ok = not pack_load_errors
 
-    checks_ok = py_ok and not dep_errors and any_provider and ckpt_writable and packs_ok
+    # sy-e28: install_ok is the same gate as the old checks_ok minus the
+    # credential check. checks_ok stays "fully runnable" by default so
+    # the existing CI/agent contract holds; --install-only drops the
+    # credential check from checks_ok so the exit code reflects install
+    # health alone.
+    install_ok = py_ok and not dep_errors and ckpt_writable and packs_ok
+    checks_ok = install_ok and (any_provider or install_only)
 
     extra: dict[str, Any] = {
         "synthpanel_version": __version__,
@@ -5787,6 +5799,8 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
         "bundled_instrument_packs": bundled_instrument_count,
         "pack_load_errors": pack_load_errors,
         "packs_ok": packs_ok,
+        "install_only": install_only,
+        "install_ok": install_ok,
         "checks_ok": checks_ok,
     }
 
@@ -5819,7 +5833,10 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
         else:
             print(f"  {warn_mark} optional: mcp not installed (`pip install synthpanel[mcp]`)")
 
-        # Credentials (one line per provider with a key)
+        # Credentials (one line per provider with a key). In --install-only
+        # mode credential absence is reported as a warning, not an error,
+        # since the user has explicitly asked to validate install health
+        # only.
         if any_provider:
             for row in provider_rows:
                 if row["available"]:
@@ -5828,6 +5845,11 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
                     print(f"  {warn_mark} {row['env_var']}: not set ({row['provider']})")
             if verbose:
                 print(f"     credential store: {credentials_path()}")
+        elif install_only:
+            print(
+                f"  {warn_mark} credentials: none configured "
+                "(install-only mode — run `synthpanel login` before running a panel)."
+            )
         else:
             print(
                 f"  {bad_mark} No LLM credentials found (env or stored). Run `synthpanel login`.",
@@ -5861,15 +5883,19 @@ def handle_doctor(args: argparse.Namespace, fmt: OutputFormat) -> int:
             for msg in pack_load_errors:
                 print(f"  {bad_mark} {msg}", file=sys.stderr)
 
-        # Tally
+        # Tally — in --install-only mode missing credentials count as a
+        # warning rather than an error so the printed summary matches the
+        # exit code.
+        credentials_error_count = 0 if (any_provider or install_only) else 1
+        credentials_warning_count = 1 if (install_only and not any_provider) else 0
         n_err = (
             (0 if py_ok else 1)
             + len(dep_errors)
-            + (0 if any_provider else 1)
+            + credentials_error_count
             + (0 if ckpt_writable else 1)
             + len(pack_load_errors)
         )
-        n_warn = len(optional_notes)
+        n_warn = len(optional_notes) + credentials_warning_count
         if rc == 0:
             tail = f"{n_warn} warning{'s' if n_warn != 1 else ''}, 0 errors." if n_warn else "0 errors."
             print(tail)

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1411,11 +1411,21 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show which providers have credentials available (env or stored).",
     )
 
-    subparsers.add_parser(
+    doctor_parser = subparsers.add_parser(
         "doctor",
         help=(
             "Preflight diagnostics: runtime, deps, and provider credentials "
             "(never prints secrets; exits 1 if no provider credential is configured)."
+        ),
+    )
+    doctor_parser.add_argument(
+        "--install-only",
+        action="store_true",
+        help=(
+            "Check package/install health only — exit 0 even when no provider "
+            "credential is configured. Credential status is still reported "
+            "informationally. Useful as a post-`pip install` smoke test in CI "
+            "and clean-room environments where keys haven't been provisioned yet."
         ),
     )
 

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -320,6 +320,103 @@ class TestDoctor:
         assert "checkpoint root:" in out
         assert "packs:" in out
 
+    def test_doctor_install_only_exits_zero_without_credentials(self, capsys, monkeypatch, tmp_path):
+        """--install-only (sy-e28) — install healthy, credentials missing → exit 0."""
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("SYNTHPANEL_CHECKPOINT_ROOT", str(tmp_path))
+        rc = main(["doctor", "--install-only"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        # The error-style "No LLM credentials found" line is suppressed in
+        # install-only mode in favour of an informational warning line.
+        assert "No LLM credentials found" not in captured.err
+        assert "install-only mode" in captured.out
+        assert "0 errors." in captured.out
+
+    def test_doctor_install_only_json_separates_install_and_credentials(self, capsys, monkeypatch, tmp_path):
+        """--install-only JSON (sy-e28) splits install_ok from credential_configured."""
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("SYNTHPANEL_CHECKPOINT_ROOT", str(tmp_path))
+        rc = main(["--output-format", "json", "doctor", "--install-only"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["message"] == "doctor_report"
+        assert payload["python_ok"] is True
+        assert payload["dependencies_ok"] is True
+        assert payload["packs_ok"] is True
+        assert payload["install_ok"] is True
+        # The credential surface is reported verbatim — it just doesn't
+        # block the exit code in install-only mode.
+        assert payload["credential_configured"] is False
+        assert payload["install_only"] is True
+        assert payload["checks_ok"] is True
+
+    def test_doctor_install_only_field_present_in_default_json(self, capsys, monkeypatch, tmp_path):
+        """install_ok / install_only fields appear in default JSON output too (sy-e28)."""
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-default-mode")
+        monkeypatch.setenv("SYNTHPANEL_CHECKPOINT_ROOT", str(tmp_path))
+        rc = main(["--output-format", "json", "doctor"])
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        # Agents always get the install/credential split, regardless of mode.
+        assert payload["install_only"] is False
+        assert payload["install_ok"] is True
+        assert payload["credential_configured"] is True
+        assert payload["checks_ok"] is True
+
+    def test_doctor_install_only_still_fails_on_broken_install(self, capsys, monkeypatch, tmp_path):
+        """--install-only doesn't paper over real install breakage (sy-e28)."""
+        for env in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "XAI_API_KEY",
+            "OPENROUTER_API_KEY",
+        ):
+            monkeypatch.delenv(env, raising=False)
+        monkeypatch.delenv("SYNTHPANEL_CREDENTIALS_PATH", raising=False)
+        monkeypatch.setenv("SYNTHPANEL_CHECKPOINT_ROOT", str(tmp_path))
+        # Force the bundled-pack loaders to return empty so doctor reports a
+        # pack registry failure — install_ok must follow.
+        from synth_panel.mcp import data as mcp_data
+
+        monkeypatch.setattr(mcp_data, "_bundled_packs", lambda: [])
+        monkeypatch.setattr(mcp_data, "_bundled_instrument_packs", lambda: [])
+        rc = main(["--output-format", "json", "doctor", "--install-only"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["packs_ok"] is False
+        assert payload["install_ok"] is False
+        assert payload["checks_ok"] is False
+        assert rc == 1
+
     def test_doctor_verbose_lists_unset_providers(self, capsys, monkeypatch, tmp_path):
         """--verbose lists every known provider env var, set or not."""
         for env in (


### PR DESCRIPTION
## Summary

Adds `synthpanel doctor --install-only` so agents and CI can validate package, dependency, bundled-pack, and checkpoint-root health without provisioning a provider credential.

- New `--install-only` flag drops the credential check from the exit-code gate but keeps it in the report. Credential absence becomes a warning rather than an error.
- JSON output gains two new fields, `install_ok` and `install_only`, alongside the existing `credential_configured` and `checks_ok` — agents can branch on install vs. credential health independently.
- `clean-install-smoke` in CI now exercises the new mode against the built wheel with no provider env set, then runs the full `doctor` check (with the fake key) as before.
- README documents the new flag in the "verify the install" smoke sequence.

Documentation-only changes alongside the feature: README, CHANGELOG (Unreleased section), and `.github/workflows/ci.yml`.

## Acceptance-criteria mapping (issue #497)

- ✅ *There is a documented command that verifies package/install health without requiring provider credentials* — `synthpanel doctor --install-only`, documented in README, CHANGELOG, and `--help`.
- ✅ *Credential absence remains clearly reported* — both the text output line ("credentials: none configured (install-only mode …)") and the JSON `credential_configured` field surface absence verbatim; the only thing that changes is the exit code.
- ✅ *JSON output separates install/deps/packs/credentials statuses* — the existing per-surface booleans (`python_ok`, `dependencies_ok`, `packs_ok`, `checkpoint_root_writable`, `credential_configured`) are now joined by `install_ok` (rollup minus credentials) and `install_only` (mode flag).
- ✅ *CI and agents can use the command as a smoke test after `pip install synthpanel`* — `clean-install-smoke` now runs `doctor --install-only` with `ANTHROPIC_API_KEY` unset, proving the contract end-to-end against the built wheel.

## Test plan

- [x] `pytest tests/test_cli_auth.py::TestDoctor --no-cov` — 13 passed (9 existing + 4 new)
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — clean
- [x] Manual `synthpanel doctor --install-only` smoke against the dev venv (no creds) → exit 0
- [x] Manual `synthpanel doctor --install-only --output-format json` → `install_ok=true, credential_configured=false, checks_ok=true`
- [x] Manual `synthpanel doctor` (no creds) → still exits 1 (existing contract preserved)

Closes #497