### PR TITLE
cli: resolve persona pack names for --personas (sy-n80)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -573,10 +573,24 @@ def _load_yaml(path: str) -> Any:
             raise ValueError(f"Invalid YAML in {path}: {exc}") from exc
 
 
-def _load_personas(path: str) -> list[dict[str, Any]]:
-    """Load personas from a YAML file.
+def _load_personas(path_or_name: str) -> list[dict[str, Any]]:
+    """Load personas from a YAML file *or* an installed pack name.
 
-    Expected format::
+    Resolution order (sy-n80 / gh-508):
+
+    1. If ``path_or_name`` is an existing file, parse it as YAML.
+    2. Otherwise try :func:`get_persona_pack` — this covers both
+       user-saved packs under ``$SYNTH_PANEL_DATA_DIR/persona_packs/``
+       and bundled packs that ship in the wheel.
+    3. Otherwise consult the registry (best-effort, offline-safe): if
+       the id is a known *registry* pack, raise a targeted
+       :class:`FileNotFoundError` whose message points the caller at
+       ``synthpanel pack import <id>`` so the happy path is one
+       command away.
+    4. Otherwise raise a generic "not found as file or installed pack"
+       error that distinguishes filesystem paths from pack aliases.
+
+    Expected file format::
 
         personas:
           - name: Alice
@@ -585,12 +599,56 @@ def _load_personas(path: str) -> list[dict[str, Any]]:
             background: ...
             personality_traits: [curious, empathetic]
     """
-    data = _load_yaml(path)
+    if Path(path_or_name).exists():
+        data = _load_yaml(path_or_name)
+    else:
+        from synth_panel.mcp.data import get_persona_pack
+
+        try:
+            data = get_persona_pack(path_or_name)
+        except (FileNotFoundError, ValueError):
+            # Registry hint: distinguishing "this name is a known
+            # registry pack you haven't installed" from "this is just
+            # garbage" is the single most useful diagnostic for an
+            # agent debugging --personas. The lookup is best-effort —
+            # offline / network failures degrade silently to the
+            # generic error so we never block a user who's working
+            # locally.
+            hint = _registry_install_hint(path_or_name)
+            if hint:
+                raise FileNotFoundError(hint) from None
+            raise FileNotFoundError(
+                f"Personas not found as file or installed pack: {path_or_name!r}. "
+                f"Run `synthpanel pack list` to see installed packs, or "
+                f"`synthpanel pack search <query>` to find registry packs."
+            ) from None
+
     if isinstance(data, dict) and "personas" in data:
         return data["personas"]
     if isinstance(data, list):
         return data
     raise ValueError(f"Invalid personas file: expected 'personas' key or a list, got {type(data).__name__}")
+
+
+def _registry_install_hint(pack_id: str) -> str | None:
+    """Return an actionable message if *pack_id* is a known registry pack.
+
+    Best-effort: any failure (offline, network, registry parse) returns
+    ``None`` so the caller falls back to the generic "not found" error.
+    """
+    try:
+        from synth_panel.registry import resolve_pack
+
+        entry = resolve_pack(pack_id)
+    except Exception:
+        return None
+    if entry is None:
+        return None
+    return (
+        f"{pack_id!r} is a registry pack, not yet installed locally. "
+        f"Run `synthpanel pack import {pack_id}` to install it, then "
+        f"re-run with `--personas {pack_id}`."
+    )
 
 
 def _merge_persona_lists_with_collisions(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,6 +361,70 @@ class TestYAMLLoading:
         with pytest.raises(FileNotFoundError):
             _load_personas("/nonexistent/path.yaml")
 
+    def test_load_personas_resolves_bundled_pack_name(self):
+        # sy-n80 / gh-508: a bundled pack id (e.g. ``developer``)
+        # passed to --personas must resolve via get_persona_pack rather
+        # than being treated as a filesystem path.
+        personas = _load_personas("developer")
+        assert isinstance(personas, list)
+        assert len(personas) > 0
+        assert all("name" in p for p in personas)
+
+    def test_load_personas_unknown_name_error_mentions_pack_lookup(self, monkeypatch):
+        # sy-n80 / gh-508: the error message for an unresolved name has
+        # to distinguish "filesystem path" from "pack alias" so an agent
+        # can pick the right next step. Force the registry probe to
+        # return None so we exercise the generic-error branch.
+        from synth_panel.cli import commands as cmd_mod
+
+        monkeypatch.setattr(cmd_mod, "_registry_install_hint", lambda _name: None)
+        with pytest.raises(FileNotFoundError) as exc:
+            _load_personas("not-a-real-pack-name")
+        msg = str(exc.value)
+        assert "not found as file or installed pack" in msg
+        assert "pack list" in msg or "pack search" in msg
+
+    def test_load_personas_registry_pack_gets_install_hint(self, monkeypatch):
+        # sy-n80 / gh-508: when the name is a known registry pack, the
+        # error must point the caller at `synthpanel pack import <id>`.
+        from synth_panel.cli import commands as cmd_mod
+
+        monkeypatch.setattr(
+            cmd_mod,
+            "_registry_install_hint",
+            lambda name: (
+                f"{name!r} is a registry pack, not yet installed locally. "
+                f"Run `synthpanel pack import {name}` to install it, then "
+                f"re-run with `--personas {name}`."
+            ),
+        )
+        with pytest.raises(FileNotFoundError) as exc:
+            _load_personas("some-registry-pack-id")
+        msg = str(exc.value)
+        assert "registry pack" in msg
+        assert "pack import some-registry-pack-id" in msg
+
+    def test_load_personas_registry_probe_is_offline_safe(self, monkeypatch):
+        # sy-n80 / gh-508: a network failure in the registry probe must
+        # not crash; it should fall through to the generic error.
+        from synth_panel.cli import commands as cmd_mod
+
+        def _boom(_name):
+            raise RuntimeError("network down")
+
+        # _registry_install_hint catches Exception internally; verify
+        # the wrapper actually returns None on failure and we fall
+        # through to the generic "not found" error.
+        monkeypatch.setattr(
+            "synth_panel.registry.resolve_pack",
+            lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("network down")),
+        )
+        # Direct probe returns None (offline-safe).
+        assert cmd_mod._registry_install_hint("anything") is None
+        # And the loader degrades to the generic error.
+        with pytest.raises(FileNotFoundError, match="not found as file or installed pack"):
+            _load_personas("not-a-real-pack-name")
+
     def test_merge_persona_lists_appends(self, tmp_path):
         extra = tmp_path / "extra.yaml"
         extra.write_text("personas:\n  - name: Carol\n    age: 40\n")


### PR DESCRIPTION
## Summary

Pre-1.5.2 `synthpanel panel run --personas developer --instrument
general-survey` failed with `File not found: developer` — `--instrument`
already accepted bundled / installed pack names, but `--personas` only
accepted file paths, so the names surfaced by `pack list` and `pack search`
were a trap on the run path. This PR teaches `--personas` the same
resolution order, with a targeted "you need to install this" hint for
known-but-uninstalled registry packs.

## Changes

- **`_load_personas(path_or_name)`** now mirrors `_load_instrument`'s resolution order:
  1. existing file → parse YAML,
  2. call `get_persona_pack()` so bundled wheel packs and user-saved packs in `~/.synthpanel/persona_packs/` resolve by id,
  3. consult the registry **best-effort** and, if the id is a known *registry* pack the user hasn't installed yet, raise a targeted error pointing at `synthpanel pack import <id>`,
  4. otherwise raise a generic "not found as file or installed pack" error that names the diagnostic commands (`pack list`, `pack search`).
- **`_registry_install_hint`** wraps the registry lookup and catches any exception, returning `None` so offline / network / parse failures fall through to the generic error rather than crashing the run.
- Same resolution applies transitively to `--personas-merge` since it funnels through `_load_personas`.

## Test plan

New coverage in `test_cli.py` for:
- bundled pack name resolves end-to-end,
- unknown-name error mentions pack-lookup commands,
- known registry id produces the install hint,
- the registry probe is offline-safe (network failure → generic error, not a crash).

## Verification

Reproduced the exact command from the bug report:

```
synthpanel panel run --personas developer \
    --instrument general-survey --dry-run
```

…now succeeds end-to-end instead of failing on the personas loader.

## References

- Bead: sy-n80
- Closes #508
- MR: sy-wisp-vdx
- Polecat: jasper-sy
- Branch: polecat/jasper-sy-n80