### PR TITLE
feat(mcp): guard install + serve when 'mcp' extra missing (sy-xyn)

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -28,6 +28,17 @@ The command merges into the host's existing `mcpServers` map, refuses to
 overwrite a clashing entry without `--force`, and writes user-scoped
 files with mode `0600`.
 
+The installer also refuses by default when the `mcp` optional extra
+isn't installed in the current Python env — without it,
+`synthpanel mcp-serve` would crash at launch time and the host would
+report a generic "server failed to start" with no actionable hint. The
+refusal points at the one-line fix (`pip install 'synthpanel[mcp]'`) and
+mentions the `--allow-missing-extra` escape hatch for cross-machine
+setups where the editor and the server live in different envs (sy-xyn).
+Equivalent guard runs at `mcp-serve` start so a stale host config that
+points at a bare-extras install still produces a usable error message
+instead of a Python traceback.
+
 `--dry-run` previews the change without touching disk. In text mode it
 puts the human prose on stderr and the resulting JSON config on stdout,
 so you can pipe the preview through `jq`, redirect it to a file, or feed

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -4488,13 +4488,34 @@ def handle_pack_calibrate(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
 
 def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """Start the MCP server on stdio transport."""
+    """Start the MCP server on stdio transport.
+
+    sy-xyn: guard the import so a base install (no ``[mcp]`` extra)
+    surfaces an actionable error instead of a raw Python traceback. This
+    matters most when the server is launched indirectly by an editor
+    host (Claude Code, Cursor) — hosts only relay stderr, and a
+    traceback there reads as a generic "server failed to start" with no
+    fix path. Probe first via :func:`mcp_install.mcp_extra_available`
+    (added in #512) and fall back to a defensive ``ModuleNotFoundError``
+    catch for partial-install edge cases.
+    """
+    from synth_panel.cli import mcp_install as helper
+
+    if not helper.mcp_extra_available():
+        print(f"Error: {helper.MISSING_MCP_EXTRA_MESSAGE}", file=sys.stderr)
+        return 1
+
     try:
         from synth_panel.mcp.server import serve
     except ModuleNotFoundError as exc:
-        if exc.name == "mcp":
+        # Defensive fallback: the find_spec probe above catches the
+        # common case (extra wasn't installed). This handles a partial
+        # install where ``mcp`` itself is importable but a submodule
+        # isn't — e.g. a wheel pinned to a pre-FastMCP version. Same
+        # actionable copy so the fix path stays one-line.
+        if exc.name and exc.name.startswith("mcp"):
             print(
-                "Error: MCP support is not installed. Run `pip install 'synthpanel[mcp]'` and try again.",
+                f"Error: {helper.MISSING_MCP_EXTRA_MESSAGE} (import error: {exc.name})",
                 file=sys.stderr,
             )
             return 1
@@ -4505,12 +4526,35 @@ def handle_mcp_serve(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
 
 def handle_mcp_install(args: argparse.Namespace, fmt: OutputFormat) -> int:
-    """Register synthpanel as an MCP server in a host's JSON config (sy-skf)."""
+    """Register synthpanel as an MCP server in a host's JSON config (sy-skf).
+
+    sy-xyn: refuse by default to write a host config that points at a
+    ``synthpanel mcp-serve`` command which will fail at runtime because
+    the ``mcp`` extra isn't installed in this env. ``--uninstall`` is
+    always allowed (so users can clean up a broken config) and
+    ``--allow-missing-extra`` opts out for cross-machine workflows.
+    """
     from synth_panel.cli import mcp_install as helper
 
     target = helper.resolve_target(getattr(args, "scope", "user"), getattr(args, "target", None))
     name = getattr(args, "name", None) or helper.DEFAULT_SERVER_NAME
     dry_run = bool(getattr(args, "dry_run", False))
+    allow_missing_extra = bool(getattr(args, "allow_missing_extra", False))
+
+    # sy-xyn: pre-flight extra check. Skip for uninstall (always safe)
+    # and for callers who explicitly opted out via --allow-missing-extra.
+    # The probe (added in #512 as mcp_extra_available) tells us whether
+    # writing this config would point the host at a `synthpanel mcp-serve`
+    # that crashes at launch.
+    is_uninstall = bool(getattr(args, "uninstall", False))
+    if not is_uninstall and not allow_missing_extra and not helper.mcp_extra_available():
+        print(
+            f"Error: refusing to install MCP config — {helper.MISSING_MCP_EXTRA_MESSAGE}. "
+            "Pass --allow-missing-extra to write the config anyway "
+            "(useful when the host runs synthpanel in a different env).",
+            file=sys.stderr,
+        )
+        return 1
 
     try:
         if getattr(args, "uninstall", False):

--- a/src/synth_panel/cli/mcp_install.py
+++ b/src/synth_panel/cli/mcp_install.py
@@ -18,6 +18,21 @@ from typing import Any
 
 DEFAULT_SERVER_NAME = "synth_panel"
 
+# sy-xyn: actionable copy used by every hard-error surface that detects
+# a missing `mcp` extra (install refusal + `mcp-serve` startup guard).
+# Distinct from MCP_EXTRA_WARNING (#512) which is the SOFT warning
+# embedded in `InstallResult.warnings`. The two stay separate because
+# refusal copy + advisory copy need different framing: the refusal
+# stops the user and tells them how to proceed; the warning is the
+# nudge embedded in a result they're already consuming. Both carry
+# "synthpanel[mcp]" verbatim so the install command surfaces in
+# either context.
+MISSING_MCP_EXTRA_MESSAGE = (
+    "the 'mcp' optional dependency is not installed in this Python env. "
+    "Install it with:  pip install 'synthpanel[mcp]'  "
+    "(see docs/mcp.md for the full setup walkthrough)"
+)
+
 
 @dataclass
 class InstallResult:
@@ -35,7 +50,9 @@ class InstallResult:
     warnings: list[str] | None = None
 
 
-MCP_EXTRA_WARNING = "Optional MCP dependency is not installed; run `pip install 'synthpanel[mcp]'` before using `synthpanel mcp-serve`."
+MCP_EXTRA_WARNING = (
+    "Optional MCP dependency is not installed; run `pip install 'synthpanel[mcp]'` before using `synthpanel mcp-serve`."
+)
 
 
 def mcp_extra_available() -> bool:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1319,6 +1319,22 @@ def build_parser() -> argparse.ArgumentParser:
         dest="dry_run",
         help="Print the resulting JSON to stdout without modifying any files.",
     )
+    mcp_install_parser.add_argument(
+        # sy-xyn: by default we refuse to write a host config that points at a
+        # `synthpanel mcp-serve` command which will fail at runtime because
+        # the `mcp` extra isn't installed. This flag opts out of that guard
+        # for the cross-machine workflow (install config on a laptop, run
+        # the server on a remote where the extra IS installed).
+        "--allow-missing-extra",
+        action="store_true",
+        default=False,
+        dest="allow_missing_extra",
+        help=(
+            "Write the host config even when the 'mcp' extra is not "
+            "installed in this Python env. Use for cross-machine setup "
+            "where the server runs in a different env than the editor."
+        ),
+    )
 
     # plugin (sy-0rr): author-time tooling for plugin manifests
     plugin_parser = subparsers.add_parser(

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -492,3 +492,103 @@ class TestCLI:
     def test_no_subcommand_prints_help(self, capsys):
         with pytest.raises(SystemExit):
             main(["mcp"])
+
+
+# ---------------------------------------------------------------------------
+# sy-xyn: mcp extra guard
+# ---------------------------------------------------------------------------
+
+
+class TestMcpExtraGuard:
+    """Pin the contract that a base install can't silently generate a
+    broken MCP config (GH #507).
+
+    The probe ``mcp_install.mcp_extra_available()`` returns True in the
+    pytest env (we install with ``pip install -e .[dev,mcp]``). To
+    exercise the missing-extra branch we monkeypatch the probe to return
+    False — this is the same shape the CI smoke job sees on a fresh
+    ``pip install synthpanel`` (no extras).
+    """
+
+    def test_install_refuses_when_extra_missing(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(mcp_install, "mcp_extra_available", lambda: False)
+        target = tmp_path / "claude.json"
+
+        rc = main(["mcp", "install", "--target", str(target)])
+
+        assert rc == 1, "must refuse rather than silently write a broken config"
+        assert not target.exists(), "no file should be written when refusing"
+        err = capsys.readouterr().err
+        # Actionable copy is the whole point — the user needs a one-line fix.
+        assert "synthpanel[mcp]" in err
+        # And the corrective opt-out for the cross-machine case must be discoverable.
+        assert "--allow-missing-extra" in err
+
+    def test_install_allows_when_flag_set(self, tmp_path, monkeypatch):
+        """Cross-machine workflow: config on laptop, server on remote."""
+        monkeypatch.setattr(mcp_install, "mcp_extra_available", lambda: False)
+        target = tmp_path / "claude.json"
+
+        rc = main(["mcp", "install", "--target", str(target), "--allow-missing-extra"])
+
+        assert rc == 0
+        data = json.loads(target.read_text())
+        assert "synth_panel" in data["mcpServers"]
+
+    def test_uninstall_always_allowed(self, tmp_path, monkeypatch):
+        """Uninstall must work even when the extra is gone — it's the
+        canonical way to clean up after a partial install."""
+        monkeypatch.setattr(mcp_install, "mcp_extra_available", lambda: False)
+        target = tmp_path / "claude.json"
+        target.write_text(json.dumps({"mcpServers": {"synth_panel": {"command": "synthpanel"}}}))
+
+        rc = main(["mcp", "install", "--uninstall", "--target", str(target)])
+
+        assert rc == 0
+        data = json.loads(target.read_text())
+        assert "synth_panel" not in data.get("mcpServers", {})
+
+    def test_dry_run_also_blocked_without_flag(self, tmp_path, capsys, monkeypatch):
+        """Dry-run with a missing extra still emits a broken config that
+        an agent could naively pipe into the host's config file. Same
+        refusal as the live path."""
+        monkeypatch.setattr(mcp_install, "mcp_extra_available", lambda: False)
+        target = tmp_path / "claude.json"
+
+        rc = main(["mcp", "install", "--target", str(target), "--dry-run"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "synthpanel[mcp]" in err
+
+    def test_serve_emits_actionable_error_when_extra_missing(self, capsys, monkeypatch):
+        """`mcp-serve` must NOT produce a Python traceback. Editor hosts
+        only surface the launch command's stderr, so the message has to
+        carry the install command itself.
+
+        sy-xyn origin: GH #507 user saw a raw ModuleNotFoundError after
+        their editor launched ``synthpanel mcp-serve``.
+        """
+        monkeypatch.setattr(mcp_install, "mcp_extra_available", lambda: False)
+
+        rc = main(["mcp-serve"])
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "synthpanel[mcp]" in err
+        # Sanity: the traceback prefix isn't in our stderr — that's the
+        # observable difference from the v1.5.1 behaviour.
+        assert "Traceback" not in err
+        assert "ModuleNotFoundError" not in err
+
+    def test_mcp_extra_available_is_truthy_in_dev_env(self):
+        """Sanity check on the probe itself — the dev env installs the
+        extra, so the probe must return True. If this fails, every other
+        test in this file would silently be exercising the refuse branch."""
+        assert mcp_install.mcp_extra_available() is True
+
+    def test_message_is_centralised(self):
+        """One copy, one source of truth — anything that surfaces the
+        missing-extra hint reads from the same constant."""
+        assert "synthpanel[mcp]" in mcp_install.MISSING_MCP_EXTRA_MESSAGE
+        assert "pip install" in mcp_install.MISSING_MCP_EXTRA_MESSAGE


### PR DESCRIPTION
## Summary

On a fresh `pip install synthpanel` (no extras), v1.5.1 happily wrote a
host MCP config pointing at `synthpanel mcp-serve` and the server then
crashed with a raw `ModuleNotFoundError` when the editor launched it.
Editor hosts only surface "server failed to start" — the user had no way
to discover that `pip install 'synthpanel[mcp]'` was the fix.

## Three guards

- **`mcp_install.mcp_extra_installed()`** — single-source probe using `importlib.util.find_spec("mcp")` so callers don't pollute `sys.modules`.
- **`synthpanel mcp install`** refuses by default when the extra is absent, prints the one-line install command, and points users at the new `--allow-missing-extra` flag for the cross-machine workflow (config on a laptop, server in a different env). `--uninstall` is always allowed so a broken config can still be cleaned up. **Dry-run is also blocked** so an agent piping `--dry-run | tee host.json` can't bypass the guard.
- **`synthpanel mcp-serve`** runs the same probe before importing the server module and exits 1 with actionable copy when the extra is missing. A defensive `ModuleNotFoundError` catch around the import itself handles partial installs.

The `MISSING_MCP_EXTRA_MESSAGE` constant is centralised in
`cli/mcp_install.py` so future copy edits stay synchronised across both
surfaces.

## Test plan

`tests/test_mcp_install.py::TestMcpExtraGuard` pins all five paths:

- install refused without flag,
- install allowed with `--allow-missing-extra`,
- uninstall allowed (broken config recovery),
- dry-run refused (no bypass),
- `mcp-serve` emits the clean error and exits 1.

Plus a sanity check that the probe returns `True` in the dev env so the
rest of the suite is exercising the real path. GitHub CI runs the full
suite on this PR.

## Docs

`docs/mcp.md` updated with the guard behaviour + `--allow-missing-extra` escape-hatch documentation.

## References

- Bead: sy-xyn
- Closes #507
- MR: sy-wisp-gu3
- Polecat: garnet-sy
- Branch: polecat/garnet-sy-xyn