### PR TITLE
feat(synthbench): tag --best-model-for recommendations with provenance source (sy-klp)

### DIFF
--- a/docs/recommended-models.md
+++ b/docs/recommended-models.md
@@ -25,8 +25,25 @@ Before the run, SynthPanel prints a recommendation line to stderr so you
 can cancel and override:
 
 ```
-synthbench: best model for globalopinionqa/Economy & Work → claude-haiku-4-5-20251001 · SPS 0.850 · JSD 0.091 · n=100 · $0.032/100q · cached 0h ago · source=synthbench.org
+synthbench: best model for globalopinionqa/Economy & Work → claude-haiku-4-5-20251001 · SPS 0.850 · JSD 0.091 · n=100 · $0.032/100q · cached 0h ago · source=live
 ```
+
+The trailing `source=` field is the **provenance discriminator** (sy-klp).
+It tells you — and any agent parsing this line — whether the
+recommendation reflects the live leaderboard, your local cache, or a
+package-bundled fallback:
+
+| `source=` value     | What it means                                                                                       | How current is the recommendation? |
+|---------------------|-----------------------------------------------------------------------------------------------------|------------------------------------|
+| `live`              | Fetched from the leaderboard URL this run — or upstream returned 304 confirming the cache is current | As of right now                    |
+| `cache`             | User's on-disk cache was fresh (< 24h), no network call made                                         | Within the last 24h                |
+| `stale-cache`       | Cache exceeded the 24h TTL and the network fetch failed; stale cache used                            | Whenever the cache was last refreshed (see `cached <N>h ago` field) |
+| `bundled-snapshot`  | No user cache and the live fetch failed (or offline mode requested without a cache) — package fallback used | The package release date (currently 2026-04-24) — *not* current |
+
+Agents should treat `live` and `cache` as authoritative, `stale-cache`
+as user-dated (caller's last successful sync), and `bundled-snapshot`
+as package-dated — same age for everyone on the same release, so the
+recommendation will drift from leaderboard reality after the snapshot.
 
 ## How it works
 
@@ -62,18 +79,70 @@ synthbench: best model for globalopinionqa/Economy & Work → claude-haiku-4-5-2
 
 ### Graceful offline behaviour
 
-- **Stale cache + network error** → stderr warning, use stale cache.
+Every degraded path tags the recommendation with a non-`live` `source=`
+discriminator (see the table above) and prints a one-line explanation
+on stderr so agents and humans can both see how degraded the answer is.
+
+- **Fresh cache hit (< 24h)** → no network. Recommendation tagged
+  `source=cache`. No stderr noise.
+- **Stale cache + 304** → conditional GET confirms cache is current.
+  Recommendation tagged `source=live` and the cache timestamp is
+  refreshed. No stderr noise.
+- **Stale cache + network error** → stderr `synthpanel: synthbench
+  fetch failed (…); using stale cache from <ISO> (source=stale-cache)`.
+  Recommendation tagged `source=stale-cache`.
 - **No cache + network error** → bundled snapshot fallback (sy-nkh):
-  stderr "synthbench unavailable — using bundled snapshot from
-  YYYY-MM-DD …" plus the `SYNTHPANEL_SYNTHBENCH_URL` override hint, then
-  a real recommendation derived from the package data.
+  stderr `synthpanel: synthbench unavailable (…); using bundled
+  snapshot from YYYY-MM-DD (source=bundled-snapshot) — override the URL
+  via $SYNTHPANEL_SYNTHBENCH_URL if you have a mirror …`. Recommendation
+  tagged `source=bundled-snapshot` and the CLI also emits a follow-up
+  note explaining the implication and the override path.
+- **Offline mode + fresh cache** → recommendation tagged
+  `source=cache`. No stderr noise.
+- **Offline mode + stale cache** → recommendation tagged
+  `source=stale-cache`. No stderr noise (offline mode is opt-in; the
+  user already knows network is disabled).
+- **Offline mode + no cache** → bundled snapshot fallback with
+  `source=bundled-snapshot`. Stderr explains the fallback once.
 - **No cache + no bundled snapshot** → stderr "synthbench unavailable",
   fall through to whatever `--model` or default was already in effect.
 - **Empty entries after filter** → same fall-through.
 
 No recommendation is ever fatal. `--best-model-for` is advisory: a bad
 network day won't take the panel down, and a 404'ing upstream URL still
-yields a sensible default via the bundled snapshot.
+yields a sensible default via the bundled snapshot — at the cost of
+freshness, which the `source=bundled-snapshot` discriminator makes
+explicit instead of pretending the data is current.
+
+### Reading the source field from code
+
+The wire field is part of the public `synth_panel.synthbench`
+surface — `Recommendation.source` and `LoadedLeaderboard.source` both
+expose the same closed enum. Allowed values are exported as
+`synth_panel.synthbench.RECOMMENDATION_SOURCES`:
+
+```python
+from synth_panel import synthbench
+
+rec = synthbench.recommend("Economy & Work")
+if rec is None:
+    ...  # leaderboard unavailable; honour the existing --model
+elif rec.source in ("live", "cache"):
+    use_with_confidence(rec.model)
+elif rec.source == "stale-cache":
+    log_warning(f"using model from cache aged {rec.cache_age_hours:.0f}h")
+    use_with_confidence(rec.model)
+elif rec.source == "bundled-snapshot":
+    log_warning(
+        f"recommendation from package snapshot dated {rec.fetched_at.date()}; "
+        "current leaderboard may have moved."
+    )
+    use_with_caveat(rec.model)
+```
+
+The same `source=` field appears at the tail of every stderr
+recommendation line (`format_line()` output), so log-scraping agents
+can extract it with one regex.
 
 ## Use-case → top-ranked model
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -195,6 +195,21 @@ def _apply_best_model_for(args: argparse.Namespace, spec: str) -> str | None:
         return None
 
     print(rec.format_line(), file=sys.stderr)
+    if rec.source == "bundled-snapshot":
+        print(
+            "synthbench: note — recommendation derived from the package-bundled "
+            "snapshot, not live leaderboard data. Treat as best-effort; for current "
+            f"picks once the upstream is reachable, unset ${synthbench.SYNTHBENCH_OFFLINE_ENV} "
+            f"and clear the cache, or set ${synthbench.SYNTHBENCH_URL_ENV} to a working mirror.",
+            file=sys.stderr,
+        )
+    elif rec.source == "stale-cache":
+        print(
+            "synthbench: note — recommendation from stale cache (live fetch failed). "
+            f"Set ${synthbench.SYNTHBENCH_REFRESH_ENV}=1 on the next run to retry once "
+            "the upstream is reachable.",
+            file=sys.stderr,
+        )
     if rec.low_confidence:
         print(
             f"synthbench: warning — recommendation has run_count={rec.run_count} "

--- a/src/synth_panel/synthbench.py
+++ b/src/synth_panel/synthbench.py
@@ -93,6 +93,16 @@ class Recommendation:
     fetched_at: datetime
     cache_age_hours: float
     low_confidence: bool
+    source: str = "live"
+    """Provenance discriminator — one of :data:`RECOMMENDATION_SOURCES`.
+
+    Agents should branch on this to decide how to phrase the
+    recommendation in downstream prose: ``live`` and ``cache`` reflect
+    current upstream data; ``stale-cache`` reflects the user's last
+    successful fetch (potentially old); ``bundled-snapshot`` reflects
+    the package release date and predates any post-release leaderboard
+    movement. See ``docs/recommended-models.md`` for the full table.
+    """
 
     def format_line(self) -> str:
         """Render a one-line summary suitable for stderr."""
@@ -109,7 +119,7 @@ class Recommendation:
             parts.append(f"${self.cost_per_100q:.3f}/100q")
         age = max(0, int(self.cache_age_hours))
         parts.append(f"cached {age}h ago")
-        parts.append("source=synthbench.org")
+        parts.append(f"source={self.source}")
         return " · ".join(parts)
 
 
@@ -290,10 +300,38 @@ def _fetch_http(
             active.close()
 
 
+RECOMMENDATION_SOURCES: tuple[str, ...] = (
+    "live",
+    "cache",
+    "stale-cache",
+    "bundled-snapshot",
+)
+"""Closed enum of provenance labels emitted alongside a recommendation.
+
+- ``live`` — the leaderboard was fetched over HTTP this run (or the
+  upstream returned 304 confirming the cached copy is still current).
+- ``cache`` — the user's on-disk cache was fresh (< ``CACHE_TTL``), so
+  no network call happened.
+- ``stale-cache`` — the user's cache exceeded its TTL and the network
+  fetch failed; the stale cache was used as a fallback.
+- ``bundled-snapshot`` — the package-bundled snapshot was used because
+  no user cache existed and the live fetch failed (or offline mode was
+  requested without a user cache).
+
+Agents inspecting the recommendation should treat ``live`` and ``cache``
+as current, ``stale-cache`` as user-dated, and ``bundled-snapshot`` as
+package-dated. See ``docs/recommended-models.md``.
+"""
+
+
 @dataclass(frozen=True)
 class LoadedLeaderboard:
     leaderboard: dict[str, Any]
     fetched_at: datetime
+    source: str = "live"
+    """One of :data:`RECOMMENDATION_SOURCES`. Defaults to ``"live"`` so
+    test fixtures that construct ``LoadedLeaderboard`` directly without
+    going through :func:`load_leaderboard` keep their existing shape."""
 
 
 def load_leaderboard(
@@ -325,7 +363,13 @@ def load_leaderboard(
 
     if offline_flag:
         if cached is not None:
-            return LoadedLeaderboard(cached.leaderboard, cached.fetched_at)
+            # Offline + cache hit: data is from the user's cache, even
+            # if it's older than CACHE_TTL — there's no way to refresh
+            # while offline. Tag as ``cache`` if it's still fresh by TTL
+            # standards, ``stale-cache`` otherwise so agents can decide
+            # whether to trust the recommendation.
+            label = "cache" if _is_fresh(cached) else "stale-cache"
+            return LoadedLeaderboard(cached.leaderboard, cached.fetched_at, source=label)
         # sy-nkh: offline mode previously gave up entirely without a cache;
         # surface the bundled snapshot here too so air-gapped users get a
         # usable recommendation on the first ever call.
@@ -335,14 +379,14 @@ def load_leaderboard(
             emit(
                 f"synthpanel: synthbench offline mode with no user cache — "
                 f"using bundled snapshot from {snapshot_at.date().isoformat()} "
-                f"(see docs/recommended-models.md)"
+                f"(source=bundled-snapshot; see docs/recommended-models.md)"
             )
-            return LoadedLeaderboard(data, snapshot_at)
+            return LoadedLeaderboard(data, snapshot_at, source="bundled-snapshot")
         return None
 
     url_matches = cached is not None and cached.source_url == target_url
     if cached is not None and url_matches and not refresh_flag and _is_fresh(cached):
-        return LoadedLeaderboard(cached.leaderboard, cached.fetched_at)
+        return LoadedLeaderboard(cached.leaderboard, cached.fetched_at, source="cache")
 
     conditional_etag: str | None = None
     if cached is not None and url_matches and not refresh_flag:
@@ -354,8 +398,11 @@ def load_leaderboard(
         )
     except SynthBenchFetchError as exc:
         if cached is not None:
-            emit(f"synthpanel: synthbench fetch failed ({exc}); using stale cache from {cached.fetched_at.isoformat()}")
-            return LoadedLeaderboard(cached.leaderboard, cached.fetched_at)
+            emit(
+                f"synthpanel: synthbench fetch failed ({exc}); using stale cache from "
+                f"{cached.fetched_at.isoformat()} (source=stale-cache)"
+            )
+            return LoadedLeaderboard(cached.leaderboard, cached.fetched_at, source="stale-cache")
         # sy-nkh: no cache + network error → bundled snapshot fallback.
         # The canonical URL has been 404 since v1.5.0 ship (GH #494) so
         # without this, every fresh install's --best-model-for is a
@@ -366,22 +413,26 @@ def load_leaderboard(
             data_snap, snapshot_at = bundled
             emit(
                 f"synthpanel: synthbench unavailable ({exc}); "
-                f"using bundled snapshot from {snapshot_at.date().isoformat()} — "
-                f"{_override_hint(target_url)}"
+                f"using bundled snapshot from {snapshot_at.date().isoformat()} "
+                f"(source=bundled-snapshot) — {_override_hint(target_url)}"
             )
-            return LoadedLeaderboard(data_snap, snapshot_at)
+            return LoadedLeaderboard(data_snap, snapshot_at, source="bundled-snapshot")
         emit(f"synthpanel: synthbench unavailable ({exc}) and no bundled snapshot found; {_override_hint(target_url)}")
         return None
 
     if not_modified and cached is not None:
+        # 304 confirms the cached copy is still authoritative as of this
+        # moment — treat as ``live`` so agents see the upstream
+        # acknowledged it, not as ``cache`` (which would imply we never
+        # talked to the upstream this run).
         now = datetime.now(timezone.utc)
         write_cache(cached.leaderboard, source_url=target_url, etag=cached.etag, fetched_at=now)
-        return LoadedLeaderboard(cached.leaderboard, now)
+        return LoadedLeaderboard(cached.leaderboard, now, source="live")
 
     assert data is not None
     now = datetime.now(timezone.utc)
     write_cache(data, source_url=target_url, etag=new_etag, fetched_at=now)
-    return LoadedLeaderboard(data, now)
+    return LoadedLeaderboard(data, now, source="live")
 
 
 # ---------- recommendation logic ----------
@@ -530,12 +581,14 @@ def recommend(
     """
     topic, dataset = parse_target(spec)
 
+    source = "live"
     if leaderboard is None:
         loaded = load_leaderboard(client=client, url=url, refresh=refresh, offline=offline, warn=warn)
         if loaded is None:
             return None
         leaderboard = loaded.leaderboard
         fetched_at = loaded.fetched_at
+        source = loaded.source
     if fetched_at is None:
         fetched_at = datetime.now(timezone.utc)
 
@@ -575,4 +628,5 @@ def recommend(
         fetched_at=fetched_at,
         cache_age_hours=cache_age_hours,
         low_confidence=run_count > 0 and run_count < MIN_RUN_COUNT,
+        source=source,
     )

--- a/tests/test_synthbench_recommend.py
+++ b/tests/test_synthbench_recommend.py
@@ -256,7 +256,21 @@ def test_recommend_format_line_has_expected_pieces() -> None:
     assert "synthbench" in line
     assert "claude-haiku-4-5-20251001" in line
     assert "SPS" in line
-    assert "source=synthbench.org" in line
+    # Default for direct-leaderboard callers (no load_leaderboard hop) is "live"
+    # so existing fixtures continue to render a wire-stable source= field.
+    assert "source=live" in line
+
+
+def test_recommend_format_line_source_reflects_recommendation_source() -> None:
+    """Wire format: format_line() must surface the source the agent reads."""
+    from synth_panel.synthbench import Recommendation
+
+    base = recommend("Economy & Work", leaderboard=SAMPLE)
+    assert base is not None
+    for source in ("live", "cache", "stale-cache", "bundled-snapshot"):
+        rec = Recommendation(**{**base.__dict__, "source": source})
+        line = rec.format_line()
+        assert f"source={source}" in line, line
 
 
 # ---------- load_leaderboard (cache + network) ----------
@@ -268,6 +282,7 @@ def test_fresh_cache_hit_skips_network() -> None:
         loaded = load_leaderboard(client=client)
     assert loaded is not None
     assert loaded.leaderboard == SAMPLE
+    assert loaded.source == "cache"
 
 
 def test_stale_cache_304_keeps_cached_leaderboard() -> None:
@@ -282,6 +297,8 @@ def test_stale_cache_304_keeps_cached_leaderboard() -> None:
         loaded = load_leaderboard(client=client)
     assert loaded is not None
     assert loaded.leaderboard == SAMPLE
+    # 304 confirmed the cached copy is still current upstream — treat as live.
+    assert loaded.source == "live"
     cached = read_cache()
     assert cached is not None
     assert (datetime.now(timezone.utc) - cached.fetched_at) < timedelta(minutes=1)
@@ -299,6 +316,7 @@ def test_stale_cache_200_overwrites_with_new_payload() -> None:
         loaded = load_leaderboard(client=client)
     assert loaded is not None
     assert loaded.leaderboard == updated
+    assert loaded.source == "live"
     cached = read_cache()
     assert cached is not None
     assert cached.etag == '"new"'
@@ -316,7 +334,9 @@ def test_stale_cache_network_fail_returns_stale_with_warning() -> None:
         loaded = load_leaderboard(client=client, warn=warnings.append)
     assert loaded is not None
     assert loaded.leaderboard == SAMPLE
+    assert loaded.source == "stale-cache"
     assert any("stale cache" in w for w in warnings)
+    assert any("source=stale-cache" in w for w in warnings)
 
 
 def test_no_cache_and_fetch_fail_returns_none(no_bundled_snapshot: None) -> None:
@@ -358,6 +378,17 @@ def test_offline_env_prevents_any_network(monkeypatch: pytest.MonkeyPatch) -> No
         loaded = load_leaderboard(client=client)
     assert loaded is not None
     assert loaded.leaderboard == SAMPLE
+    # 48h-old cache + offline → stale-cache, since CACHE_TTL is 24h.
+    assert loaded.source == "stale-cache"
+
+
+def test_offline_with_fresh_cache_reports_cache_source(monkeypatch: pytest.MonkeyPatch) -> None:
+    write_cache(SAMPLE, source_url=URL, etag='"abc"')  # default fetched_at = now
+    monkeypatch.setenv(SYNTHBENCH_OFFLINE_ENV, "1")
+    with _client(_explode) as client:
+        loaded = load_leaderboard(client=client)
+    assert loaded is not None
+    assert loaded.source == "cache"
 
 
 def test_offline_with_no_cache_returns_none(
@@ -433,7 +464,12 @@ class TestBundledSnapshotFallback:
 
         assert loaded is not None, "bundled snapshot must rescue the fresh-install path"
         assert isinstance(loaded.leaderboard.get("entries"), list)
+        assert loaded.source == "bundled-snapshot"
         assert any("bundled snapshot" in w for w in warnings), warnings
+        # Wire format: the source discriminator must appear in the
+        # warning so agents grep-parsing stderr can distinguish this
+        # path from stale-cache.
+        assert any("source=bundled-snapshot" in w for w in warnings), warnings
         # The actionable override hint travels alongside the fallback so
         # users with a working mirror know how to switch to it.
         assert any("SYNTHPANEL_SYNTHBENCH_URL" in w for w in warnings), warnings
@@ -461,6 +497,11 @@ class TestBundledSnapshotFallback:
         assert rec.model, "bundled entry must expose a non-empty model string"
         assert rec.sps > 0
         assert rec.dataset == "globalopinionqa"
+        # Provenance must propagate so format_line() / agent consumers
+        # can render the recommendation honestly instead of claiming
+        # source=synthbench.org for snapshot-derived data (sy-klp).
+        assert rec.source == "bundled-snapshot"
+        assert "source=bundled-snapshot" in rec.format_line()
 
     def test_bundled_snapshot_handles_known_topics(self) -> None:
         """Every topic mentioned in docs/recommended-models.md must
@@ -518,6 +559,7 @@ class TestBundledSnapshotFallback:
             loaded = load_leaderboard(client=client, warn=warnings.append)
         assert loaded is not None
         assert loaded.leaderboard == SAMPLE
+        assert loaded.source == "stale-cache"
         # The "stale cache" path is the explicit prior message — the
         # bundled-snapshot warning must NOT also fire.
         assert any("stale cache" in w for w in warnings)


### PR DESCRIPTION
## Summary

Threads a `source` discriminator through the `--best-model-for` pipeline so agents (and humans) can tell whether the stderr recommendation reflects the live leaderboard, the user's cache, or the package-bundled snapshot.

Hermes-filed (#511) — in v1.5.1 the fallback already worked (bundled snapshot rescued the 404 endpoint), but the stderr line claimed `source=synthbench.org` regardless of where the data came from. That made the warning effectively unparseable: agents had no honest discriminator and the recommendation line *contradicted* the fallback message that printed two lines above it.

## Acceptance criteria — addressed

- [x] **Fallback message clearly distinguishes live, cached, bundled snapshot, and override URL modes.** New \`RECOMMENDATION_SOURCES = ("live", "cache", "stale-cache", "bundled-snapshot")\` closed enum. Every \`load_leaderboard\` branch returns the correct label.
- [x] **Docs explain \`SYNTHPANEL_SYNTHBENCH_URL\`, refresh/cache behavior, and offline behavior.** \`docs/recommended-models.md\` now has a complete table for the source field, an enumerated "Graceful offline behaviour" list covering every (cache × network × offline) combination, and a code example for the typed \`Recommendation.source\` field.
- [x] **If using a bundled snapshot, output includes enough provenance for agents to report that fact.** \`Recommendation.format_line()\` emits \`source=bundled-snapshot\`; the CLI prints a follow-up note explaining the implication and the env-var override; the stderr warning embeds \`source=bundled-snapshot\` for log-scraping agents.

## Changes

- \`src/synth_panel/synthbench.py\`: new \`RECOMMENDATION_SOURCES\` enum; new \`LoadedLeaderboard.source\` and \`Recommendation.source\` fields; every \`load_leaderboard\` return path tags the result; \`format_line()\` reads from the field instead of hardcoding; warning strings embed the discriminator.
- \`src/synth_panel/cli/commands.py\`: one-line CLI clarifier when source is \`bundled-snapshot\` or \`stale-cache\`, pointing at the relevant env-var override.
- \`docs/recommended-models.md\`: full source-field table, expanded offline-behaviour list, code example.
- \`tests/test_synthbench_recommend.py\`: parameterized \`format_line\` coverage across all four sources; source-discriminator assertions on every \`load_leaderboard\` path (fresh-cache, 304, 200, stale-cache, offline, bundled-snapshot).

## Test plan

- [x] \`ruff check src/ tests/\` passes locally
- [x] Python syntax check on all modified files
- [x] Local synthbench tests fail to collect due to project's Python 3.10+ requirement; CI will run on 3.10–3.14 across 7 jobs.
- [ ] CI: lint, typecheck, security, site-cli-sync, all \`test (3.10..3.14)\` green

## References

- Bead: sy-klp
- GH issue: #511
- Target release: v1.5.2
- Related: upstream SynthBench leaderboard 404 — https://github.com/DataViking-Tech/SynthBench/issues/295 (independent fix on the SynthBench side; this PR closes the SynthPanel-side surface gap).

Closes #511