### PR TITLE
fix(poll-summary): respect declared question types (sy-oyl)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ## [Unreleased]
 
+### Fixed
+
+- **`poll-summary` respects declared question types (sy-oyl).** Open-text
+  questions whose prompt or responses contain numbers (e.g. version
+  strings like *"SynthPanel v1.5.1"*) are no longer misclassified as
+  scale questions. The classification probe (`_looks_numeric`) now
+  requires the *whole* response to be a numeric scale answer (`"4"`,
+  `"4/5"`, `"rating: 4"`) instead of pulling the first digit out of
+  arbitrary prose. Mixed open-text + scale instruments produce
+  `metric_average` / `metric_distribution` only for the bounded
+  question. `save_panel_result` now also persists the question list
+  with its `response_schema` on the SDK's `quick_poll`, single-round,
+  and multi-round paths so a reloaded saved result carries declared
+  question types through `poll-summary`.
+
 ### Added
 
 - **`synthpanel doctor --install-only` (sy-e28).** Validates package,

--- a/src/synth_panel/poll_summary.py
+++ b/src/synth_panel/poll_summary.py
@@ -924,6 +924,16 @@ def _looks_numeric(per_panelist: list[dict[str, Any]]) -> bool:
     response is a dict carrying both a categorical choice and a numeric
     confidence. Letting the confidence drive the "looks numeric" probe
     would misclassify the whole question as ``scale`` and bury the vote.
+
+    sy-oyl: this is a *classification* probe — it decides whether a
+    question without a schema is a scale. We must NOT extract numbers
+    greedily from arbitrary prose here, or any free-text answer mentioning
+    a version string ("SynthPanel v1.5.1…") gets classified as a scale
+    response. :func:`_response_is_scale_shaped` only accepts responses
+    whose entire string is a numeric scale answer (``"4"``, ``"4/5"``,
+    ``"rating: 4"``) — the post-classification scorer
+    (:func:`_extract_score`) keeps its lenient regex so legitimately-
+    classified scale runs still accept verbose answers.
     """
     numeric = 0
     seen = 0
@@ -937,9 +947,71 @@ def _looks_numeric(per_panelist: list[dict[str, Any]]) -> bool:
         # enum check downstream.
         if isinstance(rd.get("response"), dict):
             continue
-        if _extract_score(rd) is not None:
+        if _response_is_scale_shaped(rd):
             numeric += 1
     return seen > 0 and numeric / seen > 0.5
+
+
+# sy-oyl: the classification-time scale gate. A scale answer is the
+# *whole* response, not a digit buried inside a sentence. Accepted shapes:
+#
+#   "4"                  bare integer
+#   "4.5"                bare decimal
+#   "-4"                 negative scale (rare but valid for delta/Likert)
+#   "4/5"                fraction
+#   "4 out of 5"         English fraction
+#   "rating: 4"          short labelled answer
+#   "score = 4 / 5"      labelled fraction with light prose
+#
+# Rejected (the bug we're fixing):
+#
+#   "SynthPanel v1.5.1 would absolutely feel agent-ready…"  (text + version)
+#   "The fourth one, around 7/10 confidence overall."        (essay)
+#
+# The 32-character cap on the *raw* response is what enforces "this is
+# meant to be a scale, not an essay". Labels like ``score:`` / ``rating:``
+# / ``confidence:`` are stripped before the cap so the realistic short
+# forms still match.
+_SCALE_LABEL_PREFIX_RE = re.compile(
+    r"^\s*(?:rating|score|confidence|value|answer)\s*[:=]\s*",
+    re.IGNORECASE,
+)
+_SCALE_RESPONSE_RE = re.compile(
+    r"^\s*-?\d+(?:\.\d+)?(?:\s*(?:/|out\s+of)\s*\d+)?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _response_is_scale_shaped(response_dict: dict[str, Any]) -> bool:
+    """True iff the response, taken whole, is a numeric scale answer (sy-oyl).
+
+    See :data:`_SCALE_RESPONSE_RE` for the accepted shapes. Numeric
+    scalars and bare ``int``/``float`` values always pass; booleans and
+    dicts always fail. String responses must match the strict pattern
+    after stripping a leading ``rating: `` / ``score = `` label and must
+    fit inside the 32-character "this is a scale answer, not prose" cap.
+
+    Extraction-only scoring (``{"extraction": {"score": 4}}``) also
+    counts — that's the canonical structured-scale shape.
+    """
+    raw = response_dict.get("response")
+    if isinstance(raw, bool):
+        # Same booleans-aren't-numbers stance as ``_coerce_number``.
+        return False
+    if isinstance(raw, (int, float)):
+        return True
+    if isinstance(raw, str):
+        stripped = _SCALE_LABEL_PREFIX_RE.sub("", raw).strip()
+        return len(stripped) <= 32 and _SCALE_RESPONSE_RE.match(stripped) is not None
+
+    # No bare scalar — look for an extracted score on a free-text response.
+    extraction = response_dict.get("extraction")
+    if isinstance(extraction, dict):
+        for key in _SCORE_KEYS:
+            v = extraction.get(key)
+            if not isinstance(v, bool) and isinstance(v, (int, float)):
+                return True
+    return False
 
 
 def _looks_enum(per_panelist: list[dict[str, Any]]) -> bool:

--- a/src/synth_panel/sdk.py
+++ b/src/synth_panel/sdk.py
@@ -843,6 +843,10 @@ def quick_poll(
         total_cost=total_cost.format_usd(),
         persona_count=len(merged),
         question_count=1,
+        # sy-oyl: thread the question (and its response_schema if any)
+        # into the saved JSON so a reloaded result preserves type info
+        # for poll_summary's _detect_kind.
+        questions=questions,
         synthesis=synthesis_dict,
     )
 
@@ -1077,6 +1081,13 @@ def run_panel(
         # base64 blobs (79 MB at 15p x 10 images in the 2026-05-09 dogfood).
         attachment_refs = _extract_attachment_refs(instrument_obj, flat_results)
 
+        # sy-oyl: flatten every round's questions in declaration order so
+        # the saved JSON carries per-question response_schema metadata —
+        # poll_summary needs it to avoid classifying open-text questions
+        # as scales just because the prose mentioned a number.
+        flat_questions: list[dict[str, Any]] = []
+        for r in instrument_obj.rounds:
+            flat_questions.extend(r.questions)
         result_id = save_panel_result(
             results=flat_results,
             model=model,
@@ -1084,6 +1095,7 @@ def run_panel(
             total_cost=total_cost.format_usd(),
             persona_count=len(merged),
             question_count=total_question_count,
+            questions=flat_questions,
             synthesis=final_synth_dict,
             attachments=attachment_refs or None,
         )
@@ -1179,6 +1191,9 @@ def run_panel(
         persona_count=len(merged),
         question_count=len(normalised_questions),
         variant_count=variant_count,
+        # sy-oyl: preserve per-question response_schema so poll_summary
+        # can respect declared question types after reload.
+        questions=normalised_questions,
         synthesis=synthesis_dict,
         attachments=attachment_refs or None,
     )

--- a/tests/test_poll_summary.py
+++ b/tests/test_poll_summary.py
@@ -276,6 +276,113 @@ class TestFreeTextQuestions:
         assert q0.first_choice_counts is None
         assert q0.metric_average is None
 
+    def test_text_question_with_version_string_in_response_stays_text(self) -> None:
+        """sy-oyl: free-text answers that mention a version string ('v1.5.1')
+        must not classify the question as a scale. The bug: ``_looks_numeric``
+        used the lenient ``_coerce_number`` regex which greedily pulled the
+        first digit out of any string, so every panelist's prose response
+        looked like a scale answer of ~1.0 and the question was reported as
+        ``kind=scale, average=1.50``.
+        """
+        env: dict[str, object] = {
+            "persona_count": 2,
+            # Schema explicitly says text. _detect_kind has always honored
+            # this — the regression here is that the same envelope without
+            # the schema (or with the schema stripped during persistence)
+            # was classifying as scale via inference.
+            "questions": [{"text": "Would SynthPanel v1.5.1 feel agent-ready?"}],
+            "results": [
+                {
+                    "persona": "A",
+                    "responses": [
+                        {
+                            "question": "Would SynthPanel v1.5.1 feel agent-ready?",
+                            "response": (
+                                "Yes — SynthPanel v1.5.1 has the discovery affordances "
+                                "agents need, especially MCP install."
+                            ),
+                        }
+                    ],
+                },
+                {
+                    "persona": "B",
+                    "responses": [
+                        {
+                            "question": "Would SynthPanel v1.5.1 feel agent-ready?",
+                            "response": (
+                                "Almost. v1.5.1 needs a clearer agent quickstart before I'd call it agent-ready."
+                            ),
+                        }
+                    ],
+                },
+            ],
+        }
+        summary = build_poll_summary(env)
+        q0 = summary.questions[0]
+        # The whole point: kind must be text. average/distribution must be absent.
+        assert q0.kind == "text"
+        assert q0.metric_average is None
+        assert q0.metric_distribution is None
+
+    def test_mixed_text_and_scale_only_scale_gets_average(self) -> None:
+        """sy-oyl AC: mixed-instrument runs (open-text q1 + scale q2) report
+        average/distribution only for the bounded question.
+        """
+        env: dict[str, object] = {
+            "persona_count": 3,
+            "questions": [
+                {"text": "Would SynthPanel v1.5.1 feel agent-ready?", "response_schema": {"type": "text"}},
+                {"text": "Confidence (1-5)?", "response_schema": {"type": "scale", "min": 1, "max": 5}},
+            ],
+            "results": [
+                {
+                    "persona": p,
+                    "responses": [
+                        {
+                            "question": "Would SynthPanel v1.5.1 feel agent-ready?",
+                            "response": text,
+                        },
+                        {"question": "Confidence (1-5)?", "response": str(score)},
+                    ],
+                }
+                for p, text, score in [
+                    ("A", "Yes, v1.5.1 ships the right MCP install affordances.", 5),
+                    ("B", "Almost — v1.5.1 still needs a clearer quickstart.", 4),
+                    ("C", "No, v1.5.1 is missing structured-polling defaults.", 3),
+                ]
+            ],
+        }
+        summary = build_poll_summary(env)
+        q0, q1 = summary.questions
+        # Open-text: no scale numbers extracted from the prose.
+        assert q0.kind == "text"
+        assert q0.metric_average is None
+        assert q0.metric_distribution is None
+        # Scale: real 1-5 confidence with the expected histogram.
+        assert q1.kind == "scale"
+        assert q1.metric_average == 4.0
+        assert q1.metric_distribution == {"3": 1, "4": 1, "5": 1}
+
+    def test_short_numeric_string_still_classifies_as_scale(self) -> None:
+        """sy-oyl: the strict-numeric gate must still accept legitimately-
+        scale-shaped string responses (``"4"``, ``"4/5"``, ``"rating: 4"``).
+        """
+        env: dict[str, object] = {
+            "persona_count": 4,
+            "questions": [{"text": "Rate the demo 1-5"}],
+            "results": [
+                {"persona": "A", "responses": [{"question": "Rate the demo 1-5", "response": "5"}]},
+                {"persona": "B", "responses": [{"question": "Rate the demo 1-5", "response": "4/5"}]},
+                {"persona": "C", "responses": [{"question": "Rate the demo 1-5", "response": "rating: 3"}]},
+                {"persona": "D", "responses": [{"question": "Rate the demo 1-5", "response": " 4 out of 5"}]},
+            ],
+        }
+        summary = build_poll_summary(env)
+        q0 = summary.questions[0]
+        assert q0.kind == "scale"
+        # (5 + 4 + 3 + 4) / 4 = 4.0
+        assert q0.metric_average == 4.0
+
 
 class TestDeterminism:
     def test_same_input_produces_byte_identical_dict(self) -> None:

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -188,6 +188,41 @@ class TestQuickPoll:
         kwargs = mock_runner.call_args.kwargs
         assert kwargs["questions"] == [{"text": "Does this work?"}]
 
+    def test_persists_questions_metadata(self):
+        """sy-oyl: the saved result must carry the question (and any
+        response_schema) so poll_summary's _detect_kind can honor declared
+        types after reload. Previously this kwarg was dropped on the
+        single-question save path, so reloaded results fell back to
+        inference and misclassified text answers containing version strings
+        as scales.
+        """
+        from synth_panel import quick_poll
+        from synth_panel.cost import TokenUsage
+
+        fake_usage = TokenUsage(input_tokens=1, output_tokens=1)
+        fake_cost = MagicMock()
+        fake_cost.format_usd.return_value = "$0.01"
+        fake_cost.__add__ = lambda self, other: self
+
+        with (
+            patch("synth_panel.sdk.LLMClient"),
+            patch("synth_panel.sdk.run_panel_sync") as mock_runner,
+            patch("synth_panel.sdk.save_panel_result") as mock_save,
+        ):
+            mock_runner.return_value = (
+                [],
+                [{"persona": "A", "responses": [{"response": "ok"}], "usage": {}, "cost": "$0.01", "error": None}],
+                fake_usage,
+                fake_cost,
+                None,
+                None,
+            )
+            mock_save.return_value = "result-stub"
+            quick_poll("Does v1.5.1 feel agent-ready?", personas=[{"name": "A"}])
+
+        kwargs = mock_save.call_args.kwargs
+        assert kwargs["questions"] == [{"text": "Does v1.5.1 feel agent-ready?"}]
+
 
 class TestRunPanel:
     def test_requires_question_source(self):
@@ -228,6 +263,39 @@ class TestRunPanel:
             )
             kwargs = mock_runner.call_args.kwargs
             assert kwargs["questions"] == [{"text": "First?"}, {"text": "Second?"}]
+
+    def test_flat_questions_path_persists_questions_with_schema(self):
+        """sy-oyl: the flat ``questions=[{...}]`` save path now threads the
+        normalised question list (including ``response_schema``) into
+        ``save_panel_result`` so reloads preserve declared types.
+        """
+        from synth_panel import run_panel
+        from synth_panel.cost import TokenUsage
+
+        fake_usage = TokenUsage(input_tokens=1, output_tokens=1)
+        fake_cost = MagicMock()
+        fake_cost.format_usd.return_value = "$0.01"
+        fake_cost.__add__ = lambda self, other: self
+
+        questions_in = [
+            {"text": "Would v1.5.1 feel agent-ready?", "response_schema": {"type": "text"}},
+            {"text": "Confidence (1-5)?", "response_schema": {"type": "scale", "min": 1, "max": 5}},
+        ]
+        with (
+            patch("synth_panel.sdk.LLMClient"),
+            patch("synth_panel.sdk.run_panel_sync") as mock_runner,
+            patch("synth_panel.sdk.save_panel_result") as mock_save,
+        ):
+            mock_runner.return_value = ([], [], fake_usage, fake_cost, None, None)
+            mock_save.return_value = "result-stub"
+            run_panel(personas=[{"name": "Alice"}], questions=questions_in)
+
+        kwargs = mock_save.call_args.kwargs
+        saved_questions = kwargs["questions"]
+        assert len(saved_questions) == 2
+        # response_schema must round-trip — that's the whole point of the fix.
+        assert saved_questions[0]["response_schema"] == {"type": "text"}
+        assert saved_questions[1]["response_schema"] == {"type": "scale", "min": 1, "max": 5}
 
     def test_instrument_pack_takes_precedence_over_questions(self, monkeypatch):
         """If instrument_pack is given, questions/instrument are ignored."""


### PR DESCRIPTION
## Summary

Open-text questions whose prompt or responses mention a number (version strings like *"SynthPanel v1.5.1"*) were being misclassified as scale questions by `poll-summary`, producing a bogus `average=1.50` with `kind=scale`. Two-pronged fix:

1. **Tighter classification.** `poll_summary._looks_numeric` previously ran every response through the lenient `_coerce_number` regex (`re.search(r"-?\d+(?:\.\d+)?")`), which greedily extracted the first digit from any sentence. New `_response_is_scale_shaped` only accepts responses whose *whole* string is a numeric scale answer (`"4"`, `"4/5"`, `"rating: 4"`, optional `"out of N"`). The post-classification `_extract_score` keeps its lenient regex so already-classified scale runs still tolerate verbose answers.

2. **Persisted schema metadata.** The three `save_panel_result()` call sites in `sdk.py` (`quick_poll`, single-round `run_panel`, multi-round `run_panel`) now thread the question list — including each question's `response_schema` — into the saved JSON. Reloaded results carry declared types, so `_detect_kind` reads the schema branch instead of falling back to inference.

## Acceptance-criteria mapping (issue #510)

- ✅ *Open-text questions are not treated as scale questions because their prompt/answers contain numbers or version strings* — `test_text_question_with_version_string_in_response_stays_text` covers the exact bug.
- ✅ *Instrument question type is preserved into saved results or otherwise available to `poll-summary`* — `test_persists_questions_metadata` and `test_flat_questions_path_persists_questions_with_schema` assert `response_schema` flows into `save_panel_result(questions=...)` on every SDK path.
- ✅ *Mixed open-text + scale instruments summarize only the bounded questions* — `test_mixed_text_and_scale_only_scale_gets_average` covers the full envelope.

## Test plan

- [x] `pytest tests/test_poll_summary.py tests/test_sdk.py --no-cov` — 68 passed (5 new + 63 existing)
- [x] Full suite `pytest --no-cov` minus two pre-existing main env-dependent failures (`test_seed.py` paths that require `OPENROUTER_API_KEY`) — 2947 passed, 3 skipped
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check src/ tests/` — clean
- [x] CHANGELOG entry filed under `[Unreleased] ### Fixed`

Closes #510