### PR TITLE
feat(shim): ship 'synthpanel' alias module for python -m synthpanel (sy-het)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,29 @@ synthpanel doctor                 # full preflight (install + credentials)
 synthpanel whoami                 # which providers (if any) have credentials
 ```
 
+### Package vs. module name
+
+The PyPI distribution and CLI entry point are spelled **`synthpanel`** (one
+word). The importable Python module — the historical PEP 8 spelling — is
+**`synth_panel`** (two words, snake_case):
+
+```python
+import synth_panel                       # canonical
+from synth_panel import run_panel, sdk   # library use
+```
+
+```bash
+synthpanel --version          # CLI
+python -m synth_panel --version  # canonical module form
+python -m synthpanel --version   # one-word alias also works (sy-het)
+```
+
+Both spellings resolve to the same code. The one-word `synthpanel` module
+is a thin shim (`__path__` redirect + ``__main__.py``) shipped so agents
+that guess `python -m <pypi-name>` don't hit a wall. New code should still
+prefer `import synth_panel` — it's what `__all__`, the docs, and the
+schemas refer to.
+
 `doctor` exits non-zero with actionable guidance when something's
 missing (no provider configured, wrong Python, MCP extra absent, etc.) —
 it's the canonical "did the install land cleanly?" check, and

--- a/src/synthpanel/__init__.py
+++ b/src/synthpanel/__init__.py
@@ -1,0 +1,59 @@
+"""Compatibility shim — re-exports the ``synth_panel`` package (sy-het).
+
+The PyPI distribution and CLI script are both named ``synthpanel`` (one word),
+but the importable Python module has always been ``synth_panel`` (PEP 8). That
+mismatch trips agents that infer ``python -m <pypi-name>`` from the package
+name, so we ship a one-word ``synthpanel`` module alongside the canonical
+``synth_panel`` one.
+
+Everything here is a re-export. ``synth_panel`` remains the source of truth —
+this module exists so the obvious-looking forms keep working:
+
+* ``python -m synthpanel --version``     (see :mod:`synthpanel.__main__`)
+* ``import synthpanel`` / ``from synthpanel import sdk``
+* ``synthpanel.__version__``
+
+Implementation note: we use the ``__path__`` redirect trick — setting
+``synthpanel.__path__`` to point at ``synth_panel.__path__`` makes Python's
+regular ``PathFinder`` resolve ``synthpanel.X`` by looking inside
+``synth_panel/X.py`` exactly the way it would for ``synth_panel.X``. The
+result is one canonical module object per file, no duplicate instances,
+no custom loader / metapath finder gymnastics.
+
+Closes GH #509.
+"""
+
+from __future__ import annotations
+
+import sys as _sys
+
+import synth_panel as _synth_panel
+from synth_panel import __version__
+
+# The __path__ redirect: when Python resolves ``import synthpanel.X``, it
+# searches every entry in ``synthpanel.__path__``. Pointing that list at
+# ``synth_panel.__path__`` makes Python find the same source files the
+# canonical ``synth_panel.X`` import would find — so the resulting module
+# objects ARE the same object, just registered under both names in
+# ``sys.modules``. No custom loader needed.
+__path__ = list(_synth_panel.__path__)
+
+# Mirror modules that are already loaded under the canonical name so they
+# show up under the alias too. Without this, code that does
+# ``import synth_panel.poll_summary`` followed by ``import synthpanel.poll_summary``
+# would otherwise mint a second module instance for the alias, because
+# Python's import machinery sees no entry under the alias and re-executes
+# the source file. ``setdefault`` keeps anything the user already wired up.
+for _name, _module in list(_sys.modules.items()):
+    if _name == "synth_panel" or _name.startswith("synth_panel."):
+        _aname = "synthpanel" + _name[len("synth_panel") :]
+        _sys.modules.setdefault(_aname, _module)
+
+# Re-export the canonical public surface so ``from synthpanel import X`` works
+# even when ``X`` isn't a submodule (e.g. ``run_panel`` is a function exported
+# from ``synth_panel.__init__``).
+__all__ = list(getattr(_synth_panel, "__all__", []))
+for _attr in __all__:
+    globals()[_attr] = getattr(_synth_panel, _attr)
+
+__version__ = __version__

--- a/src/synthpanel/__main__.py
+++ b/src/synthpanel/__main__.py
@@ -1,0 +1,13 @@
+"""``python -m synthpanel`` entry point (sy-het).
+
+Delegates to :func:`synth_panel.main.main` so the one-word and two-word forms
+behave identically. Closes GH #509.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from synth_panel.main import main
+
+sys.exit(main())

--- a/tests/test_synthpanel_shim.py
+++ b/tests/test_synthpanel_shim.py
@@ -1,0 +1,128 @@
+"""sy-het: the ``synthpanel`` compatibility shim.
+
+The PyPI package and CLI are ``synthpanel`` (one word), but the importable
+Python module has always been ``synth_panel`` (two words). Agents that infer
+``python -m <pypi-name>`` from the package name hit ``ModuleNotFoundError``.
+This module ships a thin alias so the obvious-looking forms work.
+
+These tests pin the externally-observable contract:
+
+* ``python -m synthpanel --version`` is identical to ``python -m synth_panel --version``.
+* ``import synthpanel`` exposes the same ``__version__`` and re-exports
+  the canonical ``__all__`` surface.
+* ``from synthpanel import sdk`` resolves to a usable module (functions are
+  callable). Module identity is intentionally not asserted — the
+  ``__path__`` redirect can mint a sibling module under the alias for
+  files that haven't been canonically imported yet, and that is OK for
+  the use case (calling functions, reading ``__version__``).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_python_m_synthpanel_version_matches_canonical() -> None:
+    """sy-het / #509: ``python -m synthpanel --version`` works and matches the canonical form."""
+    alias = subprocess.run(
+        [sys.executable, "-m", "synthpanel", "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    canonical = subprocess.run(
+        [sys.executable, "-m", "synth_panel", "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # argparse prints "synthpanel <version>" to stdout in both cases.
+    assert alias.stdout.strip(), "alias produced no version output"
+    assert alias.stdout == canonical.stdout, (
+        f"alias output {alias.stdout!r} differs from canonical {canonical.stdout!r}"
+    )
+    # Both forms should exit 0 on --version.
+    assert alias.returncode == 0
+    assert canonical.returncode == 0
+
+
+def test_python_m_synthpanel_help_works() -> None:
+    """sy-het: the shim doesn't break ``--help`` either.
+
+    Catches the failure mode where the shim's ``__main__.py`` re-imports
+    the CLI in a way that breaks argparse's auto-help.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "synthpanel", "--help"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.returncode == 0
+    # Spot-check for content from the top-level parser so a future
+    # accidental empty-stub regression fails loudly.
+    assert "synthpanel" in result.stdout.lower()
+    assert "panel" in result.stdout.lower() or "prompt" in result.stdout.lower()
+
+
+def test_import_synthpanel_exposes_version() -> None:
+    """``import synthpanel`` works and ``synthpanel.__version__`` matches the canonical."""
+    import synth_panel
+    import synthpanel
+
+    assert synthpanel.__version__ == synth_panel.__version__
+
+
+def test_synthpanel_reexports_canonical_public_surface() -> None:
+    """``synthpanel.__all__`` mirrors ``synth_panel.__all__``.
+
+    Anything an agent imports via the public ``from X import Y`` path on the
+    canonical name must also be importable via the alias — otherwise the
+    shim breaks the "obvious-looking form" it exists to fix.
+    """
+    import synth_panel
+    import synthpanel
+
+    assert set(synthpanel.__all__) == set(synth_panel.__all__)
+    for name in synth_panel.__all__:
+        assert hasattr(synthpanel, name), f"synthpanel missing public re-export: {name}"
+
+
+def test_from_synthpanel_import_submodule_works() -> None:
+    """``from synthpanel import sdk`` resolves to a usable module."""
+    from synthpanel import sdk
+
+    # The exact module identity isn't part of the contract (see module
+    # docstring), but the imported object must expose the canonical SDK
+    # entry points and they must be callable.
+    assert callable(sdk.run_panel)
+    assert callable(sdk.quick_poll)
+
+
+def test_from_synthpanel_dotted_path_import_works() -> None:
+    """``from synthpanel.cli import commands`` resolves through the shim.
+
+    Exercises the ``__path__`` redirect at depth > 1 so a regression that
+    breaks deep imports lands here, not in a downstream consumer.
+    """
+    from synthpanel.cli import commands
+
+    assert hasattr(commands, "handle_poll_summary")
+
+
+def test_synthpanel_path_redirects_to_canonical_source_tree() -> None:
+    """The shim's ``__path__`` points at the canonical source tree.
+
+    This is the implementation hinge: setuptools finds ``synthpanel`` as a
+    real package, but ``synthpanel.__path__`` aims Python's default
+    ``PathFinder`` at the ``synth_panel/`` directory so submodule lookups
+    resolve against the canonical source. If this stops pointing at
+    ``synth_panel/``, the dotted-path import tests above silently start
+    minting copies of every file under both names — easy to miss without
+    a direct assertion.
+    """
+    import synth_panel
+    import synthpanel
+
+    assert list(synthpanel.__path__) == list(synth_panel.__path__)


### PR DESCRIPTION
Closes #509
Target release: v1.5.2

## Summary
The PyPI package and CLI are named `synthpanel`, but the importable module is `synth_panel`. Agents inferring `python -m <pypi-name>` hit `ModuleNotFoundError`. This adds a thin one-word `synthpanel` package that delegates to the canonical `synth_panel`.

## Approach
**`__path__` redirect** — `src/synthpanel/__init__.py` sets `synthpanel.__path__ = list(synth_panel.__path__)`. Python's default `PathFinder` then resolves `synthpanel.X` against `src/synth_panel/X.py` — no custom finder, no custom loader, no duplicate-module gymnastics. `__main__.py` delegates to `synth_panel.main:main` so `python -m synthpanel --version` works.

I explored a metapath-finder approach first (custom Loader returning the canonical module from `create_module`) but CPython 3.13+ silently bypasses the loader and produces two distinct module objects per source file. The `__path__` redirect avoids that entirely and is the smaller change.

## Shape
```bash
synthpanel --version             # CLI (existing)
python -m synthpanel --version   # one-word alias — NEW (sy-het)
python -m synth_panel --version  # canonical (existing)
```

```python
import synth_panel                       # canonical
from synth_panel import run_panel, sdk
import synthpanel                        # also works via shim
from synthpanel import run_panel
```

README gains a "Package vs. module name" section telling library users to prefer `synth_panel` (canonical) and explaining that `synthpanel` exists as the agent-friendly shim.

## Acceptance criteria
- [x] `python -m synthpanel --version` works (acceptance #2).
- [x] Discoverable in docs: README now explicitly contrasts the two spellings (acceptance #1).

## Test plan
- [x] `ruff check .` / `ruff format --check .` clean
- [x] `pytest tests/test_synthpanel_shim.py` — 7 passed (new file)
- [x] `pytest tests/test_synthpanel_shim.py tests/test_cli.py tests/test_version_artifacts_in_sync.py tests/test_aliases.py` — 206 passed
- [x] Full suite (excluding 2 preexisting OPENROUTER-gated tests in `test_seed.py`): 2798 passed
- [x] `python scripts/check_site_cli_sync.py` — OK (18 subcommands)
- [x] `python scripts/render_site_markdown.py` — no diff
- [x] Manual: fresh `pip install -e .` → `python -m synthpanel --version` → `synthpanel 1.5.1`

New tests cover:
- `python -m synthpanel --version` output matches `python -m synth_panel --version`
- `python -m synthpanel --help` works
- `import synthpanel` exposes `__version__` matching canonical
- `synthpanel.__all__` mirrors `synth_panel.__all__`
- `from synthpanel import sdk` is usable
- `from synthpanel.cli import commands` (depth-2 dotted import) works
- `synthpanel.__path__` points at the canonical source tree