### PR TITLE
fix(cli): pack import <registry-id> resolves registry entries (sy-dwc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ### Fixed
 
+- **`pack import <registry-id>` resolves registry entries (sy-dwc, #520).**
+  When `panel run --personas <id>` misses, it suggests `pack import <id>` —
+  but that command used to fall to the local-file branch and echo the same
+  failing command back (a self-referential loop). `pack import` now treats a
+  bare slug that isn't a local file as a registry id: it resolves the entry to
+  its `gh:` source, imports it, and installs the pack under the registry id so
+  the follow-up `--personas <id>` works end to end. Ids absent from the
+  registry fall through to the existing local-file "not found" error (which
+  points at `pack search`), and path-like inputs are never sent through a
+  registry network probe.
 - **`poll-summary` respects declared question types (sy-oyl).** Open-text
   questions whose prompt or responses contain numbers (e.g. version
   strings like *"SynthPanel v1.5.1"*) are no longer misclassified as

--- a/docs/registry.md
+++ b/docs/registry.md
@@ -36,13 +36,29 @@ unreachable, so `pack import` keeps working offline.
 
 ## Importing a Remote Pack
 
-`pack import` accepts three kinds of source:
+`pack import` accepts four kinds of source:
 
 | Source form | Example |
 |---|---|
+| Registry id | `icp-demo` |
 | `gh:user/repo[@ref][:path]` | `gh:dataviking-tech/example-pack` |
 | `https://github.com/.../blob/...` | `https://github.com/dv/pk/blob/main/synthpanel-pack.yaml` |
 | `https://raw.githubusercontent.com/...` | `https://raw.githubusercontent.com/dv/pk/main/synthpanel-pack.yaml` |
+
+### Registry ids
+
+```bash
+# Resolve a bare registry id to its source and install it
+synthpanel pack import icp-demo
+```
+
+When the source is a bare id (a slug — no path separator or `.yaml`/`.yml`/
+`.json` extension) that is **not** a local file, synthpanel looks it up in the
+registry and imports from the resolved `gh:` source. The pack installs under
+the registry id, so the command `panel run --personas <id>` suggests after a
+miss (`pack import <id>`, then `--personas <id>`) works end to end. Ids that
+aren't in the registry fall through to local-file handling and produce a
+"not found" error pointing you at `pack search`.
 
 ### `gh:` URIs
 

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -3422,11 +3422,23 @@ def handle_pack_import(args: argparse.Namespace, fmt: OutputFormat) -> int:
 
     - ``gh:user/repo[@ref][:path]`` / ``https://…`` → remote fetch path with
       registry consultation, collision checks, and ``--unverified`` gating.
+    - A bare registry id that isn't a local file → resolved against the
+      registry to its ``gh:`` source and imported via the remote path
+      (#520). This is the command ``panel run --personas <id>`` points
+      users at, so it must install the pack rather than echo itself back.
     - Anything else → local file path (existing behavior, unchanged).
     """
     source = args.source
     if source.startswith("gh:") or source.startswith("http://") or source.startswith("https://"):
         return _handle_pack_import_remote(args, fmt, source)
+    if not Path(source).exists() and _looks_like_pack_id(source):
+        gh_source = _resolve_registry_id_source(source)
+        if gh_source is not None:
+            # Keep the installed pack id equal to the registry id so the
+            # follow-up `--personas <id>` resolves, unless --id overrides.
+            if not getattr(args, "pack_id", None):
+                args.pack_id = source
+            return _handle_pack_import_remote(args, fmt, gh_source)
     return _handle_pack_import_local(args, fmt, source)
 
 
@@ -3558,6 +3570,46 @@ def _default_pack_id_from_source(source: str) -> str:
     parts = urlparse(source)
     tail = Path(parts.path).stem or parts.netloc or "pack"
     return _slugify_pack_id(tail)
+
+
+_PACK_FILE_SUFFIXES = {".yaml", ".yml", ".json"}
+
+
+def _looks_like_pack_id(source: str) -> bool:
+    """Return True when *source* looks like a bare registry/pack id (a slug).
+
+    Pack ids are slugs (``icp-demo``, ``pricing-discovery``); anything
+    with a path separator or a recognized data-file extension is a
+    filesystem path and must NOT trigger a registry network probe. This
+    keeps ``pack import ./some/file.yaml`` on the local branch.
+    """
+    if not source or "/" in source or "\\" in source:
+        return False
+    return Path(source).suffix.lower() not in _PACK_FILE_SUFFIXES
+
+
+def _resolve_registry_id_source(pack_id: str) -> str | None:
+    """Resolve a bare registry id to a ``gh:`` source spec, or ``None``.
+
+    This is what lets ``pack import <registry-id>`` actually install the
+    pack that ``panel run --personas <registry-id>`` points users at —
+    rather than echoing the same self-referential command back (#520).
+
+    Returns ``None`` when *pack_id* isn't a known registry pack or the
+    registry can't be consulted (offline, malformed entry). Best-effort:
+    any exception degrades to ``None`` so a network blip never crashes
+    the command — the caller then falls back to local-path import.
+    """
+    try:
+        from synth_panel.registry import resolve_pack
+
+        entry = resolve_pack(pack_id)
+    except Exception:
+        return None
+    if entry is None:
+        return None
+    ref = entry.ref or "main"
+    return f"gh:{entry.repo}@{ref}:{entry.path}"
 
 
 def _source_in_registry(source: str) -> bool:

--- a/tests/test_pack_import_gh.py
+++ b/tests/test_pack_import_gh.py
@@ -333,3 +333,97 @@ class TestLocalPathRegression:
         # Remote-only features must not appear in the local branch.
         assert "Checksum:" not in captured.err
         assert "synthpanel registry" not in captured.err
+
+
+# ---------------------------------------------------------------------------
+# bare registry-id resolution (#520)
+# ---------------------------------------------------------------------------
+
+
+class TestBareRegistryId:
+    """`pack import <registry-id>` resolves the registry entry and imports.
+
+    Before #520 a bare id fell to the local branch, whose error told the
+    user to run `pack import <id>` — the same command that just failed
+    (self-referential). These tests pin the resolve-and-import behavior.
+    """
+
+    def test_bare_registry_id_resolves_and_imports(self, tmp_data_dir, monkeypatch, capsys):
+        """`pack import icp-demo` resolves the entry, fetches it, and imports."""
+        _seed_registry_cache(tmp_data_dir, REGISTRY_WITH_ENTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            if request.url.path.endswith("synthpanel-pack.yaml"):
+                return httpx.Response(200, text=SAMPLE_PACK_YAML)
+            return httpx.Response(404)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "icp-demo"])
+        captured = capsys.readouterr()
+        assert code == 0, captured.err
+        assert "Imported pack" in captured.out
+        # Resolved from a registered entry: no --unverified gate, no warning.
+        assert "not in the synthpanel registry" not in captured.err
+        assert "--unverified" not in captured.err
+
+    def test_bare_registry_id_installs_under_registry_id(self, tmp_data_dir, monkeypatch):
+        """The installed pack id equals the registry id so `--personas <id>` resolves."""
+        from synth_panel.mcp.data import get_persona_pack
+
+        _seed_registry_cache(tmp_data_dir, REGISTRY_WITH_ENTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "icp-demo"])
+        assert code == 0
+        # The whole point of the registry hint: `--personas icp-demo` works after.
+        pack = get_persona_pack("icp-demo")
+        names = {p.get("name") for p in pack.get("personas", [])}
+        assert names == {"Alice", "Bob"}
+
+    def test_bare_registry_id_respects_id_override(self, tmp_data_dir, monkeypatch):
+        """An explicit --id overrides the default of using the registry id."""
+        from synth_panel.mcp.data import get_persona_pack
+
+        _seed_registry_cache(tmp_data_dir, REGISTRY_WITH_ENTRY)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text=SAMPLE_PACK_YAML)
+
+        _install_httpx_mock(monkeypatch, handler)
+
+        code = main(["pack", "import", "icp-demo", "--id", "custom"])
+        assert code == 0
+        pack = get_persona_pack("custom")
+        assert {p.get("name") for p in pack.get("personas", [])} == {"Alice", "Bob"}
+
+    def test_unknown_bare_id_falls_through_without_self_reference(self, tmp_data_dir, capsys):
+        """An id-shaped source not in the registry errors WITHOUT echoing the
+        same `pack import <id>` command back."""
+        _seed_registry_cache(tmp_data_dir, EMPTY_REGISTRY)
+
+        code = main(["pack", "import", "no-such-pack-id"])
+        captured = capsys.readouterr()
+        assert code == 1
+        combined = captured.err + captured.out
+        # The self-referential loop (#520) must be gone.
+        assert "pack import no-such-pack-id" not in combined
+        # Generic local not-found guidance instead.
+        assert "no-such-pack-id" in combined
+
+    def test_path_like_source_is_not_treated_as_registry_id(self):
+        """Helper guard: path-like inputs never trigger a registry probe."""
+        from synth_panel.cli.commands import _looks_like_pack_id
+
+        assert _looks_like_pack_id("icp-demo") is True
+        assert _looks_like_pack_id("pricing-discovery") is True
+        assert _looks_like_pack_id("./team.yaml") is False
+        assert _looks_like_pack_id("/abs/path.yml") is False
+        assert _looks_like_pack_id("team.yaml") is False
+        assert _looks_like_pack_id("data.json") is False
+        assert _looks_like_pack_id("sub/dir") is False
+        assert _looks_like_pack_id("") is False


### PR DESCRIPTION
## Summary

`panel run --personas <id>` suggests `pack import <id>` on a miss, but
that command routed to the local-file branch, failed to find the file,
and re-emitted the **same** `pack import <id>` hint — a self-referential
loop (#520). `pack import` now resolves a bare registry id to its `gh:`
source and installs it via the existing remote path, so the suggested
recovery command actually works and the follow-up `--personas <id>` resolves.

## Changes

- `src/synth_panel/cli/commands.py`: `handle_pack_import` now routes a bare slug that isn't a local file through registry resolution before the local branch.
  - Adds `_resolve_registry_id_source` (id → `gh:repo@ref:path` via `registry.resolve_pack`, best-effort/offline-safe).
  - Adds `_looks_like_pack_id` (guards path-like inputs so they never trigger a registry network probe).
  - Installed pack id defaults to the registry id (overridable with `--id`) so `--personas <id>` works afterward.
- `tests/test_pack_import_gh.py`: new `TestBareRegistryId` — resolve+import, installs under the registry id, `--id` override, unknown-id fall-through with no self-referential message, and `_looks_like_pack_id` guard cases.
- `docs/registry.md`: document the registry-id source form (now four forms).
- `CHANGELOG.md`: Unreleased "Fixed" entry.

## Test plan

- `tests/test_pack_import_gh.py::TestBareRegistryId` proves `pack import icp-demo` resolves the seeded registry entry, fetches the mocked `gh:` source, and installs personas under id `icp-demo`; that `--id` overrides it; and that an unknown id errors without echoing `pack import <id>`.
- Full local suite: 2979 passed, 26 skipped, 3 pre-existing failures unrelated to this change (acceptance/seed tests gated on live API keys).
- GitHub CI runs the full suite on this PR.

## References

- Bead: sy-dwc
- Closes #520
- MR: sy-wisp-d48
- Polecat: jasper
- Branch: polecat/jasper-mpirz8ix