### PR TITLE
fix(synthbench): substitute runnable model_id from leaderboard rows (sy-i7a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For auto-generated release notes, see [GitHub Releases](https://github.com/DataV
 
 ### Fixed
 
+- **`--best-model-for` substitutes a runnable upstream `model_id` (sy-i7a,
+  #519).** When the top SynthBench row's `model` field is a display label
+  (e.g. `SynthPanel (Gemini Flash Lite)`), SynthPanel now prefers the runnable
+  id the live leaderboard publishes in `model_id` (e.g.
+  `google/gemini-2.5-flash-lite`, joined with `provider_id` when `model_id` is
+  a bare slug) instead of refusing and falling through to the default model
+  (which, with only OpenRouter credentials present, landed on
+  `openrouter/auto`). A runnable `model_id` takes precedence over the
+  `config_id` base-model heuristic; a `model_id` that is itself a display
+  label is ignored, and rows with no resolvable runnable id are still refused
+  with the existing actionable message. The picked model is visible under
+  `--dry-run`.
 - **Saved-result provenance is populated (sy-g1g, #525).** Every `--save`
   artifact now embeds the run `metadata` block (synthpanel/Python version,
   `config_hash`, and the new `cost.pricing_snapshot_date`) that

--- a/README.md
+++ b/README.md
@@ -1017,12 +1017,15 @@ The leaderboard is cached for 24 hours at
 [docs/recommended-models.md](docs/recommended-models.md) for the full
 rules, offline behaviour, and a use-case → top-model table.
 
-If the top-ranked entry is a product/ensemble row that only exposes a
-display label (e.g. `SynthPanel (Gemini Flash Lite)`) rather than a
-runnable provider model id, `--best-model-for` refuses to stamp it onto
-`--model` — it prints an actionable message and falls back to your
-existing `--model`/default. Pair with `--dry-run` to see the picked
-model (and any such refusal) before any LLM call is made.
+If the top-ranked entry exposes a display label (e.g. `SynthPanel (Gemini
+Flash Lite)`) rather than a runnable provider model id in its `model`
+field, `--best-model-for` substitutes the runnable `model_id` the
+leaderboard publishes alongside it (e.g. `google/gemini-2.5-flash-lite`),
+so you get a real, runnable model instead of a refusal. Only when no
+runnable id can be resolved does it refuse to stamp the label — printing
+an actionable message and falling back to your existing `--model`/default.
+Pair with `--dry-run` to see the picked model (and any such refusal)
+before any LLM call is made.
 
 ### Model packs (agent guidance)
 

--- a/docs/recommended-models.md
+++ b/docs/recommended-models.md
@@ -161,11 +161,20 @@ CLI flag or [synthbench.org](https://synthbench.org) for current picks.
 
 ## Caveats
 
-- **Ensembles & product configs.** Some leaderboard entries are
-  SynthPanel product configs (`framework=product`, `is_ensemble=true`).
-  These aren't runnable as a plain `--model` value, so SynthPanel falls
-  back to the underlying base model inferred from the entry's
-  `config_id`. A stderr note records the substitution.
+- **Display labels & runnable ids (gh-519).** Some leaderboard rows carry a
+  human-readable display label (e.g. `SynthPanel (Gemini Flash Lite)`) in
+  their `model` field rather than a runnable provider model id. SynthPanel
+  never stamps such a label onto `--model`. Instead it substitutes a runnable
+  id in this order:
+  1. The row's runnable `model_id` (e.g. `google/gemini-2.5-flash-lite`)
+     published by SynthBench — joined with `provider_id` as
+     `<provider_id>/<model_id>` when `model_id` is a bare slug.
+  2. For product/ensemble rows (`framework=product`, `is_ensemble=true`)
+     without a `model_id`, a base model inferred from the entry's `config_id`,
+     adopted only when it resolves to a recognized provider id or alias.
+  3. If neither yields a runnable id, the recommendation is **refused** with
+     an actionable stderr message and SynthPanel keeps your existing
+     `--model`/default. A stderr note records any substitution.
 - **Sparse topics.** When the top entry's `run_count < 3`, a
   low-confidence warning is emitted. Treat those recommendations as
   suggestive rather than authoritative.

--- a/src/synth_panel/synthbench.py
+++ b/src/synth_panel/synthbench.py
@@ -100,9 +100,10 @@ class Recommendation:
     label (e.g. ``"SynthPanel (Gemini Flash Lite)"``) in their ``model``
     field rather than a provider-runnable id. Stamping such a label onto
     ``--model`` fails at call time with a provider "not a valid model ID"
-    error. ``recommend`` sets this to ``False`` when neither the entry's
-    model field nor an inferred config base resolves to a runnable id, so
-    the CLI can refuse with an actionable message instead of producing a
+    error. ``recommend`` sets this to ``False`` only when none of the
+    entry's runnable ``model_id``/``provider_id`` (SynthBench #297), its
+    ``model`` field, or an inferred config base resolves to a runnable id,
+    so the CLI can refuse with an actionable message instead of producing a
     non-runnable selection. Defaults to ``True`` so test fixtures that
     construct :class:`Recommendation` directly keep their prior shape.
     """
@@ -641,6 +642,42 @@ def _underlying_base(entry: dict[str, Any]) -> str | None:
     return config_id or None
 
 
+def _runnable_id_from_row(entry: dict[str, Any]) -> str | None:
+    """Return the machine-runnable provider model id SynthBench publishes
+    alongside the display label (gh-519 retry; SynthBench #297), or ``None``.
+
+    SynthBench product/ensemble rows carry a human-readable string in
+    ``model`` (e.g. ``"SynthPanel (Gemini Flash Lite)"``) but the live
+    leaderboard now also exposes a runnable id in ``model_id`` (e.g.
+    ``"google/gemini-2.5-flash-lite"``). Preferring that id lets
+    ``--best-model-for`` substitute a real upstream model instead of
+    refusing the display label and falling through to the default model
+    (which, with only OpenRouter credentials present, lands on
+    ``openrouter/auto`` — see gh-519).
+
+    ``model_id`` is used verbatim when it already carries a provider segment
+    (contains ``/``) or is otherwise a single runnable token. When it is a
+    bare slug and a separate runnable ``provider_id`` is published, the two
+    are joined as ``"<provider_id>/<model_id>"`` to reconstruct the full
+    provider/model slug. A ``model_id`` that is itself a display label
+    (whitespace- or paren-bearing) is ignored so we never reintroduce the
+    original non-runnable-stamping failure.
+    """
+    model_id = entry.get("model_id")
+    if not isinstance(model_id, str):
+        return None
+    model_id = model_id.strip()
+    if not is_runnable_model_id(model_id):
+        return None
+    if "/" not in model_id:
+        provider_id = entry.get("provider_id")
+        if isinstance(provider_id, str):
+            pid = provider_id.strip()
+            if pid and is_runnable_model_id(pid) and "/" not in pid:
+                return f"{pid}/{model_id}"
+    return model_id
+
+
 def recommend(
     spec: str,
     *,
@@ -682,19 +719,29 @@ def recommend(
     framework = entry.get("framework") if isinstance(entry.get("framework"), str) else None
     is_ensemble = bool(entry.get("is_ensemble"))
 
-    # Product/ensemble configs aren't runnable as-is. When the entry's
-    # model field is empty OR a non-runnable display label (gh-519: e.g.
-    # "SynthPanel (Gemini Flash Lite)"), try to infer a runnable base model
-    # from config_id instead. Only adopt the inferred base when it itself
-    # resolves to a runnable id — otherwise keep the original string so the
-    # caller can report it verbatim and refuse rather than silently swap in
-    # a config-id hash fragment.
-    if (is_ensemble or framework == "product") and not is_runnable_model_id(resolved_model):
-        base = _underlying_base(entry)
-        if base:
-            candidate = _resolve_model_string(base)
-            if _is_recognized_model_id(candidate):
-                resolved_model = candidate
+    # When the entry's model field is empty OR a non-runnable display label
+    # (gh-519: e.g. "SynthPanel (Gemini Flash Lite)"), substitute a runnable
+    # provider model id instead of stamping the label onto --model.
+    #
+    # 1. Prefer the runnable id SynthBench now publishes in model_id /
+    #    provider_id (gh-519 retry; SynthBench #297). This is the authoritative
+    #    upstream id (e.g. "google/gemini-2.5-flash-lite") and applies to any
+    #    row — product/ensemble or not — that surfaces a display label.
+    # 2. Fall back to inferring a base model from config_id only when no
+    #    runnable model_id exists. Only adopt the inferred base when it itself
+    #    resolves to a runnable id — otherwise keep the original string so the
+    #    caller can report it verbatim and refuse rather than silently swap in
+    #    a config-id hash fragment.
+    if not is_runnable_model_id(resolved_model):
+        runnable_upstream = _runnable_id_from_row(entry)
+        if runnable_upstream is not None:
+            resolved_model = _resolve_model_string(runnable_upstream)
+        elif is_ensemble or framework == "product":
+            base = _underlying_base(entry)
+            if base:
+                candidate = _resolve_model_string(base)
+                if _is_recognized_model_id(candidate):
+                    resolved_model = candidate
 
     final_model = resolved_model or raw_model
     run_count = _as_int(entry, "run_count") or 0

--- a/tests/test_best_model_for_cli.py
+++ b/tests/test_best_model_for_cli.py
@@ -86,3 +86,39 @@ def test_no_recommendation_falls_through(monkeypatch: pytest.MonkeyPatch, capsys
     assert picked is None
     assert args.model == "haiku"
     assert "no recommendation" in capsys.readouterr().err
+
+
+def test_display_label_with_model_id_is_stamped_end_to_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """gh-519 retry: a top row whose ``model`` is a display label but that
+    carries a runnable ``model_id`` (SynthBench #297) is resolved through the
+    real ``recommend`` and stamped onto ``--model`` — not refused. Previously
+    such a row fell through to the existing selection (e.g. openrouter/auto)."""
+    board = {
+        "entries": [
+            {
+                "config_id": "synthpanel-gemini-flash-lite-tdefault-ba37570c",
+                "model": "SynthPanel (Gemini Flash Lite)",
+                "model_id": "google/gemini-2.5-flash-lite",
+                "provider": "SynthPanel (Gemini Flash Lite)",
+                "dataset": "globalopinionqa",
+                "is_ensemble": False,
+                "sps": 0.901,
+                "n": 100,
+                "jsd": 0.313,
+                "topic_scores": {"Technology & Digital Life": 0.901},
+                "run_count": 100,
+            }
+        ]
+    }
+    real_recommend = synthbench.recommend
+    monkeypatch.setattr(
+        synthbench,
+        "recommend",
+        lambda spec: real_recommend(spec, leaderboard=board),
+    )
+    args = argparse.Namespace(model="openrouter/auto")
+    picked = _apply_best_model_for(args, "Technology & Digital Life:globalopinionqa")
+    assert picked == "google/gemini-2.5-flash-lite"
+    assert args.model == "google/gemini-2.5-flash-lite"

--- a/tests/test_synthbench_recommend.py
+++ b/tests/test_synthbench_recommend.py
@@ -48,8 +48,10 @@ def _entry(
     cost_per_100q: float = 0.5,
     run_count: int = 5,
     config_id: str | None = None,
+    model_id: str | None = None,
+    provider_id: str | None = None,
 ) -> dict[str, Any]:
-    return {
+    entry: dict[str, Any] = {
         "config_id": config_id or f"cfg-{model}",
         "model": model,
         "provider": provider,
@@ -63,6 +65,11 @@ def _entry(
         "cost_per_100q": cost_per_100q,
         "run_count": run_count,
     }
+    if model_id is not None:
+        entry["model_id"] = model_id
+    if provider_id is not None:
+        entry["provider_id"] = provider_id
+    return entry
 
 
 SAMPLE: dict[str, Any] = {
@@ -315,6 +322,108 @@ def test_recommend_display_label_resolves_runnable_base_from_config_id(
     assert rec is not None
     assert rec.runnable is True
     assert rec.model == "claude-haiku-4-5-20251001"
+
+
+def test_recommend_prefers_runnable_model_id_over_display_label() -> None:
+    """gh-519 retry: when the display ``model`` is a label but the row exposes
+    a runnable ``model_id`` (SynthBench #297), substitute the model_id and mark
+    the recommendation runnable instead of refusing."""
+    board = {
+        "entries": [
+            _entry(
+                model="SynthPanel (Gemini Flash Lite)",
+                provider="SynthPanel (Gemini Flash Lite)",
+                model_id="google/gemini-2.5-flash-lite",
+                sps=0.95,
+                is_ensemble=False,
+            )
+        ]
+    }
+    rec = recommend(":globalopinionqa", leaderboard=board)
+    assert rec is not None
+    assert rec.model == "google/gemini-2.5-flash-lite"
+    assert rec.runnable is True
+    # The original display label is preserved as raw_model for provenance.
+    assert rec.raw_model == "SynthPanel (Gemini Flash Lite)"
+
+
+def test_recommend_model_id_wins_over_config_id_inference() -> None:
+    """A runnable model_id takes precedence over the config_id base heuristic
+    so the authoritative upstream id is used rather than a guessed tail."""
+    board = {
+        "entries": [
+            _entry(
+                model="SynthPanel (Gemini Flash Lite)",
+                model_id="google/gemini-2.5-flash-lite",
+                config_id="synthpanel:haiku",
+                sps=0.95,
+                framework="product",
+                is_ensemble=True,
+            )
+        ]
+    }
+    rec = recommend(":globalopinionqa", leaderboard=board)
+    assert rec is not None
+    assert rec.model == "google/gemini-2.5-flash-lite"
+    assert rec.runnable is True
+
+
+def test_recommend_joins_provider_id_with_bare_model_id() -> None:
+    """When model_id is a bare slug and provider_id is published separately,
+    they are joined into a full provider/model slug."""
+    board = {
+        "entries": [
+            _entry(
+                model="SynthPanel (Gemini Flash Lite)",
+                model_id="gemini-2.5-flash-lite",
+                provider_id="google",
+                sps=0.95,
+            )
+        ]
+    }
+    rec = recommend(":globalopinionqa", leaderboard=board)
+    assert rec is not None
+    assert rec.model == "google/gemini-2.5-flash-lite"
+    assert rec.runnable is True
+
+
+def test_recommend_ignores_non_runnable_model_id() -> None:
+    """A model_id that is itself a display label must not be substituted —
+    the row stays non-runnable so the CLI refuses (no gh-519 regression)."""
+    board = {
+        "entries": [
+            _entry(
+                model="SynthPanel (Gemini Flash Lite)",
+                model_id="Gemini Flash Lite (preview)",
+                config_id="synthpanel-gemini-flash-lite-ba37570c",
+                sps=0.95,
+                framework="product",
+                is_ensemble=True,
+            )
+        ]
+    }
+    rec = recommend(":globalopinionqa", leaderboard=board)
+    assert rec is not None
+    assert rec.runnable is False
+    assert rec.model == "SynthPanel (Gemini Flash Lite)"
+
+
+def test_recommend_runnable_model_field_ignores_model_id() -> None:
+    """When the display ``model`` is already runnable, it is used as-is and a
+    present model_id does not override it (no surprise reroute)."""
+    board = {
+        "entries": [
+            _entry(
+                model="gpt-4o-mini",
+                model_id="openai/gpt-4o-mini",
+                sps=0.95,
+            )
+        ]
+    }
+    rec = recommend(":globalopinionqa", leaderboard=board)
+    assert rec is not None
+    assert rec.model == "gpt-4o-mini"
+    assert rec.runnable is True
 
 
 def test_recommend_plain_model_is_runnable() -> None:


### PR DESCRIPTION
## Summary

When a top SynthBench row's `model` field is a display label (e.g.
`"SynthPanel (Gemini Flash Lite)"`) the prior fix (sy-kh3, #521) refused
it and fell back to the default model — which, with only OpenRouter
credentials present, lands on `openrouter/auto`. But SynthBench #297 now
publishes a runnable id in the row's `model_id` (e.g.
`"google/gemini-2.5-flash-lite"`). Hermes v1.5.4 dogfood re-reported #519:
**refuse-and-fallback works, but the runnable `model_id` is ignored**.

## Fix

- **`_runnable_id_from_row()`** — prefer `entry["model_id"]`, joined with `entry["provider_id"]` as `"<provider_id>/<model_id>"` when `model_id` is a bare slug. A `model_id` that is itself a display label is ignored so we never reintroduce the non-runnable-stamping failure.
- **`recommend()`** — when the display `model` is non-runnable, prefer the runnable `model_id` (authoritative) over the `config_id` base-model heuristic; fall back to `config_id` inference only when no `model_id` exists; refuse only when neither yields a runnable id. `runnable=True` now lets the CLI stamp the real upstream id instead of falling through to the default. `raw_model` preserves the original display label for provenance.

Applies to **any** row surfacing a display label (product/ensemble or
not), matching the dogfood evidence (`is_ensemble=false` with a `model_id`).

## Test plan

- 5 new `recommend()`-level tests covering the `model_id` substitution paths.
- 1 end-to-end CLI test exercising the dogfood scenario.
- GitHub CI runs the full suite on this PR.

## Docs

`README`, `recommended-models`, and `CHANGELOG` updated to reflect the new
`model_id`-aware recommendation behaviour.

## References

- Bead: sy-i7a
- Closes #519 (re-opened after Hermes v1.5.4 dogfood)
- Builds on: sy-kh3 (#521 — refuse-display-label fallback)
- MR: sy-wisp-7u9
- Polecat: garnet
- Branch: polecat/garnet-mpj27ppb