### PR TITLE
feat(cli): include result_id + saved_path in --save JSON output (sy-659)

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,15 @@ synthpanel report path/to/result.json
 synthpanel report <result-id> -o report.md
 ```
 
+**Machine-readable handle (agents):** pairing `--save` with
+`--output-format json` adds two stable top-level keys to the stdout JSON —
+`result_id` (the saved handle) and `saved_path` (its absolute path). Feed
+`result_id` straight into `report`, `results show`, `analyze`, or the MCP
+tools without scraping the stderr `Result saved:` line or guessing the file
+location. The keys are present **only** when `--save` is active; a checkpointed
+run additionally surfaces its checkpoint `run_id`. The human-facing
+`Result saved:` hint still goes to stderr, keeping stdout pure JSON.
+
 #### Discovering saved results (`synthpanel results`)
 
 `--save` writes to the results store (`~/.synthpanel/results`), which is

--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -1631,16 +1631,18 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             template_vars=template_vars or None,
             panelist_per_model=ens_per_model_meta,
         )
-        emit(fmt, message="Ensemble complete", extra=output)
-
         # hq-0pnq: --save was a silent no-op in the ensemble path because
         # this branch returned before the persistence block at the end of
         # handle_panel_run(). Flatten per-model panelist results into the
         # standard saved-result shape so consumers (`synthpanel inspect`,
         # `synthpanel analyze`) see ensemble runs the same way they see
         # single-model runs.
+        #
+        # sy-659 (#471): persist BEFORE emit so the saved-result handle +
+        # path can be injected into the JSON object agents parse from stdout.
+        ensemble_result_id: str | None = None
         if getattr(args, "save", False):
-            from synth_panel.mcp.data import save_panel_result
+            from synth_panel.mcp.data import _results_dir, save_panel_result
 
             inst_name: str | None = None
             inst_arg = getattr(args, "instrument", None)
@@ -1653,7 +1655,7 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 for pr in mr.panelist_results:
                     ensemble_results.append(_fmt_panelist(pr, mr.model))
 
-            result_id = save_panel_result(
+            ensemble_result_id = save_panel_result(
                 results=ensemble_results,
                 model=ensemble_models[0],
                 total_usage=ens_result.total_usage.to_dict(),
@@ -1664,7 +1666,13 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
                 models=list(ensemble_models),
                 metadata=output["metadata"],
             )
-            _print_saved_result_hint(result_id)
+            output["result_id"] = ensemble_result_id
+            output["saved_path"] = str(_results_dir() / f"{ensemble_result_id}.json")
+
+        emit(fmt, message="Ensemble complete", extra=output)
+
+        if ensemble_result_id is not None:
+            _print_saved_result_hint(ensemble_result_id)
 
         return 0
 
@@ -1877,6 +1885,10 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
         return 1
 
     checkpoint_writer: CheckpointWriter | None = None
+    # sy-659 (#471): the checkpoint run_id, when checkpointing is active, is
+    # surfaced in JSON output so agents resuming a run have the handle without
+    # scraping stderr. Stays None for non-checkpointed runs (the common case).
+    run_id: str | None = None
     preloaded_results: list[PanelistResult] = []
     resumed_config_note: str | None = None
     active_personas = personas  # may be filtered below on resume
@@ -2457,6 +2469,47 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             convergence_report["human_baseline_error"] = convergence_baseline_error
         convergence_tracker.close()
 
+    # ── sy-659 (#471): persist --save BEFORE the text/json branch split ──
+    # The saved-result handle (result_id) and its absolute path must land in
+    # the JSON object agents parse from stdout, so the write happens here —
+    # ahead of emit() — rather than at the end of the function. The
+    # human-facing "Result saved" hint still prints after the branch (below)
+    # to preserve stderr-after-stdout ordering for TEXT-mode operators.
+    saved_result_id: str | None = None
+    saved_result_path: str | None = None
+    if getattr(args, "save", False):
+        from synth_panel.mcp.data import _results_dir, save_panel_result
+
+        # Determine instrument name (pack name or filename stem)
+        inst_name = None
+        inst_arg = getattr(args, "instrument", None)
+        if inst_arg:
+            inst_path = Path(inst_arg)
+            if inst_path.exists():
+                inst_name = inst_path.stem
+            else:
+                inst_name = inst_arg  # pack name
+
+        all_models: list[str] | None = None
+        if persona_models:
+            all_models = sorted(set(persona_models.values()))
+        elif model_spec:
+            all_models = [m for m, _w in model_spec]
+
+        saved_result_id = save_panel_result(
+            results=results,
+            model=model,
+            total_usage=total_usage.to_dict(),
+            total_cost=total_cost_est.format_usd(),
+            persona_count=len(personas),
+            question_count=len(questions),
+            instrument_name=inst_name,
+            models=all_models,
+            synthesis=synthesis_dict,
+            metadata=metadata,
+        )
+        saved_result_path = str(_results_dir() / f"{saved_result_id}.json")
+
     if fmt is OutputFormat.TEXT:
         if banner:
             print(banner, file=sys.stderr)
@@ -2760,6 +2813,16 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             }
         if run_invalid or strict_violation:
             extra["message"] = banner.replace("\n", " ").strip() if banner else "PANEL RUN INVALID"
+        # sy-659 (#471): surface the saved-result handle + path so agents
+        # running with --save --output-format json get a stable follow-up
+        # handle from stdout instead of scraping the stderr "Result saved"
+        # line. run_id is the checkpoint identity (present only when
+        # checkpointing was active).
+        if saved_result_id is not None:
+            extra["result_id"] = saved_result_id
+            extra["saved_path"] = saved_result_path
+        if run_id is not None:
+            extra["run_id"] = run_id
         emit(fmt, message=extra.get("message", "Panel complete"), extra=extra)
 
     # ── sp-ezz: opt-in SynthBench submission ─────────────────────────
@@ -2809,38 +2872,12 @@ def handle_panel_run(args: argparse.Namespace, fmt: OutputFormat) -> int:
             )
 
     # ── sp-7vp: auto-save results with --save ─────────────────────────
-    if getattr(args, "save", False):
-        from synth_panel.mcp.data import save_panel_result
-
-        # Determine instrument name (pack name or filename stem)
-        inst_name = None
-        inst_arg = getattr(args, "instrument", None)
-        if inst_arg:
-            inst_path = Path(inst_arg)
-            if inst_path.exists():
-                inst_name = inst_path.stem
-            else:
-                inst_name = inst_arg  # pack name
-
-        all_models: list[str] | None = None
-        if persona_models:
-            all_models = sorted(set(persona_models.values()))
-        elif model_spec:
-            all_models = [m for m, _w in model_spec]
-
-        result_id = save_panel_result(
-            results=results,
-            model=model,
-            total_usage=total_usage.to_dict(),
-            total_cost=total_cost_est.format_usd(),
-            persona_count=len(personas),
-            question_count=len(questions),
-            instrument_name=inst_name,
-            models=all_models,
-            synthesis=synthesis_dict,
-            metadata=metadata,
-        )
-        _print_saved_result_hint(result_id)
+    # sy-659 (#471): the write itself now happens before the text/json branch
+    # split (so JSON output can carry result_id + saved_path); here we only
+    # print the human-facing follow-up hint to stderr, keeping it after the
+    # stdout body for readable terminal ordering.
+    if saved_result_id is not None:
+        _print_saved_result_hint(saved_result_id)
 
     # sp-2hg: exit non-zero when the run is invalid so automation (CI,
     # refinery, wrapper scripts) can detect silent-failure scenarios.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1618,6 +1619,158 @@ class TestPanelRunSave:
         assert len(data["results"]) == 4  # 2 personas × 2 models
         models_seen = {r.get("model") for r in data["results"]}
         assert models_seen == {"haiku", "sonnet"}
+
+    # --- sy-659 (#471): result handle in machine-readable output ----------
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_save_json_output_includes_result_handle(
+        self, mock_client_cls, mock_runtime_cls, mock_synth, capsys, tmp_path, monkeypatch
+    ):
+        """#471: --save --output-format json emits result_id + saved_path on stdout.
+
+        Agents must get a stable handle from the parseable JSON object, not by
+        scraping the stderr "Result saved" prose line.
+        """
+        mock_runtime = MagicMock()
+        mock_runtime.run_turn.return_value = _mock_turn_summary("answer")
+        mock_runtime_cls.return_value = mock_runtime
+        mock_synth.return_value = _mock_synthesis_result()
+
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n    age: 30\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: What do you think?\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--save",
+            ]
+        )
+        assert code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+
+        # The handle lives in stdout JSON, not just stderr.
+        assert "result_id" in data, f"result_id missing; keys={sorted(data.keys())}"
+        assert "saved_path" in data, f"saved_path missing; keys={sorted(data.keys())}"
+        assert data["result_id"].startswith("result-")
+
+        # saved_path is an absolute path that actually exists and matches
+        # where the file landed.
+        saved_path = Path(data["saved_path"])
+        assert saved_path.is_absolute()
+        assert saved_path.exists()
+        assert saved_path == tmp_path / "data" / "results" / f"{data['result_id']}.json"
+
+        # The stdout handle agrees with the stderr "Result saved" prose.
+        stderr_id = None
+        for line in captured.err.splitlines():
+            if line.startswith("Result saved: "):
+                stderr_id = line.split("Result saved: ")[1].strip()
+                break
+        assert stderr_id == data["result_id"]
+
+    @patch("synth_panel.cli.commands.synthesize_panel")
+    @patch("synth_panel.orchestrator.AgentRuntime")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_no_save_omits_result_handle_from_json(
+        self, mock_client_cls, mock_runtime_cls, mock_synth, capsys, tmp_path, monkeypatch
+    ):
+        """#471: without --save, JSON output must NOT carry result_id/saved_path."""
+        mock_runtime = MagicMock()
+        mock_runtime.run_turn.return_value = _mock_turn_summary("answer")
+        mock_runtime_cls.return_value = mock_runtime
+        mock_synth.return_value = _mock_synthesis_result()
+
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n    age: 30\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: What do you think?\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "result_id" not in data
+        assert "saved_path" not in data
+
+    @patch("synth_panel.ensemble.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_save_json_output_includes_result_handle_in_ensemble_mode(
+        self, mock_client_cls, mock_rpp, capsys, tmp_path, monkeypatch
+    ):
+        """#471: ensemble (--models a,b) --save --output-format json carries the handle too."""
+        from synth_panel.cost import TokenUsage as CostTokenUsage
+        from synth_panel.orchestrator import PanelistResult
+
+        def _fake_run_parallel(**kwargs):
+            model = kwargs["model"]
+            personas = kwargs["personas"]
+            results = [
+                PanelistResult(
+                    persona_name=p["name"],
+                    responses=[{"question": "Q1", "response": f"answer from {model}", "error": False}],
+                    usage=CostTokenUsage(input_tokens=100, output_tokens=50),
+                    model=model,
+                )
+                for p in personas
+            ]
+            sessions = {p["name"]: MagicMock() for p in personas}
+            return results, MagicMock(), sessions
+
+        mock_rpp.side_effect = _fake_run_parallel
+        monkeypatch.setenv("SYNTH_PANEL_DATA_DIR", str(tmp_path / "data"))
+
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n    age: 30\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text("instrument:\n  questions:\n    - text: What do you think?\n")
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--models",
+                "haiku,sonnet",
+                "--save",
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["result_id"].startswith("result-")
+        saved_path = Path(data["saved_path"])
+        assert saved_path.exists()
+        assert saved_path == tmp_path / "data" / "results" / f"{data['result_id']}.json"
 
 
 class TestPanelRunBlendEnsemble:
@@ -3244,8 +3397,6 @@ class TestPanelRunWithSchema:
 class TestMainModule:
     def test_main_module_importable(self):
         """Verify __main__.py exists and references main()."""
-        from pathlib import Path
-
         main_path = Path(__file__).parent.parent / "src" / "synth_panel" / "__main__.py"
         assert main_path.exists()
         content = main_path.read_text()


### PR DESCRIPTION
## Summary

When `--save` runs with `--output-format json`, the stdout JSON now carries top-level `result_id` and `saved_path` keys so agents get a stable follow-up handle without scraping the stderr "Result saved" line or rediscovering the saved file. A checkpointed run additionally surfaces its `run_id`. The bug was ordering: `emit()` ran before the `--save` persistence block, so the handle was computed too late to reach stdout — the write now happens ahead of the text/json branch split (and before emit in the ensemble path).

## Changes

- `src/synth_panel/cli/commands.py`: move `save_panel_result()` ahead of the text/json branch split (single-model + ensemble paths); inject `result_id` + `saved_path` (and `run_id` when checkpointing) into emitted JSON; stderr hint still prints after stdout body
- `README.md`: document the machine-readable `result_id`/`saved_path` handles in the `--save` section
- `tests/test_cli.py`: 3 new tests covering single-model + ensemble JSON output and the no-save omission case

## Test plan

- `tests/test_cli.py`: covers single-model JSON, ensemble JSON, and no-save omission of the keys
- Polecat reports: ruff check+format clean, full suite 3013 passed locally (coverage 86%)

## References

- Spec/Bead: sy-659
- GH issue: #471

Closes #471