### PR TITLE
docs: surface attachments in README + note vision-model / [visual] gotchas

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,45 @@ instrument:
         type: text
 ```
 
+### Attachments — show panelists a screenshot, a live URL, a PDF, or HTML
+
+Instruments can carry an **attachment bank** so panelists react to something
+visual or external instead of (or alongside) the question text. Declare a
+top-level `attachments:` mapping on the instrument and reference entries by id
+from a question's `attachments:` list. Four types are supported:
+
+| Type | Source | Use when |
+|------|--------|----------|
+| `image` | `base64`, `url`, or `file_id` | A screenshot, mockup, or photo. |
+| `document` | `base64`, `url`, or `file_id` | A PDF (spec, brief, contract). |
+| `url` | A live URL fetched at run time | A real, currently-live page. |
+| `html` | Inline string | A literal markup fragment (pricing block, email, copy variant). |
+
+```yaml
+instrument:
+  version: 3
+  attachments:
+    landing_page:
+      type: url
+      url: https://example.com
+      fetch_mode: screenshot   # auto | html_text | markdown | screenshot
+  rounds:
+    - name: reaction
+      questions:
+        - text: "What does this studio do, and is it for someone like you?"
+          attachments: [landing_page]
+```
+
+> **Two gotchas worth knowing up front:**
+> - **`image` / `screenshot` attachments need a vision-capable model.** Text-only
+>   models (e.g. `claude-3.5-haiku`) are rejected fast with a clear error — use a
+>   multimodal model such as `claude-haiku-4.5`, `gpt-4o-mini`, or `gemini-2.0-flash`.
+> - **`fetch_mode: screenshot` requires the visual extra:** `pip install 'synthpanel[visual]'`
+>   (installs Playwright; then `python -m playwright install chromium`). Text modes
+>   (`markdown` / `html_text`) don't need it.
+
+Full guide and a runnable starter: [docs/cookbook/with-attachments.md](docs/cookbook/with-attachments.md).
+
 ## Adaptive Research (0.5.0): Branching Instruments
 
 A v3 instrument is a small DAG of *rounds*. After each round, a routing

--- a/docs/cookbook/with-attachments.md
+++ b/docs/cookbook/with-attachments.md
@@ -68,6 +68,15 @@ instrument:
   or `markdown`. `markdown` is usually the cleanest signal for
   content-heavy pages; `screenshot` is the right choice when layout or
   visual hierarchy is the thing under test.
+- **`image` and `screenshot` attachments require a vision-capable model.**
+  Text-only models (e.g. `claude-3.5-haiku`) are rejected fast with an
+  explicit error — point `--models` at a multimodal model such as
+  `claude-haiku-4.5`, `gpt-4o-mini`, or `gemini-2.0-flash`. (`markdown` /
+  `html_text` modes return text and work with any model.)
+- **`fetch_mode: screenshot` needs the `visual` extra.** Install with
+  `pip install 'synthpanel[visual]'`, then fetch the browser once with
+  `python -m playwright install chromium`. Without it, screenshot mode
+  can't render the page. Text-only modes have no extra dependency.
 - **Inline HTML** — YAML's `|` (literal block scalar) preserves newlines
   and indentation, which is what you want for HTML fragments.
 - **Image media types** — `image/png`, `image/jpeg`, `image/gif`,


### PR DESCRIPTION
## Why
While dogfooding SynthPanel against a live site (passing the published page as a `url` attachment), I initially concluded attachments weren't supported — because the **README never mentions them**. The prominent `run_panel` / "Defining Instruments" examples only show a text `stimulus`, so it reads as "panels are text-only." The feature is actually well-documented in [`docs/cookbook/with-attachments.md`](docs/cookbook/with-attachments.md) — it's purely a **discoverability** gap.

Then, building the run, I hit two things that aren't called out anywhere:
1. **`image`/`screenshot` attachments require a vision-capable model.** A `claude-3.5-haiku` run fast-failed (good guard!) with "model … does not support image or document attachments." The fix (use `claude-haiku-4.5` etc.) isn't documented.
2. **`fetch_mode: screenshot` needs the `[visual]` extra** (Playwright) — not mentioned near the attachment docs.

## What
- **README:** new "Attachments" subsection under *Defining Instruments* — the four types, a `url` + `fetch_mode` example, the two gotchas, and a link to the cookbook recipe.
- **Cookbook (`with-attachments.md`):** two bullets in *Notes* for the vision-model requirement and the `[visual]` extra.

Docs only — no code/behavior change.

## Related friction (filing separately as issues)
- `panel run --dry-run` validates "OK" even when the instrument has image attachments but the chosen model is text-only — it could warn there.
- `panel run --save` persists raw Q&A but the report shows `Synthesis: Not run` (synthesis is the headline value).
- `synthpanel report`'s "Next" hint suggests `synthpanel cost <result-id>`, but `cost` only accepts `summary`.
- `synthpanel mcp install` wrote a bare `command: synthpanel` from a venv (not the resolved abs path), which won't launch if synthpanel isn't on PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)