### PR TITLE
fix(cli): point saved-result hint at real cost command (#538)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -6167,9 +6167,12 @@ def _print_saved_result_hint(result_id: str) -> None:
     """
     print(f"Result saved: {result_id}", file=sys.stderr)
     print("Next:", file=sys.stderr)
-    print(f"  synthpanel report {result_id}          # full Markdown report", file=sys.stderr)
+    print(f"  synthpanel report {result_id}          # full Markdown report (incl. cost rollup)", file=sys.stderr)
     print(f"  synthpanel results show {result_id}    # raw saved result", file=sys.stderr)
     print("  synthpanel results list                # all saved results", file=sys.stderr)
+    # #538: there is no per-result `cost <id>` command — the per-run cost
+    # rollup lives in `report` above. `cost summary` aggregates across runs.
+    print("  synthpanel cost summary                # cost rollup across saved runs", file=sys.stderr)
 
 
 def handle_runs_prune(args: argparse.Namespace, fmt: OutputFormat) -> int:

--- a/tests/test_results_discovery.py
+++ b/tests/test_results_discovery.py
@@ -140,3 +140,22 @@ class TestRunsListPointsAtResults:
         out = capsys.readouterr().out
         assert code == 0
         assert "synthpanel results list" in out
+
+
+class TestSavedResultHintCommands:
+    """The saved-result "Next:" block must only suggest real commands (#538)."""
+
+    def test_hint_suggests_real_commands_not_per_result_cost(self, capsys):
+        from synth_panel.cli.commands import _print_saved_result_hint
+
+        _print_saved_result_hint("result-abc123")
+        err = capsys.readouterr().err
+
+        # Real, existing commands are surfaced.
+        assert "synthpanel report result-abc123" in err
+        assert "synthpanel results show result-abc123" in err
+        assert "synthpanel results list" in err
+        # The per-run cost rollup is reachable via the real `cost summary`
+        # subcommand, not a nonexistent per-result `cost <id>` command.
+        assert "synthpanel cost summary" in err
+        assert "cost result-abc123" not in err


### PR DESCRIPTION
## Summary
`synthpanel cost <result-id>` errors (`invalid choice: ... (choose from summary)`) because `cost` only has the `summary` subcommand. The saved-result "Next:" block (printed after `panel run --save`) is where users look for follow-ups, so it now explicitly points at the two **real** cost surfaces instead of leaving a per-result `cost <id>` command implied:

- `synthpanel report <id>` — full Markdown report (now annotated as including the cost rollup)
- `synthpanel cost summary` — cost rollup across saved runs

This closes the CLI/docs inconsistency called out in the issue: the per-run cost rollup lives in `report`, and cross-run aggregation lives in `cost summary`. There is no per-result `cost` command.

## Test
Added `TestSavedResultHintCommands.test_hint_suggests_real_commands_not_per_result_cost` in `tests/test_results_discovery.py`, asserting the hint surfaces `report <id>`, `results show <id>`, `results list`, and `cost summary` — and never the invalid `cost <id>` form.

## Gates
- `ruff check .` / `ruff format --check .`: pass
- `pytest tests/test_results_discovery.py`: 10 passed

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)