### PR TITLE
fix(mcp): resolve absolute synthpanel launcher for mcp install (#539)

### DIFF
--- a/src/synth_panel/cli/mcp_install.py
+++ b/src/synth_panel/cli/mcp_install.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import os
 import shutil
+import sys
 from dataclasses import dataclass
 from importlib.util import find_spec
 from pathlib import Path
@@ -70,11 +71,60 @@ def resolve_target(scope: str, target: str | None) -> Path:
 
 
 def resolve_command(explicit: str | None) -> str:
-    """Resolve the command string the host should invoke."""
+    """Resolve the command string the host should invoke (#539).
+
+    The MCP host launches this command in its own environment, which may
+    not have the installing venv's ``bin`` on ``PATH``. A bare
+    ``"synthpanel"`` then fails to launch. Resolve a robust absolute path,
+    in order of preference:
+
+    1. an explicit ``--command`` override (used verbatim);
+    2. ``shutil.which("synthpanel")`` — the launcher on the current PATH;
+    3. the running entry point's real path (``os.path.realpath(sys.argv[0])``)
+       when it names a ``synthpanel`` launcher — this is the venv-installed
+       console script even when its ``bin`` is not on PATH;
+    4. a ``synthpanel`` executable sitting next to the running interpreter
+       (``<sys.executable dir>/synthpanel``) — the canonical venv layout;
+    5. the literal ``"synthpanel"`` as a last resort.
+    """
     if explicit:
         return explicit
+
     found = shutil.which("synthpanel")
-    return found or "synthpanel"
+    if found:
+        return os.path.realpath(found)
+
+    # The console script we're (likely) running under. In a venv this is an
+    # absolute path like <venv>/bin/synthpanel even when that bin dir is not
+    # on PATH, so it's a reliable launcher for the host to invoke.
+    argv0 = sys.argv[0] if sys.argv else ""
+    if argv0:
+        real_argv0 = os.path.realpath(argv0)
+        base = os.path.basename(real_argv0)
+        if base in ("synthpanel", "synthpanel.exe") and os.path.isfile(real_argv0):
+            return real_argv0
+
+    # A synthpanel launcher next to the interpreter (canonical venv layout:
+    # <venv>/bin/python + <venv>/bin/synthpanel). Check the literal
+    # sys.executable dir FIRST: in a venv, sys.executable is <venv>/bin/python
+    # (a symlink), so resolving it would jump to the base interpreter's bin
+    # and miss the venv's console script. Fall back to the realpath dir for
+    # non-venv layouts.
+    if sys.executable:
+        seen: set[str] = set()
+        for bindir in (
+            os.path.dirname(sys.executable),
+            os.path.dirname(os.path.realpath(sys.executable)),
+        ):
+            if not bindir or bindir in seen:
+                continue
+            seen.add(bindir)
+            for name in ("synthpanel", "synthpanel.exe"):
+                candidate = os.path.join(bindir, name)
+                if os.path.isfile(candidate):
+                    return candidate
+
+    return "synthpanel"
 
 
 def parse_env_pairs(pairs: list[str] | None) -> dict[str, str]:

--- a/src/synth_panel/cli/parser.py
+++ b/src/synth_panel/cli/parser.py
@@ -1290,9 +1290,11 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="CMD",
         dest="mcp_command_override",
         help=(
-            "Command the host should invoke to start the server "
-            "(default: the resolved path to the running 'synthpanel' "
-            "executable, falling back to the literal string 'synthpanel')."
+            "Command the host should invoke to start the server (default: "
+            "an absolute path to the 'synthpanel' launcher — resolved via "
+            "PATH, then the running console script or the one beside the "
+            "active interpreter so a venv whose bin is not on PATH still "
+            "works, falling back to the literal string 'synthpanel')."
         ),
     )
     mcp_install_parser.add_argument(

--- a/tests/test_mcp_install.py
+++ b/tests/test_mcp_install.py
@@ -92,8 +92,56 @@ class TestHelpers:
     def test_resolve_command_explicit(self):
         assert mcp_install.resolve_command("/opt/bin/synthpanel") == "/opt/bin/synthpanel"
 
-    def test_resolve_command_falls_back_to_literal(self, monkeypatch):
+    def test_resolve_command_prefers_which(self, monkeypatch, tmp_path):
+        launcher = tmp_path / "synthpanel"
+        launcher.write_text("#!/bin/sh\n")
+        monkeypatch.setattr("synth_panel.cli.mcp_install.shutil.which", lambda _name: str(launcher))
+        assert mcp_install.resolve_command(None) == str(launcher)
+
+    def test_resolve_command_uses_venv_argv0_when_not_on_path(self, monkeypatch, tmp_path):
+        # Simulate `synthpanel mcp install` invoked from a venv whose bin is
+        # NOT on PATH: shutil.which finds nothing, but argv[0] is the
+        # absolute path to the venv console script (#539). The host must get
+        # that absolute path, not the unlaunchable literal "synthpanel".
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        launcher = venv_bin / "synthpanel"
+        launcher.write_text("#!/bin/sh\n")
+
         monkeypatch.setattr("synth_panel.cli.mcp_install.shutil.which", lambda _name: None)
+        monkeypatch.setattr("synth_panel.cli.mcp_install.sys.argv", [str(launcher)])
+
+        assert mcp_install.resolve_command(None) == str(launcher)
+
+    def test_resolve_command_uses_synthpanel_next_to_interpreter(self, monkeypatch, tmp_path):
+        # No PATH hit and argv[0] is not a synthpanel launcher (e.g. invoked
+        # as `python -m synth_panel`), but a synthpanel console script lives
+        # next to sys.executable — the canonical venv layout.
+        venv_bin = tmp_path / "venv" / "bin"
+        venv_bin.mkdir(parents=True)
+        py = venv_bin / "python"
+        py.write_text("#!/bin/sh\n")
+        launcher = venv_bin / "synthpanel"
+        launcher.write_text("#!/bin/sh\n")
+
+        monkeypatch.setattr("synth_panel.cli.mcp_install.shutil.which", lambda _name: None)
+        monkeypatch.setattr("synth_panel.cli.mcp_install.sys.argv", ["python"])
+        monkeypatch.setattr("synth_panel.cli.mcp_install.sys.executable", str(py))
+
+        assert mcp_install.resolve_command(None) == str(launcher)
+
+    def test_resolve_command_falls_back_to_literal(self, monkeypatch, tmp_path):
+        # Nothing resolvable: no PATH hit, argv[0] is not a synthpanel
+        # launcher, and no synthpanel sits beside the interpreter.
+        empty_bin = tmp_path / "empty"
+        empty_bin.mkdir()
+        py = empty_bin / "python"
+        py.write_text("#!/bin/sh\n")
+
+        monkeypatch.setattr("synth_panel.cli.mcp_install.shutil.which", lambda _name: None)
+        monkeypatch.setattr("synth_panel.cli.mcp_install.sys.argv", ["pytest"])
+        monkeypatch.setattr("synth_panel.cli.mcp_install.sys.executable", str(py))
+
         assert mcp_install.resolve_command(None) == "synthpanel"
 
     def test_parse_env_pairs(self):


### PR DESCRIPTION
## Summary
`synthpanel mcp install` registered a bare `command: "synthpanel"` whenever `shutil.which("synthpanel")` returned None — which is exactly the case when the install is run from a venv whose `bin` dir is not on `PATH`. The MCP host then can't launch the unqualified literal and the server silently fails to start.

`resolve_command` now resolves a robust absolute path before the literal fallback:
1. explicit `--command` (verbatim)
2. `shutil.which("synthpanel")` → `realpath`
3. the running console script (`realpath(sys.argv[0])`) when it names a `synthpanel` launcher — the venv-installed entry point even when its bin is off PATH
4. a `synthpanel` launcher beside `sys.executable` — canonical venv layout. The literal `sys.executable` dir is checked first because a venv's `python` is a symlink whose `realpath` points at the base interpreter (and would miss the venv's own console script); the realpath'd dir is the fallback for non-venv layouts.
5. literal `"synthpanel"` only as a last resort

Verified manually: with `PATH` stripped and a non-`synthpanel` `argv[0]`, resolution now yields the absolute venv path `<venv>/bin/synthpanel` instead of the literal.

Also updates the `--command` help text in `parser.py`.

## Tests
Added to `tests/test_mcp_install.py::TestHelpers`:
- `test_resolve_command_prefers_which`
- `test_resolve_command_uses_venv_argv0_when_not_on_path` (the #539 repro)
- `test_resolve_command_uses_synthpanel_next_to_interpreter`
- `test_resolve_command_falls_back_to_literal` (tightened to control PATH/argv0/executable)

## Gates
- `ruff check .` / `ruff format --check .`: pass
- `pytest tests/test_mcp_install.py tests/mcp`: 84 passed, 1 skipped

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)