### PR TITLE
fix(cli): dry-run guards vision/text-only attachment conflict (#536)

### DIFF
--- a/src/synth_panel/cli/commands.py
+++ b/src/synth_panel/cli/commands.py
@@ -874,6 +874,53 @@ def _estimate_output_tokens_per_response(question: Any) -> int:
     return _DRY_RUN_OUTPUT_TOKENS_TEXT_DEFAULT
 
 
+def _iter_instrument_attachments(instrument: Instrument):
+    """Yield every attachment dict the instrument would send to the model.
+
+    Covers the shared bank (``Instrument.attachments`` values) and every
+    per-question ``inline_attachments`` dict. Bank-ref strings in a
+    question's ``attachments`` list resolve back to bank entries, which are
+    already yielded from the bank, so we don't need to dereference them here.
+    """
+    for att in instrument.attachments.values():
+        if isinstance(att, dict):
+            yield att
+    for q in instrument.questions:
+        if not isinstance(q, dict):
+            continue
+        for att in q.get("inline_attachments") or []:
+            if isinstance(att, dict):
+                yield att
+        # Defensive: some authoring shapes inline dicts directly under
+        # `attachments` (not just bank-ref strings).
+        for att in q.get("attachments") or []:
+            if isinstance(att, dict):
+                yield att
+
+
+def _instrument_visual_attachment_kinds(instrument: Instrument) -> list[str]:
+    """Return the distinct visual-attachment kinds present in *instrument*.
+
+    A "visual" attachment is one the run-time guard
+    (:func:`assert_supports_attachments`) would reject on a text-only model:
+    ``image`` (-> ImageBlock), ``document`` (-> DocumentBlock), and ``url``
+    attachments fetched as a screenshot (``fetch_mode: screenshot``), which
+    lower to an image block. Returned in a stable order for deterministic
+    output.
+    """
+    found: set[str] = set()
+    for att in _iter_instrument_attachments(instrument):
+        atype = att.get("type")
+        if atype == "image":
+            found.add("image")
+        elif atype == "document":
+            found.add("document")
+        elif atype == "url" and att.get("fetch_mode") == "screenshot":
+            found.add("screenshot")
+    order = ["image", "document", "screenshot"]
+    return [k for k in order if k in found]
+
+
 def _emit_dry_run_preview(
     *,
     personas: list[dict[str, Any]],
@@ -923,6 +970,26 @@ def _emit_dry_run_preview(
         pricing,
     )
 
+    # #536: a real run fast-fails when image/document/screenshot attachments
+    # are routed to a text-only model (assert_supports_attachments). Mirror
+    # that guard in dry-run so validation surfaces the misconfiguration
+    # instead of reporting "OK" and letting the user burn tokens on the
+    # real run.
+    from synth_panel.llm.capabilities import model_supports_vision
+
+    visual_kinds = _instrument_visual_attachment_kinds(instrument)
+    vision_conflict = bool(visual_kinds) and not model_supports_vision(model)
+    vision_warning = None
+    if vision_conflict:
+        kinds_str = ", ".join(visual_kinds)
+        vision_warning = (
+            f"model {model!r} is text-only but the instrument has "
+            f"{kinds_str} attachment(s). A real run would fail "
+            "(or silently burn tokens returning a no-image response). "
+            "Switch to a vision-capable model (e.g. sonnet, opus, "
+            "claude-haiku-4-5) or remove the attachments."
+        )
+
     if fmt is OutputFormat.TEXT:
         print("DRY RUN — no LLM calls will be made", file=sys.stderr)
         print(f"Model: {model}", file=sys.stderr)
@@ -967,7 +1034,10 @@ def _emit_dry_run_preview(
             f"Estimated cost ({model}): ~${cost.total_cost:.4f}{cost_suffix}",
             file=sys.stderr,
         )
-        print("Validation: OK", file=sys.stderr)
+        if vision_warning:
+            print(f"Validation: WARNING — {vision_warning}", file=sys.stderr)
+        else:
+            print("Validation: OK", file=sys.stderr)
         return
 
     preview: dict[str, Any] = {
@@ -980,7 +1050,7 @@ def _emit_dry_run_preview(
         "estimated_output_tokens": estimated_output_tokens,
         "estimated_cost_usd": round(cost.total_cost, 6),
         "cost_is_estimated": pricing_is_estimated,
-        "validation": "ok",
+        "validation": "warning" if vision_warning else "ok",
         "rounds": [
             {
                 "name": r.name,
@@ -993,6 +1063,14 @@ def _emit_dry_run_preview(
     # consumers see the dropped names without parsing stderr.
     if personas_merge_used:
         preview["personas_merge_warnings"] = personas_merge_warnings or []
+    # #536: structured surface of the vision/text-only conflict so JSON
+    # consumers can gate on it without scraping the warning string.
+    if vision_warning:
+        preview["vision_conflict"] = {
+            "model": model,
+            "attachment_kinds": visual_kinds,
+            "message": vision_warning,
+        }
     emit(fmt, message="Dry-run preview", extra=preview)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3914,6 +3914,172 @@ class TestPanelRunDryRun:
 
     @patch("synth_panel.cli.commands.run_panel_parallel")
     @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_text_only_model_with_image_attachment_warns(
+        self, mock_client_cls, mock_run_panel, capsys, tmp_path
+    ):
+        """#536: an image attachment + a text-only model warns instead of OK."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  attachments:\n"
+            "    hero:\n"
+            "      type: image\n"
+            "      media_type: image/png\n"
+            "      source:\n"
+            "        type: base64\n"
+            "        data: AAAA\n"
+            "  questions:\n"
+            "    - text: What do you think of this?\n"
+            "      attachments: [hero]\n"
+        )
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "claude-3-5-haiku-20241022",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "Validation: OK" not in err
+        assert "Validation: WARNING" in err
+        assert "text-only" in err
+        assert "image" in err
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_text_only_model_with_image_attachment_json(
+        self, mock_client_cls, mock_run_panel, capsys, tmp_path
+    ):
+        """#536: JSON dry-run surfaces validation=warning + vision_conflict."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  attachments:\n"
+            "    hero:\n"
+            "      type: image\n"
+            "      media_type: image/png\n"
+            "      source:\n"
+            "        type: base64\n"
+            "        data: AAAA\n"
+            "  questions:\n"
+            "    - text: What do you think of this?\n"
+            "      attachments: [hero]\n"
+        )
+
+        code = main(
+            [
+                "--output-format",
+                "json",
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "claude-3-5-haiku-20241022",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["validation"] == "warning"
+        assert data["vision_conflict"]["attachment_kinds"] == ["image"]
+        assert "text-only" in data["vision_conflict"]["message"]
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_vision_model_with_image_attachment_ok(self, mock_client_cls, mock_run_panel, capsys, tmp_path):
+        """A vision-capable model + image attachment still validates OK."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  attachments:\n"
+            "    hero:\n"
+            "      type: image\n"
+            "      media_type: image/png\n"
+            "      source:\n"
+            "        type: base64\n"
+            "        data: AAAA\n"
+            "  questions:\n"
+            "    - text: What do you think of this?\n"
+            "      attachments: [hero]\n"
+        )
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "sonnet",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "Validation: OK" in err
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
+    def test_dry_run_text_only_model_with_screenshot_url_warns(self, mock_client_cls, mock_run_panel, capsys, tmp_path):
+        """#536: a url attachment fetched as a screenshot also warns."""
+        personas_file = tmp_path / "personas.yaml"
+        personas_file.write_text("personas:\n  - name: Alice\n")
+        survey_file = tmp_path / "survey.yaml"
+        survey_file.write_text(
+            "instrument:\n"
+            "  attachments:\n"
+            "    page:\n"
+            "      type: url\n"
+            "      url: https://example.com\n"
+            "      fetch_mode: screenshot\n"
+            "  questions:\n"
+            "    - text: What do you think of this page?\n"
+            "      attachments: [page]\n"
+        )
+
+        code = main(
+            [
+                "panel",
+                "run",
+                "--personas",
+                str(personas_file),
+                "--instrument",
+                str(survey_file),
+                "--model",
+                "claude-3-5-haiku-20241022",
+                "--dry-run",
+            ]
+        )
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "Validation: WARNING" in err
+        assert "screenshot" in err
+        mock_run_panel.assert_not_called()
+
+    @patch("synth_panel.cli.commands.run_panel_parallel")
+    @patch("synth_panel.cli.commands.LLMClient")
     def test_dry_run_unknown_model_flags_estimated_pricing(self, mock_client_cls, mock_run_panel, capsys, tmp_path):
         """Models not in the pricing table fall back to DEFAULT_PRICING."""
         personas_file = tmp_path / "personas.yaml"


### PR DESCRIPTION
## Summary
`panel run --dry-run` reported `Validation: OK` even when the resolved instrument carried image/document/screenshot attachments while the selected model is text-only. A real run fast-fails on exactly that condition via `assert_supports_attachments` (`src/synth_panel/llm/capabilities.py`), so the dry-run gave false confidence and let the user proceed to a token-burning no-image run.

The dry-run preview now scans the instrument's attachments — the shared bank (`Instrument.attachments`) and per-question inline attachments — for visual kinds:
- `image` -> ImageBlock
- `document` -> DocumentBlock
- `url` with `fetch_mode: screenshot` (lowers to an image block)

When a visual attachment is present and `model_supports_vision(model)` is False, the preview emits:
- **text mode:** `Validation: WARNING — <reason>` instead of `Validation: OK`
- **JSON mode:** `validation: "warning"` plus a structured `vision_conflict` block (`model`, `attachment_kinds`, `message`)

Exit code stays 0 (it's a preview/warning, matching the existing dry-run contract); the message points at vision-capable alternatives.

## Tests (in `tests/test_cli.py`)
- `test_dry_run_text_only_model_with_image_attachment_warns`
- `test_dry_run_text_only_model_with_image_attachment_json`
- `test_dry_run_vision_model_with_image_attachment_ok` (no false positive)
- `test_dry_run_text_only_model_with_screenshot_url_warns`

## Gates
- `ruff check .` / `ruff format --check .`: pass
- `pytest tests/test_cli.py tests/test_vision_capability.py tests/attachments`: 232 passed

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)