### PR TITLE
fix(report): explain how to synthesize a flat-saved result (#537)

### DIFF
--- a/src/synth_panel/reporting/markdown.py
+++ b/src/synth_panel/reporting/markdown.py
@@ -229,6 +229,21 @@ def _synthesis_block(report: InspectReport, raw: dict[str, Any]) -> list[str]:
     s = report.synthesis
     if not s.ran and s.error is None and s.summary_peek is None:
         lines.append("_Not run._")
+        # #537: a flat saved result with no synthesis is a common dogfood
+        # surprise — the synthesis block (summary/themes/recommendation) is
+        # the headline value of a run. Point the user at the command that
+        # generates it for an already-saved result instead of leaving the
+        # path from "I saved a run" -> "where's my synthesis?" unexplained.
+        if not report.has_rounds_shape:
+            target = report.result_id or "<result-id>"
+            lines.append("")
+            lines.append(
+                f"> Generate it with: `synthpanel panel synthesize {target}` "
+                "(writes a synthesis sidecar). To capture synthesis inline at "
+                "run time, `panel run` synthesizes by default — pass "
+                "`--synthesis-model` to choose the model, or `--no-synthesis` "
+                "to skip it."
+            )
         return lines
     if s.error and not s.ran:
         lines.append(f"**Status:** failed — {_escape_inline(s.error)}")

--- a/tests/test_reporting_markdown.py
+++ b/tests/test_reporting_markdown.py
@@ -386,5 +386,74 @@ def test_render_synthesis_skips_empty_sections() -> None:
     assert "**Status:** ran" in md
 
 
+# ---------------------------------------------------------------------------
+# 11. Flat-saved result without synthesis explains how to generate it (#537)
+# ---------------------------------------------------------------------------
+
+
+def test_render_flat_no_synthesis_points_at_synthesize_command() -> None:
+    md, _ = _render("flat_shape.json")
+    synth_idx = md.index("## Synthesis")
+    block = md[synth_idx:]
+    # Still reports it didn't run.
+    assert "_Not run._" in block
+    # ...but no longer leaves the user stranded: the report names the command
+    # that generates synthesis for an already-saved result.
+    assert "synthpanel panel synthesize" in block
+    # flat_shape.json carries no `id`, so the placeholder is used.
+    assert "<result-id>" in block
+
+
+def test_render_flat_no_synthesis_uses_result_id_when_present() -> None:
+    raw: dict = {
+        "id": "result-20260603-abc123",
+        "model": "claude-sonnet-4-6",
+        "question_count": 1,
+        "persona_count": 1,
+        "results": [
+            {
+                "persona": "Anon",
+                "model": "claude-sonnet-4-6",
+                "responses": [{"question": "q?", "response": "a", "usage": {"input_tokens": 1, "output_tokens": 1}}],
+            }
+        ],
+    }
+    report = build_inspect_report(raw)
+    md = render_markdown(report, raw)
+    assert "synthpanel panel synthesize result-20260603-abc123" in md
+
+
+def test_render_rounds_shape_no_synthesis_omits_flat_hint() -> None:
+    # The "how to synthesize a flat save" hint is specific to flat saves; a
+    # rounds-shaped payload that genuinely didn't synthesize must not claim a
+    # flat-save remedy.
+    raw: dict = {
+        "id": "rounds-no-synth",
+        "model": "claude-sonnet-4-6",
+        "question_count": 1,
+        "persona_count": 1,
+        "rounds": [
+            {
+                "name": "default",
+                "results": [
+                    {
+                        "persona": "Anon",
+                        "model": "claude-sonnet-4-6",
+                        "responses": [
+                            {"question": "q?", "response": "a", "usage": {"input_tokens": 1, "output_tokens": 1}}
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    report = build_inspect_report(raw)
+    md = render_markdown(report, raw)
+    synth_idx = md.index("## Synthesis")
+    block = md[synth_idx:]
+    assert "_Not run._" in block
+    assert "synthpanel panel synthesize" not in block
+
+
 if __name__ == "__main__":  # pragma: no cover - convenience
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
`synthpanel report <id>` on a flat result saved via `panel run --save` that has no synthesis rendered `## Synthesis — _Not run._` with no path forward. Dogfooders were surprised: the synthesis block (summary/themes/agreements/recommendation) is the headline value of a run, and `analyze` is descriptive-only/non-LLM.

### Investigation / scope (conservative, per the issue's alternative ask)
I traced the `--save` flow before changing behavior:
- The **single-model** `panel run --save` path **already** computes synthesis (on by default) and persists it — `save_panel_result(..., synthesis=synthesis_dict)` (`cli/commands.py`), threaded in commit `f2803c6`. I verified end-to-end (mocked run) that the saved JSON carries top-level `synthesis` and `report` renders `Status: ran`. So the originally-reported single-model gap is already fixed on `main`.
- The remaining `Not run` cases are **legitimate, not bugs**: `--no-synthesis`, a halted/invalid run (synthesis is intentionally skipped on truncated panels), and the **bare ensemble** path (`--models a,b`), which by design produces a per-model comparison rather than a synthesized narrative (and the bare-ensemble save does not pass synthesis because none is computed).

Forcing synthesis onto those paths would be an invasive behavior change with real cost/latency implications. Instead I took the issue's explicit alternative: **have `report` explain how to generate synthesis for a flat-saved result.** The report now points the user at the existing `synthpanel panel synthesize <id>` re-synthesis command and notes that `panel run` synthesizes by default at run time.

The hint is scoped to flat saves (not rounds-shaped payloads), and uses the result's `id` when present, falling back to a `<result-id>` placeholder.

### Why not auto-persist on the ensemble path
The bare ensemble path doesn't compute synthesis at all (documented design: blend mode synthesizes, bare ensemble compares). Wiring synthesis into it is a feature, not a bug fix, and out of scope for a conservative single-purpose change. Flagging here per instructions.

## Tests (in `tests/test_reporting_markdown.py`)
- `test_render_flat_no_synthesis_points_at_synthesize_command` (uses the `flat_shape.json` fixture — the #537 scenario)
- `test_render_flat_no_synthesis_uses_result_id_when_present`
- `test_render_rounds_shape_no_synthesis_omits_flat_hint` (no false hint on rounds-shaped payloads)

## Gates
- `ruff check .` / `ruff format --check .`: pass
- `pytest tests/test_reporting_markdown.py tests/test_cli_report.py tests/test_reporting_loader.py tests/test_inspect.py`: 37 passed

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)