### PR TITLE
ci(auto-tag): push version bump to main as the release-bot App (2c)

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -189,11 +189,32 @@ jobs:
           # added here AND covered by tests/test_version_artifacts_in_sync.py
           # so the next release doesn't need a manual follow-up PR.
 
+      # Mint a token for the org-owned `dataviking-release-bot` App. The App is
+      # an Integration bypass actor on the main branch ruleset (see
+      # dataviking-infra synthpanel.tf), so pushing the bump commit AS the App
+      # is allowed — whereas a github-actions[bot] / GITHUB_TOKEN push to main
+      # is rejected with GH013. This removed the manual "pre-bump the version in
+      # the PR" workaround (the escape-hatch branch below still works if a PR
+      # happens to be pre-bumped, but it is no longer required).
+      - name: Mint release-bot app token
+        if: steps.check.outputs.skipped != 'true'
+        id: app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Commit version bump to main
         if: steps.check.outputs.skipped != 'true'
         env:
           NEW_TAG: ${{ steps.bump.outputs.tag }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Pushed via env (not inline ${{ }}) so the token never lands in the
+          # command echo; create-github-app-token also registers it as a masked
+          # secret. Only the bump push uses it — the tag push below stays on
+          # GITHUB_TOKEN so it does NOT trigger publish.yml (publish is invoked
+          # by the explicit workflow_dispatch step further down).
+          APP_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -205,11 +226,12 @@ jobs:
           git add src/synth_panel/__version__.py site/index.html site/ \
                   site/.well-known/mcp/server-card.json
           if git diff --staged --quiet; then
-            echo "Version artifacts already at ${NEW_TAG} (dev pre-bumped in PR) — nothing to commit."
+            echo "Version artifacts already at ${NEW_TAG} (pre-bumped in PR) — nothing to commit."
           else
             VERSION="${NEW_TAG#v}"
             git commit -m "chore(release): sync __version__.py + rendered artifacts to ${VERSION} (PR #${PR_NUMBER}) (sy-hs4)"
-            git push origin HEAD:main
+            # Push as the release-bot App (Integration bypass actor on main).
+            git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
           fi
 
       - name: Create and push tag


### PR DESCRIPTION
Companion to **dataviking-infra #64**. Completes "2c": the release pipeline now pushes the version-bump commit to `main` **as the `dataviking-release-bot` App** (an Integration bypass actor on the main ruleset) instead of `github-actions[bot]`/`GITHUB_TOKEN`, which the ruleset rejects with `GH013`.

### What changed
- New step mints a token via `actions/create-github-app-token` (pinned `@bcd2ba4` v3.2.0) from the `RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY` secrets (already set on this repo).
- The **bump push** uses that app token. **Only** the bump push — the tag push deliberately stays on `GITHUB_TOKEN` so it doesn't trigger `publish.yml` (publish stays driven by the explicit `workflow_dispatch`), avoiding a double publish.
- Removes the need to manually pre-bump every release PR (the no-op escape-hatch branch still works if a PR is pre-bumped, but it's no longer required).

### Labeled `semver:skip`
CI plumbing only — no package change, so no release. (Also sidesteps the chicken-and-egg: a `pull_request`-triggered workflow runs the **base branch's** copy, so the new logic only takes effect for the *next* PR after this lands.)

### Merge order
1. Apply **dataviking-infra #64** (makes the App a bypass actor).
2. Merge this PR.
3. The next normal `semver:patch` PR will exercise 2c end-to-end (auto-bump pushed by the App, no pre-bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)