### PR TITLE
ci: SHA-pin third-party GitHub Actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,13 +83,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up QEMU (multi-arch emulation)
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Build and push image
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
       # Trusted Publishing — no API token needed; PyPI verifies the GitHub
       # workflow's OIDC identity. skip-existing: true makes retries idempotent.
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           skip-existing: true
 


### PR DESCRIPTION
## SHA-pin third-party GitHub Actions

Pins **5** third-party action reference(s) in this repo to immutable commit SHAs.

**Scope:** Only genuinely third-party actions (owner not `actions`/`github`) that were on mutable refs (tags/branches) were pinned. GitHub-maintained `actions/*` and `github/*` actions, actions already pinned to a 40-char SHA, and local `./...` actions/reusable-workflow calls were intentionally left unchanged. Each pinned line keeps a `# <version>` trailing comment so the intended version stays readable to humans and Dependabot. Pins point at the commit each tag resolved to at audit time (2026-06-07).

No unresolved refs.

### Changes

| File | Action | Old ref | Pinned SHA |
|---|---|---|---|
| `.github/workflows/docker.yml` | `docker/setup-qemu-action` | `v4` | `06116385d9baf250c9f4dcb4858b16962ea869c3` |
| `.github/workflows/docker.yml` | `docker/setup-buildx-action` | `v4` | `d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` |
| `.github/workflows/docker.yml` | `docker/login-action` | `v4` | `650006c6eb7dba73a995cc03b0b2d7f5ca915bee` |
| `.github/workflows/docker.yml` | `docker/build-push-action` | `v7` | `f9f3042f7e2789586610d6e8b85c8f03e5195baf` |
| `.github/workflows/publish.yml` | `pypa/gh-action-pypi-publish` | `release/v1` | `cef221092ed1bacb1cc03d23a2d87d1d172e277b` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
